### PR TITLE
docs: add Jido to Mix project supervisor in 'Your first LLM agent'

### DIFF
--- a/priv/pages/docs/getting-started/first-llm-agent.livemd
+++ b/priv/pages/docs/getting-started/first-llm-agent.livemd
@@ -123,6 +123,37 @@ Export the key in the shell session where you run your app:
 export OPENAI_API_KEY="your-api-key-here"
 ```
 
+Then add your Jido app to your application's supervision tree:
+
+**my_app/jido.ex**
+
+```elixir
+defmodule MyApp.Jido do
+  use Jido, otp_app: :my_app
+end
+```
+
+**my_app/application.ex**
+
+```elixir
+defmodule MyApp.Application do
+
+  use Application
+
+    @impl true
+    def start(_type, _args) do
+      children =
+        [
+          ...
+          {MyApp.Jido, name: Jido}
+        ]
+
+      opts = [strategy: :one_for_one, name: MyApp.Supervisor]
+      Supervisor.start_link(children, opts)
+    end
+end
+```
+
 ## Next steps
 
 - Build a multi-step orchestration in [Build your first workflow](/docs/learn/first-workflow).


### PR DESCRIPTION
## Description

Adds an example of adding Jido to your project's supervision tree for the example on the 'Your first LLM agent' page to work. It's something I hit trying out a Jido AI agent, and the Jido registry wasn't running:

```
iex(4)> {:ok, pid} = Jido.AgentServer.start_link(agent: MyApp.Jido.ShowsAgent)
** (EXIT from #PID<0.808.0>) shell process exited with reason: an exception was raised:
    ** (ArgumentError) unknown registry: Jido.Registry
        (elixir 1.19.5) lib/registry.ex:1551: Registry.info!/1
        (elixir 1.19.5) lib/registry.ex:1169: Registry.register/3
        (jido 2.0.0) lib/jido/agent_server.ex:671: Jido.AgentServer.maybe_register_global/2
        (jido 2.0.0) lib/jido/agent_server.ex:657: Jido.AgentServer.init/1
        (stdlib 7.2) gen_server.erl:2276: :gen_server.init_it/2
        (stdlib 7.2) gen_server.erl:2236: :gen_server.init_it/6
        (stdlib 7.2) proc_lib.erl:333: :proc_lib.init_p_do_apply/3
```

Note: I did not see any meaningful updates to make to the corresponding content plan, but I'm happy to update that if there are any suggestions.

<img width="1048" height="831" alt="Screenshot 2026-03-02 at 12 18 56 PM" src="https://github.com/user-attachments/assets/821032ba-7970-4d42-a4d0-31317e0e0b60" />

First contrib -- let me know if I've missed anything. Thanks!

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [x] Documentation update

## Breaking Changes

<!-- If this is a breaking change, describe the impact and migration path -->

## Testing

- [x] Tests pass (`mix test`)
- [ ] Quality checks pass (`mix quality`)

## Checklist

- [ ] My code follows the project's style guidelines
- [x] I have updated the documentation accordingly
- [ ] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)

## Related Issues

Closes #
