### PR TITLE
agents.md - def run(   parameters are in the wrong order

### DIFF
--- a/priv/pages/docs/concepts/agents.md
+++ b/priv/pages/docs/concepts/agents.md
@@ -73,7 +73,7 @@ defmodule MyApp.Increment do
     schema: Zoi.object(%{by: Zoi.integer() |> Zoi.default(1)})
 
   @impl true
-  def run(ctx, params) do
+  def run(params, ctx) do
     agent = Map.get(ctx, :agent) || Map.get(ctx, "agent") || ctx
     by = Map.get(params, :by) || Map.get(params, "by") || 1
     {:ok, %{count: agent.state.count + by, status: :active}}
@@ -128,7 +128,7 @@ defmodule MyApp.ProcessRegistration do
   alias Jido.Agent.Directive
 
   @impl true
-  def run(ctx, params) do
+  def run(params, ctx) do
     agent = Map.get(ctx, :agent) || Map.get(ctx, "agent") || ctx
     user_id = Map.get(params, :user_id) || Map.get(params, "user_id")
 


### PR DESCRIPTION
## Description

According to agentjido/Jido actions.md, the proper parameter order is:

```elixir
def run(params, context) do
```

I've also checked the rest of the jido_run examples and didn't find any other situations where they were reversed.


## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [x ] Documentation update

## Breaking Changes

<!-- If this is a breaking change, describe the impact and migration path -->

## Testing

- [ ] Tests pass (`mix test`)
- [ ] Quality checks pass (`mix quality`)

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have updated the documentation accordingly
- [ ] I have added tests that prove my fix/feature works
- [ ] All new and existing tests pass
- [ ] My commits follow conventional commit format
- [ ] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)

## Related Issues

Closes #
