### PR TITLE
fix: correct plugin tutorial runtime startup example

### DIFF
--- a/priv/pages/docs/learn/plugins-and-composable-agents.livemd
+++ b/priv/pages/docs/learn/plugins-and-composable-agents.livemd
@@ -190,14 +190,17 @@ The entries list is empty again.
 
 ### Signal routing through the runtime
 
-Plugins define signal routes so you can drive Actions through Signals instead of direct `cmd/2` calls. Start the Jido runtime, spawn an Agent process, and send Signals:
+Plugins define signal routes so you can drive Actions through Signals instead of direct `cmd/2` calls. Start a named Jido runtime, spawn an Agent process under that runtime by name, and send Signals:
 
 ```elixir
-{:ok, jido} = Jido.start_link(name: :learn_plugins)
+runtime_name = :learn_plugins
+{:ok, _runtime_pid} = Jido.start_link(name: runtime_name)
 
 {:ok, pid} =
-  Jido.start_agent(jido, MyApp.NotesAgent, id: "notes-demo")
+  Jido.start_agent(runtime_name, MyApp.NotesAgent, id: "notes-demo")
 ```
+
+`Jido.start_link/1` returns the supervisor pid, but `Jido.start_agent/3` expects the runtime instance name, not that pid.
 
 Send a `"notes.add"` Signal. The router matches it to `MyApp.AddNoteAction` through the Plugin's `signal_routes/1`:
 

--- a/test/livebooks/docs/plugins_and_composable_agents_livebook_test.exs
+++ b/test/livebooks/docs/plugins_and_composable_agents_livebook_test.exs
@@ -1,0 +1,9 @@
+defmodule AgentJido.Livebooks.Docs.PluginsAndComposableAgentsLivebookTest do
+  use AgentJido.LivebookCase,
+    livebook: "priv/pages/docs/learn/plugins-and-composable-agents.livemd",
+    timeout: 60_000
+
+  test "runs cleanly" do
+    assert :ok = run_livebook()
+  end
+end


### PR DESCRIPTION
## Summary
- update the `Plugins and composable agents` tutorial to pass the named Jido runtime instance to `Jido.start_agent/3`
- explain why the pid returned by `Jido.start_link/1` is not the correct `start_agent/3` argument
- add a livebook drift test for the tutorial page

## Testing
- `ASDF_ELIXIR_VERSION=1.18.4-otp-27 ASDF_ERLANG_VERSION=27.3 mix test test/livebooks/docs/plugins_and_composable_agents_livebook_test.exs` *(fails in local test boot because PostgreSQL does not have the `vector` extension installed)*

Closes #70