### PR TITLE
Tighten browser workflow example closeout

### DIFF
--- a/lib/agent_jido_web/examples/simulated_showcase_live.ex
+++ b/lib/agent_jido_web/examples/simulated_showcase_live.ex
@@ -376,26 +376,6 @@ defmodule AgentJidoWeb.Examples.SimulatedShowcaseLive do
     }
   end
 
-  defp scenario_for("jido-ai-browser-web-workflow") do
-    %{
-      title: "Jido.AI Browser Web Workflow",
-      steps: [
-        %{label: "Turn 1 read", detail: "read_page fixture loaded target URL markdown snapshot"},
-        %{label: "Turn 2 extract", detail: "Context reused to list map/filter usage from same page"},
-        %{label: "Turn 3 synthesize", detail: "Produced combined pipeline example from retained context"},
-        %{label: "Guardrails", detail: "Confirmed no refetch and single-source turn progression"}
-      ],
-      result: """
-      {
-        "model": "simulated:browser-scout",
-        "turns": 3,
-        "same_url_reused": true,
-        "semantic_checks": "passed"
-      }
-      """
-    }
-  end
-
   defp scenario_for("jido-ai-weather-multi-turn-context") do
     %{
       title: "Jido.AI Weather Multi-Turn Context",

--- a/priv/examples/jido-ai-browser-web-workflow.md
+++ b/priv/examples/jido-ai-browser-web-workflow.md
@@ -55,13 +55,18 @@
 
 - How to mount `Jido.Browser.Plugin` on a plain `Jido.Agent`
 - How to keep browser-enabled demos deterministic with a simulated adapter
+- How to carry browser session context across a 3-turn walkthrough without refetching the first URL
 - How to navigate a docs page, extract markdown, follow a link, and capture a screenshot
 - How to swap the simulated adapter for `Jido.Browser.Adapters.Vibium` or `Jido.Browser.Adapters.Web`
+- How to fall back safely to the simulated adapter until a live browser backend is installed
 
-## Why this example is simulated
+## Deterministic site demo vs live browser flow
 
 This page runs **real `Jido.Browser` integration code** against a local simulated adapter.
 That keeps the example deterministic, testable, and browser-binary-free inside this repo.
+
+No API keys or browser binaries are required for this site demo.
+When you move this pattern into your own project, the agent, plugin, and wrapper actions stay the same and only the adapter changes.
 
 The agent shape is still the one you would use in your own project:
 
@@ -70,13 +75,13 @@ use Jido.Agent,
   plugins: [{Jido.Browser.Plugin, %{adapter: MyApp.BrowserAdapter, headless: true}}]
 ```
 
-## Demo flow
+## Three-turn walkthrough
 
-1. Open a docs page with `Jido.Browser.Actions.Navigate`
-2. Extract markdown from the active page with `Jido.Browser.Actions.ExtractContent`
-3. Follow a related docs link with `Jido.Browser.Actions.Click`
-4. Capture a screenshot with `Jido.Browser.Actions.Screenshot`
-5. Reset the browser session and local outputs
+1. Open the plugin guide with `Jido.Browser.Actions.Navigate`
+2. Extract markdown from the active page with `Jido.Browser.Actions.ExtractContent` without refetching the URL
+3. Follow the testing guide link with `Jido.Browser.Actions.Click` while reusing the same browser session
+
+The demo then captures a screenshot and lets you reset the session so you can replay the flow from a clean state.
 
 ## Pull this into your own project
 
@@ -96,10 +101,14 @@ defp aliases do
 end
 ```
 
-Then replace `AgentJido.Demos.BrowserDocsScout.SimulatedAdapter` with a real adapter:
+## Requirements and safe fallback
+
+For a live browser backend in your own app, follow the `jido_browser` README and replace `AgentJido.Demos.BrowserDocsScout.SimulatedAdapter` with a real adapter:
 
 - `Jido.Browser.Adapters.Vibium`
 - `Jido.Browser.Adapters.Web`
+
+If your browser backend is not installed yet, keep the simulated adapter wired in dev/test so the workflow stays deterministic while you finish local setup.
 
 ## Source layout
 

--- a/test/agent_jido/demos/browser_docs_scout_agent_test.exs
+++ b/test/agent_jido/demos/browser_docs_scout_agent_test.exs
@@ -43,4 +43,27 @@ defmodule AgentJido.Demos.BrowserDocsScoutAgentTest do
     assert agent.state.current_page == %{}
     assert agent.state.screenshot == %{}
   end
+
+  test "preserves browser session across multi-turn follow-up actions" do
+    agent = BrowserDocsScoutAgent.new()
+
+    {agent, []} = BrowserDocsScoutAgent.open_page(agent, SimulatedAdapter.overview_url())
+    session_id = BrowserDocsScoutAgent.plugin_state(agent, Plugin).session.id
+    first_url = agent.state.current_page.url
+
+    {agent, []} = BrowserDocsScoutAgent.extract_current_page(agent)
+    assert BrowserDocsScoutAgent.plugin_state(agent, Plugin).session.id == session_id
+    assert agent.state.extracted_content =~ "Jido Browser Plugin Guide"
+
+    {agent, []} =
+      BrowserDocsScoutAgent.follow_link(
+        agent,
+        "a[data-doc-link='testing']",
+        text: "Testing browser agents"
+      )
+
+    assert BrowserDocsScoutAgent.plugin_state(agent, Plugin).session.id == session_id
+    assert agent.state.current_page.title == "Testing Browser Agents"
+    assert agent.state.current_page.url != first_url
+  end
 end

--- a/test/agent_jido_web/live/jido_example_live_test.exs
+++ b/test/agent_jido_web/live/jido_example_live_test.exs
@@ -195,13 +195,16 @@ defmodule AgentJidoWeb.JidoExampleLiveTest do
   end
 
   describe "/examples/jido-ai-browser-web-workflow" do
-    test "renders explanation tab with jido_browser guidance", %{conn: conn} do
+    test "renders explanation tab with live-browser requirements and fallback guidance", %{conn: conn} do
       {:ok, _view, html} = live(conn, "/examples/jido-ai-browser-web-workflow?tab=explanation")
 
       assert html =~ "Jido Browser Docs Scout Agent"
       assert html =~ "agentjido/jido_browser"
       assert html =~ "Jido.Browser.Plugin"
       assert html =~ "jido_browser.install --if-missing"
+      assert html =~ "No API keys or browser binaries are required for this site demo."
+      assert html =~ "without refetching the URL"
+      assert html =~ "keep the simulated adapter wired in dev/test"
     end
 
     test "renders source tab for the dedicated browser example", %{conn: conn} do
@@ -243,6 +246,7 @@ defmodule AgentJidoWeb.JidoExampleLiveTest do
         |> render_click()
 
       assert html =~ "Testing Browser Agents"
+      assert html =~ "3 step(s)"
 
       html =
         demo_view


### PR DESCRIPTION
## Summary
- tighten the browser workflow example explanation so it explicitly distinguishes the deterministic site demo from a live browser backend
- add explicit three-turn walkthrough and safe fallback guidance for adapter setup
- remove the stale browser scenario from `SimulatedShowcaseLive` and add stronger context-carryover assertions

## Verification
- `ASDF_ELIXIR_VERSION=1.18.4-otp-27 ASDF_ERLANG_VERSION=27.3 mix format lib/agent_jido_web/examples/simulated_showcase_live.ex test/agent_jido/demos/browser_docs_scout_agent_test.exs test/agent_jido_web/live/jido_example_live_test.exs`
- `ASDF_ELIXIR_VERSION=1.18.4-otp-27 ASDF_ERLANG_VERSION=27.3 mix compile`
- `TELEGRAM_BOT_TOKEN=dummy DISCORD_BOT_TOKEN=dummy ASDF_ELIXIR_VERSION=1.18.4-otp-27 ASDF_ERLANG_VERSION=27.3 mix run --no-start -e 'example = AgentJido.Examples.get_example!("jido-ai-browser-web-workflow"); IO.puts(example.slug); IO.puts(example.live_view_module); IO.puts(Enum.join(example.source_files, "\\n"))'`

## Notes
- `mix test test/agent_jido/demos/browser_docs_scout_agent_test.exs` still fails in this environment because the local PostgreSQL instance does not have the `vector` extension installed.

Closes #40