### PR TITLE
Replace simulated actions runtime demo

### DIFF
--- a/lib/agent_jido/demos/actions_runtime/convert_temperature_action.ex
+++ b/lib/agent_jido/demos/actions_runtime/convert_temperature_action.ex
@@ -1,0 +1,61 @@
+defmodule AgentJido.Demos.ActionsRuntime.ConvertTemperatureAction do
+  @moduledoc """
+  Deterministic temperature conversion tool used by the actions runtime demo.
+  """
+
+  use Jido.Action,
+    name: "convert_temperature",
+    description: "Convert a temperature between Fahrenheit and Celsius",
+    category: "ai",
+    tags: ["tool", "temperature", "deterministic"],
+    vsn: "1.0.0",
+    schema:
+      Zoi.object(%{
+        value: Zoi.float(description: "Temperature value to convert"),
+        from: Zoi.string(description: "Source unit (`fahrenheit` or `celsius`)"),
+        to: Zoi.string(description: "Target unit (`fahrenheit` or `celsius`)")
+      })
+
+  @impl true
+  def run(params, _context) do
+    value = params[:value]
+    from = normalize_unit(params[:from])
+    to = normalize_unit(params[:to])
+
+    with {:ok, from} <- validate_unit(from),
+         {:ok, to} <- validate_unit(to) do
+      converted_value =
+        case {from, to} do
+          {:fahrenheit, :celsius} -> (value - 32.0) * 5.0 / 9.0
+          {:celsius, :fahrenheit} -> value * 9.0 / 5.0 + 32.0
+          _same -> value
+        end
+
+      {:ok,
+       %{
+         input_value: value,
+         input_unit: Atom.to_string(from),
+         converted_value: Float.round(converted_value, 1),
+         output_unit: Atom.to_string(to),
+         formula: formula_for(from, to)
+       }}
+    end
+  end
+
+  defp normalize_unit(unit) when is_binary(unit) do
+    unit
+    |> String.downcase()
+    |> String.trim()
+    |> String.to_atom()
+  end
+
+  defp normalize_unit(unit) when is_atom(unit), do: unit
+  defp normalize_unit(_other), do: :invalid
+
+  defp validate_unit(unit) when unit in [:fahrenheit, :celsius], do: {:ok, unit}
+  defp validate_unit(_unit), do: {:error, :unsupported_temperature_unit}
+
+  defp formula_for(:fahrenheit, :celsius), do: "(F - 32) * 5 / 9"
+  defp formula_for(:celsius, :fahrenheit), do: "(C * 9 / 5) + 32"
+  defp formula_for(_from, _to), do: "identity"
+end

--- a/lib/agent_jido/demos/actions_runtime/fixture_actions.ex
+++ b/lib/agent_jido/demos/actions_runtime/fixture_actions.ex
@@ -1,0 +1,424 @@
+defmodule AgentJido.Demos.ActionsRuntime.FixtureHelpers do
+  @moduledoc false
+
+  @spec usage(non_neg_integer(), non_neg_integer()) :: map()
+  def usage(input_tokens, output_tokens) do
+    %{
+      input_tokens: input_tokens,
+      output_tokens: output_tokens,
+      total_tokens: input_tokens + output_tokens
+    }
+  end
+
+  @spec compact_whitespace(String.t()) :: String.t()
+  def compact_whitespace(text) when is_binary(text) do
+    text
+    |> String.replace(~r/\s+/, " ")
+    |> String.trim()
+  end
+end
+
+defmodule AgentJido.Demos.ActionsRuntime.FixtureChatAction do
+  @moduledoc """
+  Deterministic stand-in for a chat-style runtime action envelope.
+  """
+
+  use Jido.Action,
+    name: "fixture_llm_chat",
+    description: "Return a deterministic chat response envelope",
+    category: "ai",
+    tags: ["llm", "fixture", "chat"],
+    vsn: "1.0.0",
+    schema:
+      Zoi.object(%{
+        prompt: Zoi.string(description: "The prompt to answer")
+      })
+
+  alias AgentJido.Demos.ActionsRuntime.FixtureHelpers
+
+  @impl true
+  def run(params, _context) do
+    prompt = FixtureHelpers.compact_whitespace(params[:prompt])
+
+    {:ok,
+     %{
+       text: "Elixir keeps concurrency manageable because processes, supervisors, and message passing are built into the runtime. Prompt: #{prompt}",
+       model: "fixture:haiku",
+       usage: FixtureHelpers.usage(18, 26)
+     }}
+  end
+end
+
+defmodule AgentJido.Demos.ActionsRuntime.FixtureCompleteAction do
+  @moduledoc """
+  Deterministic stand-in for a completion-style runtime action envelope.
+  """
+
+  use Jido.Action,
+    name: "fixture_llm_complete",
+    description: "Return a deterministic completion response envelope",
+    category: "ai",
+    tags: ["llm", "fixture", "completion"],
+    vsn: "1.0.0",
+    schema:
+      Zoi.object(%{
+        prompt: Zoi.string(description: "The completion prefix")
+      })
+
+  alias AgentJido.Demos.ActionsRuntime.FixtureHelpers
+
+  @impl true
+  def run(params, _context) do
+    prompt = FixtureHelpers.compact_whitespace(params[:prompt])
+
+    {:ok,
+     %{
+       text: "#{prompt} process isolation, supervision trees, and message passing that recover cleanly from failures.",
+       model: "fixture:haiku",
+       usage: FixtureHelpers.usage(14, 22)
+     }}
+  end
+end
+
+defmodule AgentJido.Demos.ActionsRuntime.FixtureGenerateObjectAction do
+  @moduledoc """
+  Deterministic stand-in for a generate-object runtime envelope.
+  """
+
+  use Jido.Action,
+    name: "fixture_llm_generate_object",
+    description: "Return a deterministic object-generation envelope",
+    category: "ai",
+    tags: ["llm", "fixture", "structured-output"],
+    vsn: "1.0.0",
+    schema:
+      Zoi.object(%{
+        prompt: Zoi.string(description: "Prompt describing the object to return")
+      })
+
+  alias AgentJido.Demos.ActionsRuntime.FixtureHelpers
+
+  @impl true
+  def run(_params, _context) do
+    {:ok,
+     %{
+       object: %{
+         title: "Jido AI roadmap",
+         confidence: 0.93,
+         status: "ready_for_review"
+       },
+       model: "fixture:haiku",
+       usage: FixtureHelpers.usage(20, 18)
+     }}
+  end
+end
+
+defmodule AgentJido.Demos.ActionsRuntime.FixturePlanAction do
+  @moduledoc """
+  Deterministic plan action for local runtime demos.
+  """
+
+  use Jido.Action,
+    name: "fixture_planning_plan",
+    description: "Return a deterministic plan from a goal",
+    category: "ai",
+    tags: ["planning", "fixture"],
+    vsn: "1.0.0",
+    schema:
+      Zoi.object(%{
+        goal: Zoi.string(description: "The goal to plan"),
+        constraints: Zoi.list(Zoi.string(), description: "Constraints") |> Zoi.default([]),
+        resources: Zoi.list(Zoi.string(), description: "Resources") |> Zoi.default([])
+      })
+
+  alias AgentJido.Demos.ActionsRuntime.FixtureHelpers
+
+  @impl true
+  def run(params, _context) do
+    steps = [
+      "Define onboarding scope",
+      "Build the first-time user path",
+      "Instrument analytics and launch behind a flag"
+    ]
+
+    plan_text =
+      """
+      Goal: #{params[:goal]}
+      Constraints: #{Enum.join(params[:constraints], ", ")}
+      Resources: #{Enum.join(params[:resources], ", ")}
+      """
+      |> FixtureHelpers.compact_whitespace()
+
+    {:ok,
+     %{
+       plan: plan_text,
+       steps: steps,
+       goal: params[:goal],
+       model: "fixture:planner",
+       usage: FixtureHelpers.usage(24, 28)
+     }}
+  end
+end
+
+defmodule AgentJido.Demos.ActionsRuntime.FixtureDecomposeAction do
+  @moduledoc """
+  Deterministic decomposition action for local runtime demos.
+  """
+
+  use Jido.Action,
+    name: "fixture_planning_decompose",
+    description: "Return a deterministic task decomposition",
+    category: "ai",
+    tags: ["planning", "fixture", "decompose"],
+    vsn: "1.0.0",
+    schema:
+      Zoi.object(%{
+        goal: Zoi.string(description: "The goal to decompose"),
+        max_depth: Zoi.integer(description: "Requested decomposition depth") |> Zoi.default(3),
+        context: Zoi.string(description: "Optional extra context") |> Zoi.optional()
+      })
+
+  alias AgentJido.Demos.ActionsRuntime.FixtureHelpers
+
+  @impl true
+  def run(params, _context) do
+    {:ok,
+     %{
+       decomposition: [
+         %{level: 1, task: "Product design"},
+         %{level: 2, task: "Build signup steps"},
+         %{level: 2, task: "Add event tracking"}
+       ],
+       goal: params[:goal],
+       max_depth: params[:max_depth],
+       model: "fixture:planner",
+       usage: FixtureHelpers.usage(19, 17)
+     }}
+  end
+end
+
+defmodule AgentJido.Demos.ActionsRuntime.FixturePrioritizeAction do
+  @moduledoc """
+  Deterministic prioritization action for local runtime demos.
+  """
+
+  use Jido.Action,
+    name: "fixture_planning_prioritize",
+    description: "Return a deterministic prioritization of tasks",
+    category: "ai",
+    tags: ["planning", "fixture", "prioritize"],
+    vsn: "1.0.0",
+    schema:
+      Zoi.object(%{
+        tasks: Zoi.list(Zoi.string(), description: "Tasks to prioritize"),
+        criteria: Zoi.string(description: "Prioritization criteria")
+      })
+
+  alias AgentJido.Demos.ActionsRuntime.FixtureHelpers
+
+  @impl true
+  def run(params, _context) do
+    prioritized =
+      params[:tasks]
+      |> Enum.with_index(1)
+      |> Enum.map(fn {task, rank} ->
+        %{task: task, rank: rank, reason: "Ranked by #{FixtureHelpers.compact_whitespace(params[:criteria])}"}
+      end)
+
+    {:ok,
+     %{
+       prioritized_tasks: prioritized,
+       criteria: params[:criteria],
+       model: "fixture:planner",
+       usage: FixtureHelpers.usage(16, 15)
+     }}
+  end
+end
+
+defmodule AgentJido.Demos.ActionsRuntime.FixtureAnalyzeAction do
+  @moduledoc """
+  Deterministic reasoning analyze action for local runtime demos.
+  """
+
+  use Jido.Action,
+    name: "fixture_reasoning_analyze",
+    description: "Return deterministic analysis text",
+    category: "ai",
+    tags: ["reasoning", "fixture", "analysis"],
+    vsn: "1.0.0",
+    schema:
+      Zoi.object(%{
+        input: Zoi.string(description: "Input to analyze"),
+        analysis_type: Zoi.atom(description: "Analysis type") |> Zoi.default(:summary)
+      })
+
+  alias AgentJido.Demos.ActionsRuntime.FixtureHelpers
+
+  @impl true
+  def run(params, _context) do
+    {:ok,
+     %{
+       result:
+         "Summary analysis: support volume stayed flat while churn rose, which points to onboarding or pricing issues rather than incident-driven dissatisfaction.",
+       analysis_type: params[:analysis_type],
+       model: "fixture:reasoner",
+       usage: FixtureHelpers.usage(20, 23)
+     }}
+  end
+end
+
+defmodule AgentJido.Demos.ActionsRuntime.FixtureInferAction do
+  @moduledoc """
+  Deterministic reasoning infer action for local runtime demos.
+  """
+
+  use Jido.Action,
+    name: "fixture_reasoning_infer",
+    description: "Return deterministic inference output",
+    category: "ai",
+    tags: ["reasoning", "fixture", "inference"],
+    vsn: "1.0.0",
+    schema:
+      Zoi.object(%{
+        premises: Zoi.string(description: "Premises to reason over"),
+        question: Zoi.string(description: "Question to answer")
+      })
+
+  alias AgentJido.Demos.ActionsRuntime.FixtureHelpers
+
+  @impl true
+  def run(params, _context) do
+    {:ok,
+     %{
+       result: "Yes. If every production incident requires a postmortem and INC-42 is a production incident, the postmortem requirement applies.",
+       premises: params[:premises],
+       question: params[:question],
+       model: "fixture:reasoner",
+       usage: FixtureHelpers.usage(18, 19)
+     }}
+  end
+end
+
+defmodule AgentJido.Demos.ActionsRuntime.FixtureExplainAction do
+  @moduledoc """
+  Deterministic reasoning explain action for local runtime demos.
+  """
+
+  use Jido.Action,
+    name: "fixture_reasoning_explain",
+    description: "Return deterministic explanation output",
+    category: "ai",
+    tags: ["reasoning", "fixture", "explain"],
+    vsn: "1.0.0",
+    schema:
+      Zoi.object(%{
+        topic: Zoi.string(description: "Topic to explain"),
+        audience: Zoi.string(description: "Audience receiving the explanation"),
+        detail_level: Zoi.atom(description: "Detail level") |> Zoi.default(:intermediate),
+        include_examples: Zoi.boolean(description: "Whether to include examples") |> Zoi.default(true)
+      })
+
+  alias AgentJido.Demos.ActionsRuntime.FixtureHelpers
+
+  @impl true
+  def run(params, _context) do
+    {:ok,
+     %{
+       result:
+         "Supervision trees group processes so failures restart only the affected part of the system. A GenServer crashing under a DynamicSupervisor can restart without taking the whole app down.",
+       topic: params[:topic],
+       audience: params[:audience],
+       detail_level: params[:detail_level],
+       model: "fixture:reasoner",
+       usage: FixtureHelpers.usage(17, 24)
+     }}
+  end
+end
+
+defmodule AgentJido.Demos.ActionsRuntime.FixtureRunStrategyAction do
+  @moduledoc """
+  Deterministic reasoning strategy runner for local runtime demos.
+  """
+
+  use Jido.Action,
+    name: "fixture_reasoning_run_strategy",
+    description: "Return deterministic strategy-run output",
+    category: "ai",
+    tags: ["reasoning", "fixture", "strategy"],
+    vsn: "1.0.0",
+    schema:
+      Zoi.object(%{
+        strategy: Zoi.atom(description: "Reasoning strategy") |> Zoi.default(:cot),
+        prompt: Zoi.string(description: "Prompt for the strategy run")
+      })
+
+  alias AgentJido.Demos.ActionsRuntime.FixtureHelpers
+
+  @impl true
+  def run(params, _context) do
+    {:ok,
+     %{
+       result: "Recommendation: launch behind a feature flag, measure activation weekly, and keep a manual rollback checklist ready.",
+       strategy: params[:strategy],
+       trace: [
+         "Identify the safest rollout option",
+         "Choose one measurable checkpoint",
+         "Add a fallback before general availability"
+       ],
+       model: "fixture:reasoner",
+       usage: FixtureHelpers.usage(22, 20)
+     }}
+  end
+end
+
+defmodule AgentJido.Demos.ActionsRuntime.FixtureCallWithToolsAction do
+  @moduledoc """
+  Deterministic stand-in for a tool-calling round trip with auto execution.
+  """
+
+  use Jido.Action,
+    name: "fixture_tool_calling_call_with_tools",
+    description: "Return a deterministic tool-calling conversation result",
+    category: "ai",
+    tags: ["tool-calling", "fixture", "runtime"],
+    vsn: "1.0.0",
+    schema:
+      Zoi.object(%{
+        prompt: Zoi.string(description: "Prompt to route through tool calling"),
+        tools: Zoi.list(Zoi.string(), description: "Allowed tool names") |> Zoi.default([]),
+        auto_execute: Zoi.boolean(description: "Whether to auto-execute tool calls") |> Zoi.default(true),
+        max_turns: Zoi.integer(description: "Maximum turns") |> Zoi.default(5)
+      })
+
+  alias AgentJido.Demos.ActionsRuntime.{ConvertTemperatureAction, FixtureHelpers}
+  alias Jido.AI.Actions.ToolCalling.ExecuteTool
+
+  @impl true
+  def run(params, context) do
+    tools = Map.merge(%{ConvertTemperatureAction.name() => ConvertTemperatureAction}, Map.get(context, :tools, %{}))
+    context = Map.put(context, :tools, tools)
+
+    arguments = %{"value" => 72.0, "from" => "fahrenheit", "to" => "celsius"}
+
+    {:ok, executed} =
+      Jido.Exec.run(
+        ExecuteTool,
+        %{tool_name: ConvertTemperatureAction.name(), params: arguments},
+        context
+      )
+
+    {:ok,
+     %{
+       type: :final,
+       content: "Converted 72F to 22.2C using convert_temperature. For a quick errand, a light jacket is enough.",
+       prompt: params[:prompt],
+       tool_calls: [
+         %{id: "tc_runtime_1", name: ConvertTemperatureAction.name(), arguments: arguments}
+       ],
+       tool_results: [executed],
+       turns: 2,
+       model: "fixture:tool-router",
+       usage: FixtureHelpers.usage(21, 18)
+     }}
+  end
+end

--- a/lib/agent_jido/demos/actions_runtime/runtime_demo.ex
+++ b/lib/agent_jido/demos/actions_runtime/runtime_demo.ex
@@ -1,0 +1,320 @@
+defmodule AgentJido.Demos.ActionsRuntimeDemo do
+  @moduledoc """
+  Deterministic `Jido.Exec.run/3` walkthrough for the public actions runtime demo.
+  """
+
+  alias AgentJido.Demos.ActionsRuntime.{
+    ConvertTemperatureAction,
+    FixtureAnalyzeAction,
+    FixtureCallWithToolsAction,
+    FixtureChatAction,
+    FixtureCompleteAction,
+    FixtureDecomposeAction,
+    FixtureExplainAction,
+    FixtureGenerateObjectAction,
+    FixtureInferAction,
+    FixturePlanAction,
+    FixturePrioritizeAction,
+    FixtureRunStrategyAction
+  }
+
+  alias Jido.AI.Actions.Quota.{GetStatus, Reset}
+  alias Jido.AI.Actions.Retrieval.{ClearMemory, RecallMemory, UpsertMemory}
+  alias Jido.AI.Actions.ToolCalling.{ExecuteTool, ListTools}
+  alias Jido.AI.Quota.Store, as: QuotaStore
+  alias Jido.AI.Retrieval.Store, as: RetrievalStore
+
+  @retrieval_namespace "actions_runtime_demo"
+  @quota_scope "actions_runtime_demo"
+  @quota_window_ms 60_000
+
+  @families [
+    %{
+      id: "llm",
+      title: "LLM envelopes",
+      description: "Chat, complete, and generate-object envelopes through deterministic fixture actions."
+    },
+    %{
+      id: "tool_calling",
+      title: "Tool calling",
+      description: "List tools, execute a deterministic conversion tool, and complete a fixture call_with_tools round trip."
+    },
+    %{
+      id: "planning",
+      title: "Planning",
+      description: "Plan, decompose, and prioritize work through deterministic planning fixtures."
+    },
+    %{
+      id: "reasoning",
+      title: "Reasoning",
+      description: "Analyze, infer, explain, and run one strategy with deterministic reasoning fixtures."
+    },
+    %{
+      id: "retrieval",
+      title: "Retrieval",
+      description: "Use the shipped retrieval actions against the in-process memory store."
+    },
+    %{
+      id: "quota",
+      title: "Quota usage and reset",
+      description: "Use the shipped quota actions against the in-process quota store."
+    }
+  ]
+
+  @spec families() :: [map()]
+  def families, do: @families
+
+  @spec run_all() :: [map()]
+  def run_all do
+    Enum.map(@families, &run_family(&1.id))
+  end
+
+  @spec run_family(String.t() | atom()) :: map()
+  def run_family(family) when is_atom(family), do: run_family(Atom.to_string(family))
+
+  def run_family("llm") do
+    calls = [
+      run_call("Chat", FixtureChatAction, %{prompt: "Summarize Elixir in one sentence."}),
+      run_call("Complete", FixtureCompleteAction, %{prompt: "The key feature of OTP is"}),
+      run_call("GenerateObject", FixtureGenerateObjectAction, %{prompt: "Return title/confidence for note: Jido AI roadmap"})
+    ]
+
+    package_result(
+      "llm",
+      "LLM envelopes",
+      "Three deterministic fixture actions return the same envelope shape you inspect when calling runtime actions directly.",
+      calls
+    )
+  end
+
+  def run_family("tool_calling") do
+    context = tool_context()
+
+    calls = [
+      run_call("ListTools", ListTools, %{include_schema: true}, context),
+      run_call(
+        "ExecuteTool",
+        ExecuteTool,
+        %{
+          tool_name: ConvertTemperatureAction.name(),
+          params: %{"value" => 72.0, "from" => "fahrenheit", "to" => "celsius"}
+        },
+        context
+      ),
+      run_call(
+        "CallWithTools",
+        FixtureCallWithToolsAction,
+        %{
+          prompt: "Use convert_temperature for 72F to C and explain.",
+          tools: [ConvertTemperatureAction.name()],
+          auto_execute: true,
+          max_turns: 5
+        },
+        context
+      )
+    ]
+
+    package_result(
+      "tool_calling",
+      "Tool calling",
+      "The demo keeps the real runtime entrypoint, uses the shipped list/execute actions, and swaps in one deterministic auto-executed tool round trip.",
+      calls
+    )
+  end
+
+  def run_family("planning") do
+    calls = [
+      run_call(
+        "Plan",
+        FixturePlanAction,
+        %{
+          goal: "Ship v1 onboarding flow",
+          constraints: ["Two engineers", "Six-week timeline"],
+          resources: ["Existing auth service", "Hosted Postgres"]
+        }
+      ),
+      run_call(
+        "Decompose",
+        FixtureDecomposeAction,
+        %{
+          goal: "Ship v1 onboarding flow",
+          max_depth: 3,
+          context: "B2B SaaS onboarding"
+        }
+      ),
+      run_call(
+        "Prioritize",
+        FixturePrioritizeAction,
+        %{
+          tasks: ["Design onboarding steps", "Implement analytics events", "Write migration docs"],
+          criteria: "Customer impact first, then dependency risk"
+        }
+      )
+    ]
+
+    package_result(
+      "planning",
+      "Planning",
+      "The planning family stays deterministic while preserving the direct runtime call pattern for plan, decompose, and prioritize.",
+      calls
+    )
+  end
+
+  def run_family("reasoning") do
+    calls = [
+      run_call(
+        "Analyze",
+        FixtureAnalyzeAction,
+        %{
+          input: "Customer churn increased 18% this quarter while support volume stayed flat.",
+          analysis_type: :summary
+        }
+      ),
+      run_call(
+        "Infer",
+        FixtureInferAction,
+        %{
+          premises: "All production incidents trigger a postmortem. Incident INC-42 was a production incident.",
+          question: "Should INC-42 have a postmortem?"
+        }
+      ),
+      run_call(
+        "Explain",
+        FixtureExplainAction,
+        %{
+          topic: "GenServer supervision trees",
+          detail_level: :intermediate,
+          audience: "backend engineers",
+          include_examples: true
+        }
+      ),
+      run_call(
+        "RunStrategy",
+        FixtureRunStrategyAction,
+        %{
+          strategy: :cot,
+          prompt: "Recommend one rollout option and include a fallback in three bullets."
+        }
+      )
+    ]
+
+    package_result(
+      "reasoning",
+      "Reasoning",
+      "Analyze, infer, explain, and run_strategy all exercise real runtime calls while staying deterministic for the site demo.",
+      calls
+    )
+  end
+
+  def run_family("retrieval") do
+    :ok = RetrievalStore.ensure_table!()
+    _ = Jido.Exec.run(ClearMemory, %{namespace: @retrieval_namespace}, %{})
+
+    calls = [
+      run_call(
+        "UpsertMemory",
+        UpsertMemory,
+        %{
+          namespace: @retrieval_namespace,
+          id: "seattle_weekly",
+          text: "Seattle mornings are cooler this week with intermittent rain.",
+          metadata: %{source: "weekly_summary", region: "pnw"}
+        }
+      ),
+      run_call(
+        "UpsertMemory",
+        UpsertMemory,
+        %{
+          namespace: @retrieval_namespace,
+          id: "gear_note",
+          text: "Keep a light shell ready for Seattle commutes when rain bands move in.",
+          metadata: %{source: "gear_note", region: "pnw"}
+        }
+      ),
+      run_call(
+        "RecallMemory",
+        RecallMemory,
+        %{namespace: @retrieval_namespace, query: "seattle rain outlook", top_k: 2}
+      ),
+      run_call("ClearMemory", ClearMemory, %{namespace: @retrieval_namespace})
+    ]
+
+    package_result(
+      "retrieval",
+      "Retrieval",
+      "This family uses the shipped retrieval actions directly against the in-process store, so the site demo and your local runtime calls are the same surface.",
+      calls
+    )
+  end
+
+  def run_family("quota") do
+    :ok = QuotaStore.ensure_table!()
+    :ok = QuotaStore.reset(@quota_scope)
+    _ = QuotaStore.add_usage(@quota_scope, 180, @quota_window_ms)
+    _ = QuotaStore.add_usage(@quota_scope, 240, @quota_window_ms)
+
+    context = %{
+      plugin_state: %{
+        quota: %{
+          scope: @quota_scope,
+          window_ms: @quota_window_ms,
+          max_requests: 5,
+          max_total_tokens: 1_000
+        }
+      }
+    }
+
+    calls = [
+      run_call("GetStatus", GetStatus, %{}, context),
+      run_call("Reset", Reset, %{scope: @quota_scope}, context),
+      run_call("GetStatus After Reset", GetStatus, %{}, context)
+    ]
+
+    package_result(
+      "quota",
+      "Quota usage and reset",
+      "The quota family uses the shipped actions directly and shows the before/reset/after flow against the in-process quota store.",
+      calls
+    )
+  end
+
+  def run_family(other) do
+    raise ArgumentError, "unsupported actions runtime family: #{inspect(other)}"
+  end
+
+  defp package_result(id, title, summary, calls) do
+    %{
+      id: id,
+      title: title,
+      summary: summary,
+      calls: calls,
+      succeeded: Enum.all?(calls, &match?(%{status: :ok}, &1))
+    }
+  end
+
+  defp run_call(label, module, params, context \\ %{}) do
+    case Jido.Exec.run(module, params, context) do
+      {:ok, result} ->
+        %{
+          label: label,
+          module: inspect(module),
+          params: params,
+          result: result,
+          status: :ok
+        }
+
+      {:error, reason} ->
+        %{
+          label: label,
+          module: inspect(module),
+          params: params,
+          result: %{error: inspect(reason)},
+          status: :error
+        }
+    end
+  end
+
+  defp tool_context do
+    %{tools: %{ConvertTemperatureAction.name() => ConvertTemperatureAction}}
+  end
+end

--- a/lib/agent_jido_web/examples/actions_runtime_demo_live.ex
+++ b/lib/agent_jido_web/examples/actions_runtime_demo_live.ex
@@ -1,0 +1,198 @@
+defmodule AgentJidoWeb.Examples.ActionsRuntimeDemoLive do
+  @moduledoc """
+  Interactive demo for deterministic `Jido.Exec.run/3` action runtime walkthroughs.
+  """
+
+  use AgentJidoWeb, :live_view
+
+  alias AgentJido.Demos.ActionsRuntimeDemo
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {:ok,
+     socket
+     |> assign(:families, ActionsRuntimeDemo.families())
+     |> assign(:family_results, %{})
+     |> assign(:selected_family, nil)
+     |> assign(:log_entries, [])
+     |> assign(:last_error, nil)}
+  end
+
+  @impl true
+  def render(assigns) do
+    selected_result = Map.get(assigns.family_results, assigns.selected_family)
+    assigns = assign(assigns, :selected_result, selected_result)
+
+    ~H"""
+    <div id="actions-runtime-demo" class="rounded-lg border border-border bg-card p-6 space-y-6">
+      <div class="flex items-center justify-between gap-4">
+        <div>
+          <div class="text-sm font-semibold text-foreground">Jido.AI Actions Runtime Demos</div>
+          <div class="text-[11px] text-muted-foreground">
+            Real `Jido.Exec.run/3` calls with deterministic local fixtures and in-process stores
+          </div>
+        </div>
+        <div class="text-[10px] font-mono text-muted-foreground bg-elevated px-2 py-1 rounded border border-border">
+          {map_size(@family_results)} / {length(@families)} families completed
+        </div>
+      </div>
+
+      <div :if={@last_error} class="rounded-md border border-red-400/30 bg-red-400/10 px-3 py-2 text-xs text-red-300">
+        {@last_error}
+      </div>
+
+      <div class="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+        <%= for family <- @families do %>
+          <button
+            id={"actions-runtime-#{family.id}-btn"}
+            phx-click="run_family"
+            phx-value-family={family.id}
+            class="rounded-md border border-border bg-elevated p-4 text-left hover:border-primary/40 transition-colors"
+          >
+            <div class="flex items-center justify-between gap-3">
+              <div class="text-xs font-semibold text-foreground">{family.title}</div>
+              <div
+                :if={Map.has_key?(@family_results, family.id)}
+                class="text-[10px] uppercase tracking-wider text-emerald-300"
+              >
+                complete
+              </div>
+            </div>
+            <div class="mt-2 text-[11px] text-muted-foreground leading-relaxed">{family.description}</div>
+          </button>
+        <% end %>
+      </div>
+
+      <div class="flex gap-3 flex-wrap">
+        <button
+          id="actions-runtime-run-all-btn"
+          phx-click="run_all"
+          class="px-4 py-2 rounded-md bg-primary/10 border border-primary/30 text-primary hover:bg-primary/20 transition-colors text-sm font-semibold"
+        >
+          Run All Families
+        </button>
+        <button
+          id="actions-runtime-reset-btn"
+          phx-click="reset_demo"
+          class="px-3 py-2 rounded-md bg-elevated border border-border text-muted-foreground hover:text-foreground hover:border-primary/40 transition-colors text-xs"
+        >
+          Reset
+        </button>
+      </div>
+
+      <div class="grid gap-4 xl:grid-cols-[0.85fr_1.15fr]">
+        <div class="rounded-md border border-border bg-elevated p-4">
+          <div class="flex items-center justify-between mb-2">
+            <div class="text-[10px] uppercase tracking-wider text-muted-foreground">Execution Log</div>
+            <div class="text-[10px] text-muted-foreground">{length(@log_entries)} entries</div>
+          </div>
+          <div :if={@log_entries == []} class="text-xs text-muted-foreground">
+            Run one family or the full suite to inspect the deterministic runtime calls.
+          </div>
+          <div :if={@log_entries != []} class="space-y-2 max-h-[32rem] overflow-y-auto">
+            <%= for entry <- @log_entries do %>
+              <div class="rounded-md border border-border bg-background/70 px-3 py-2">
+                <div class="text-[11px] font-semibold text-foreground">{entry.title}</div>
+                <div class="text-[11px] text-muted-foreground">{entry.detail}</div>
+              </div>
+            <% end %>
+          </div>
+        </div>
+
+        <div class="rounded-md border border-border bg-elevated p-4">
+          <div class="flex items-center justify-between mb-2">
+            <div class="text-[10px] uppercase tracking-wider text-muted-foreground">Latest Result</div>
+            <div :if={@selected_result} class="text-[10px] text-muted-foreground">{@selected_result.title}</div>
+          </div>
+
+          <div :if={is_nil(@selected_result)} class="text-xs text-muted-foreground">
+            Select a family to inspect the exact `Jido.Exec.run/3` calls and results.
+          </div>
+
+          <div :if={@selected_result} class="space-y-4">
+            <div>
+              <div class="text-sm font-semibold text-foreground">{@selected_result.title}</div>
+              <div class="text-xs text-muted-foreground mt-1">{@selected_result.summary}</div>
+            </div>
+
+            <div class="space-y-3">
+              <%= for call <- @selected_result.calls do %>
+                <div class="rounded-md border border-border bg-background/80 p-3 space-y-2">
+                  <div class="flex items-center justify-between gap-3">
+                    <div class="text-xs font-semibold text-foreground">{call.label}</div>
+                    <div class="text-[10px] uppercase tracking-wider text-muted-foreground">
+                      {if call.status == :ok, do: "ok", else: "error"}
+                    </div>
+                  </div>
+                  <div class="text-[11px] text-muted-foreground font-mono break-all">{call.module}</div>
+                  <div class="grid gap-2 lg:grid-cols-2">
+                    <div>
+                      <div class="text-[10px] uppercase tracking-wider text-muted-foreground mb-1">Params</div>
+                      <pre class="text-[11px] text-foreground whitespace-pre-wrap font-mono"><%= inspect(call.params, pretty: true, width: 70) %></pre>
+                    </div>
+                    <div>
+                      <div class="text-[10px] uppercase tracking-wider text-muted-foreground mb-1">Result</div>
+                      <pre class="text-[11px] text-foreground whitespace-pre-wrap font-mono"><%= inspect(call.result, pretty: true, width: 70) %></pre>
+                    </div>
+                  </div>
+                </div>
+              <% end %>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  @impl true
+  def handle_event("run_family", %{"family" => family}, socket) do
+    run = ActionsRuntimeDemo.run_family(family)
+
+    {:noreply,
+     socket
+     |> assign(:selected_family, family)
+     |> assign(:family_results, Map.put(socket.assigns.family_results, family, run))
+     |> assign(:last_error, nil)
+     |> prepend_log(run)}
+  rescue
+    error ->
+      {:noreply, assign(socket, :last_error, Exception.message(error))}
+  end
+
+  def handle_event("run_all", _params, socket) do
+    results = ActionsRuntimeDemo.run_all()
+    family_results = Map.new(results, &{&1.id, &1})
+    selected_family = results |> List.last() |> Map.fetch!(:id)
+
+    socket =
+      Enum.reduce(results, socket, fn run, acc -> prepend_log(acc, run) end)
+
+    {:noreply,
+     socket
+     |> assign(:family_results, Map.merge(socket.assigns.family_results, family_results))
+     |> assign(:selected_family, selected_family)
+     |> assign(:last_error, nil)}
+  rescue
+    error ->
+      {:noreply, assign(socket, :last_error, Exception.message(error))}
+  end
+
+  def handle_event("reset_demo", _params, socket) do
+    {:noreply,
+     socket
+     |> assign(:family_results, %{})
+     |> assign(:selected_family, nil)
+     |> assign(:log_entries, [])
+     |> assign(:last_error, nil)}
+  end
+
+  defp prepend_log(socket, run) do
+    entry = %{
+      title: run.title,
+      detail: "#{length(run.calls)} calls completed through Jido.Exec.run/3."
+    }
+
+    assign(socket, :log_entries, [entry | socket.assigns.log_entries] |> Enum.take(40))
+  end
+end

--- a/lib/agent_jido_web/examples/simulated_showcase_live.ex
+++ b/lib/agent_jido_web/examples/simulated_showcase_live.ex
@@ -356,26 +356,6 @@ defmodule AgentJidoWeb.Examples.SimulatedShowcaseLive do
     }
   end
 
-  defp scenario_for("jido-ai-actions-runtime-demos") do
-    %{
-      title: "Jido.AI Actions Runtime Demos",
-      steps: [
-        %{label: "LLM actions", detail: "Validated chat/complete/generate_object output envelopes"},
-        %{label: "Tool calling actions", detail: "Listed tools and executed conversion tool"},
-        %{label: "Planning actions", detail: "Ran plan/decompose/prioritize sequence"},
-        %{label: "Reasoning actions", detail: "Ran analyze/infer/explain/run_strategy checks"},
-        %{label: "Retrieval + quota", detail: "Exercised memory upsert/recall/clear and quota status/reset"}
-      ],
-      result: """
-      {
-        "model": "simulated:haiku",
-        "families_passed": 6,
-        "runtime_surface": "Jido.Exec.run/3"
-      }
-      """
-    }
-  end
-
   defp scenario_for("jido-ai-weather-multi-turn-context") do
     %{
       title: "Jido.AI Weather Multi-Turn Context",

--- a/priv/examples/jido-ai-actions-runtime-demos.md
+++ b/priv/examples/jido-ai-actions-runtime-demos.md
@@ -1,7 +1,7 @@
 %{
   title: "Jido.AI Actions Runtime Demos",
-  description: "Direct `Jido.Exec.run/3` action demos for LLM, planning, reasoning, retrieval, quota, and tool-calling.",
-  tags: ["primary", "showcase", "simulated", "ai", "l2", "ai-tool-use", "jido_ai", "actions"],
+  description: "Deterministic `Jido.Exec.run/3` walkthrough for LLM envelopes, tool execution, planning, reasoning, retrieval, and quota flows.",
+  tags: ["primary", "showcase", "ai", "l2", "ai-tool-use", "jido_ai", "actions", "runtime"],
   category: :ai,
   emoji: "🧰",
   related_resources: [
@@ -20,9 +20,12 @@
     }
   ],
   source_files: [
-    "lib/agent_jido_web/examples/simulated_showcase_live.ex"
+    "lib/agent_jido/demos/actions_runtime/runtime_demo.ex",
+    "lib/agent_jido/demos/actions_runtime/fixture_actions.ex",
+    "lib/agent_jido/demos/actions_runtime/convert_temperature_action.ex",
+    "lib/agent_jido_web/examples/actions_runtime_demo_live.ex"
   ],
-  live_view_module: "AgentJidoWeb.Examples.SimulatedShowcaseLive",
+  live_view_module: "AgentJidoWeb.Examples.ActionsRuntimeDemoLive",
   difficulty: :intermediate,
   status: :live,
   scenario_cluster: :ai_tool_use,
@@ -31,7 +34,7 @@
   content_intent: :reference,
   capability_theme: :ai_intelligence,
   evidence_surface: :runnable_example,
-  demo_mode: :simulated,
+  demo_mode: :real,
   sort_order: 19
 }
 ---
@@ -40,17 +43,32 @@
 
 - When to use direct action runtime calls instead of long-lived agent loops
 - How the core action families map to practical workflows
-- How to demonstrate runtime behavior using deterministic fixtures
+- How to keep a runtime demo deterministic without external API keys or network access
+- How to swap fixture-backed families to `Jido.AI.Actions.*` modules in your own app
 
 ## Covered action families
 
-- LLM actions
-- Tool calling actions
-- Planning actions
-- Reasoning actions
-- Retrieval actions
-- Quota actions
+- LLM envelopes: fixture-backed `chat`, `complete`, and `generate_object`
+- Tool calling: shipped `list_tools` / `execute_tool` plus one deterministic `call_with_tools` companion
+- Planning: deterministic `plan`, `decompose`, and `prioritize`
+- Reasoning: deterministic `analyze`, `infer`, `explain`, and `run_strategy`
+- Retrieval: shipped `upsert_memory`, `recall_memory`, and `clear_memory`
+- Quota: shipped `get_status` and `reset`
 
-## Demo note
+## How this demo stays deterministic
 
-This page replays deterministic traces for each family and does not call external providers.
+This page runs **real `Jido.Exec.run/3` calls** on every button press.
+
+- Retrieval and quota use the shipped `Jido.AI.Actions.*` modules directly.
+- Tool discovery and direct tool execution use the shipped tool-calling actions directly.
+- The LLM-backed families use local fixture actions in this repo so the site demo never depends on provider credentials.
+
+That keeps the public example truthful: the runtime surface is real, the code is local, and the outputs stay repeatable.
+
+## Pull the pattern into your own app
+
+In your own project, keep the same `Jido.Exec.run/3` shape and swap the fixture-backed families to the production modules from `Jido.AI.Actions.*`.
+
+- Keep retrieval and quota as-is if the in-process stores fit your needs.
+- Replace the fixture tool with your own tool Action modules.
+- Replace the fixture LLM/planning/reasoning actions with the shipped `Jido.AI.Actions.*` modules once provider credentials are configured.

--- a/test/agent_jido/demos/actions_runtime_demo_test.exs
+++ b/test/agent_jido/demos/actions_runtime_demo_test.exs
@@ -1,0 +1,87 @@
+defmodule AgentJido.Demos.ActionsRuntimeDemoTest do
+  use ExUnit.Case, async: false
+
+  alias AgentJido.Demos.ActionsRuntimeDemo
+
+  test "llm family returns deterministic envelope-style results" do
+    result = ActionsRuntimeDemo.run_family(:llm)
+
+    assert result.id == "llm"
+    assert result.succeeded == true
+    assert length(result.calls) == 3
+
+    [chat, complete, generated] = result.calls
+
+    assert chat.module =~ "FixtureChatAction"
+    assert chat.result.model == "fixture:haiku"
+    assert chat.result.text =~ "Elixir"
+
+    assert complete.module =~ "FixtureCompleteAction"
+    assert complete.result.text =~ "OTP"
+
+    assert generated.module =~ "FixtureGenerateObjectAction"
+    assert generated.result.object.title == "Jido AI roadmap"
+    assert generated.result.object.confidence == 0.93
+  end
+
+  test "tool-calling family lists tools and executes deterministic tool flow" do
+    result = ActionsRuntimeDemo.run_family(:tool_calling)
+
+    assert result.id == "tool_calling"
+    assert result.succeeded == true
+    assert length(result.calls) == 3
+
+    [listed, executed, called] = result.calls
+
+    assert listed.module == "Jido.AI.Actions.ToolCalling.ListTools"
+    assert listed.result.count == 1
+    assert hd(listed.result.tools).name == "convert_temperature"
+
+    assert executed.module == "Jido.AI.Actions.ToolCalling.ExecuteTool"
+    assert executed.result.result.converted_value == 22.2
+    assert executed.result.result.output_unit == "celsius"
+
+    assert called.module =~ "FixtureCallWithToolsAction"
+    assert called.result.content =~ "22.2C"
+    assert called.result.turns == 2
+  end
+
+  test "retrieval family uses runtime retrieval actions against the in-process store" do
+    result = ActionsRuntimeDemo.run_family(:retrieval)
+
+    assert result.id == "retrieval"
+    assert result.succeeded == true
+    assert length(result.calls) == 4
+
+    recall = Enum.find(result.calls, &(&1.label == "RecallMemory"))
+    clear = List.last(result.calls)
+
+    assert recall.module == "Jido.AI.Actions.Retrieval.RecallMemory"
+    assert recall.result.retrieval.count == 2
+    assert Enum.any?(recall.result.retrieval.memories, &String.contains?(&1.text, "Seattle"))
+
+    assert clear.module == "Jido.AI.Actions.Retrieval.ClearMemory"
+    assert clear.result.retrieval.cleared == 2
+  end
+
+  test "quota family reports usage and resets the scope" do
+    result = ActionsRuntimeDemo.run_family(:quota)
+
+    assert result.id == "quota"
+    assert result.succeeded == true
+    assert length(result.calls) == 3
+
+    [status, reset, after_reset] = result.calls
+
+    assert status.module == "Jido.AI.Actions.Quota.GetStatus"
+    assert status.result.quota.usage.requests == 2
+    assert status.result.quota.usage.total_tokens == 420
+
+    assert reset.module == "Jido.AI.Actions.Quota.Reset"
+    assert reset.result.quota.reset == true
+
+    assert after_reset.module == "Jido.AI.Actions.Quota.GetStatus"
+    assert after_reset.result.quota.usage.requests == 0
+    assert after_reset.result.quota.usage.total_tokens == 0
+  end
+end

--- a/test/agent_jido/examples_test.exs
+++ b/test/agent_jido/examples_test.exs
@@ -17,7 +17,7 @@ defmodule AgentJido.ExamplesTest do
     {"runic-adaptive-researcher", "AgentJidoWeb.Examples.SimulatedShowcaseLive"},
     {"runic-structured-llm-branching", "AgentJidoWeb.Examples.SimulatedShowcaseLive"},
     {"runic-delegating-orchestrator", "AgentJidoWeb.Examples.SimulatedShowcaseLive"},
-    {"jido-ai-actions-runtime-demos", "AgentJidoWeb.Examples.SimulatedShowcaseLive"},
+    {"jido-ai-actions-runtime-demos", "AgentJidoWeb.Examples.ActionsRuntimeDemoLive"},
     {"jido-ai-browser-web-workflow", "AgentJidoWeb.Examples.BrowserDocsScoutAgentLive"},
     {"jido-ai-weather-multi-turn-context", "AgentJidoWeb.Examples.SimulatedShowcaseLive"},
     {"jido-ai-task-execution-workflow", "AgentJidoWeb.Examples.SimulatedShowcaseLive"},

--- a/test/agent_jido_web/live/jido_example_live_test.exs
+++ b/test/agent_jido_web/live/jido_example_live_test.exs
@@ -12,7 +12,6 @@ defmodule AgentJidoWeb.JidoExampleLiveTest do
     {"runic-adaptive-researcher", "Runic Adaptive Researcher"},
     {"runic-structured-llm-branching", "Runic Structured LLM Branching"},
     {"runic-delegating-orchestrator", "Runic Delegating Orchestrator"},
-    {"jido-ai-actions-runtime-demos", "Jido.AI Actions Runtime Demos"},
     {"jido-ai-weather-multi-turn-context", "Jido.AI Weather Multi-Turn Context"},
     {"jido-ai-task-execution-workflow", "Jido.AI Task Execution Workflow"},
     {"jido-ai-skills-runtime-foundations", "Jido.AI Skills Runtime Foundations"},
@@ -275,6 +274,77 @@ defmodule AgentJidoWeb.JidoExampleLiveTest do
                "lib/agent_jido/demos/browser_docs_scout/browser_actions.ex",
                "lib/agent_jido/demos/browser_docs_scout/simulated_adapter.ex",
                "lib/agent_jido_web/examples/browser_docs_scout_agent_live.ex"
+             ]
+
+      assert Enum.map(example.sources, & &1.path) == example.source_files
+    end
+  end
+
+  describe "/examples/jido-ai-actions-runtime-demos" do
+    test "renders explanation tab with real runtime and fixture guidance", %{conn: conn} do
+      {:ok, _view, html} = live(conn, "/examples/jido-ai-actions-runtime-demos?tab=explanation")
+
+      assert html =~ "Jido.AI Actions Runtime Demos"
+      assert html =~ "Jido.Exec.run/3"
+      assert html =~ "Retrieval and quota use the shipped"
+      assert html =~ "fixture-backed families"
+    end
+
+    test "renders source tab for the dedicated actions runtime example", %{conn: conn} do
+      {:ok, _view, html} = live(conn, "/examples/jido-ai-actions-runtime-demos?tab=source")
+
+      assert html =~ "runtime_demo.ex"
+      assert html =~ "fixture_actions.ex"
+      assert html =~ "convert_temperature_action.ex"
+      assert html =~ "actions_runtime_demo_live.ex"
+    end
+
+    test "demo tab runs deterministic runtime families", %{conn: conn} do
+      {:ok, view, html} = live(conn, "/examples/jido-ai-actions-runtime-demos?tab=demo")
+
+      assert html =~ "Jido.AI Actions Runtime Demos"
+      refute html =~ "Simulated demo"
+
+      demo_view = find_live_child(view, "demo-jido-ai-actions-runtime-demos")
+
+      html =
+        demo_view
+        |> element("#actions-runtime-demo button[phx-value-family='llm']")
+        |> render_click()
+
+      assert html =~ "LLM envelopes"
+      assert html =~ "FixtureChatAction"
+      assert html =~ "fixture:haiku"
+
+      html =
+        demo_view
+        |> element("#actions-runtime-demo button[phx-value-family='tool_calling']")
+        |> render_click()
+
+      assert html =~ "convert_temperature"
+      assert html =~ "22.2"
+
+      html =
+        demo_view
+        |> element("#actions-runtime-demo button[phx-click='run_all']")
+        |> render_click()
+
+      assert html =~ "6 / 6 families completed"
+      assert html =~ "Quota usage and reset"
+      assert html =~ "GetStatus After Reset"
+    end
+
+    test "example registry metadata resolves new runtime source files", %{conn: _conn} do
+      example = Examples.get_example!("jido-ai-actions-runtime-demos")
+
+      assert example.title == "Jido.AI Actions Runtime Demos"
+      assert example.live_view_module == "AgentJidoWeb.Examples.ActionsRuntimeDemoLive"
+
+      assert example.source_files == [
+               "lib/agent_jido/demos/actions_runtime/runtime_demo.ex",
+               "lib/agent_jido/demos/actions_runtime/fixture_actions.ex",
+               "lib/agent_jido/demos/actions_runtime/convert_temperature_action.ex",
+               "lib/agent_jido_web/examples/actions_runtime_demo_live.ex"
              ]
 
       assert Enum.map(example.sources, & &1.path) == example.source_files


### PR DESCRIPTION
## Summary
- replace the `jido-ai-actions-runtime-demos` slug with a dedicated deterministic runtime implementation
- add fixture-backed runtime actions, a local temperature conversion tool, and a dedicated LiveView that runs real `Jido.Exec.run/3` calls
- update the example metadata/tests and remove the stale simulator scenario for this slug

## Verification
- `ASDF_ELIXIR_VERSION=1.18.4-otp-27 ASDF_ERLANG_VERSION=27.3 mix test test/agent_jido/demos/actions_runtime_demo_test.exs test/agent_jido/examples_test.exs test/agent_jido_web/live/jido_example_live_test.exs`
- `ASDF_ELIXIR_VERSION=1.18.4-otp-27 ASDF_ERLANG_VERSION=27.3 mix test`

Closes #59