### PR TITLE
Replace simulated skills runtime foundations demo

### DIFF
--- a/lib/agent_jido/demos/skills_runtime_foundations/calculator_skill.ex
+++ b/lib/agent_jido/demos/skills_runtime_foundations/calculator_skill.ex
@@ -1,0 +1,22 @@
+defmodule AgentJido.Demos.SkillsRuntimeFoundations.CalculatorSkill do
+  @moduledoc """
+  Module-backed skill used by the public skills runtime foundations example.
+  """
+
+  use Jido.AI.Skill,
+    name: "demo-runtime-calculator",
+    description: "Performs arithmetic with tool-based execution for the skills runtime foundations demo.",
+    license: "Apache-2.0",
+    allowed_tools: ~w(add subtract multiply divide),
+    tags: ["demo", "skills", "math", "runtime"],
+    body: """
+    # Demo Runtime Calculator
+
+    Use arithmetic tools for every operation in this demo.
+
+    ## Workflow
+    1. Identify the arithmetic request.
+    2. Select the matching math tool.
+    3. Return the computed result with a short explanation.
+    """
+end

--- a/lib/agent_jido/demos/skills_runtime_foundations/runtime_demo.ex
+++ b/lib/agent_jido/demos/skills_runtime_foundations/runtime_demo.ex
@@ -1,0 +1,156 @@
+defmodule AgentJido.Demos.SkillsRuntimeFoundations.RuntimeDemo do
+  @moduledoc """
+  Deterministic skills runtime walkthrough backed by real module and SKILL.md specs.
+  """
+
+  alias AgentJido.Demos.SkillsRuntimeFoundations.CalculatorSkill
+  alias Jido.AI.Skill
+  alias Jido.AI.Skill.{Loader, Prompt, Registry, Spec}
+
+  @project_root Path.expand("../../../..", __DIR__)
+  @skills_root_source_path "priv/skills/skills-runtime-foundations"
+  @primary_skill_source_path Path.join(@skills_root_source_path, "demo-code-review/SKILL.md")
+  @demo_skill_names ["demo-runtime-calculator", "demo-code-review", "demo-release-notes"]
+
+  defstruct file_manifest: nil,
+            module_manifest: nil,
+            registry_specs: [],
+            prompt: "",
+            allowed_tools: [],
+            loaded_count: 0,
+            log: [],
+            primary_skill_source_path: @primary_skill_source_path,
+            skills_root_source_path: @skills_root_source_path
+
+  @type log_entry :: %{
+          required(:label) => String.t(),
+          required(:detail) => String.t()
+        }
+
+  @type t :: %__MODULE__{
+          file_manifest: Spec.t() | nil,
+          module_manifest: Spec.t() | nil,
+          registry_specs: [Spec.t()],
+          prompt: String.t(),
+          allowed_tools: [String.t()],
+          loaded_count: non_neg_integer(),
+          log: [log_entry()],
+          primary_skill_source_path: String.t(),
+          skills_root_source_path: String.t()
+        }
+
+  @doc "Builds a new demo state and removes any previously registered demo skills."
+  @spec new() :: t()
+  def new do
+    cleanup_demo_skills()
+    refresh(%__MODULE__{})
+  end
+
+  @doc "Loads the checked-in file-backed skill manifest without registering it."
+  @spec load_file_manifest(t()) :: t()
+  def load_file_manifest(%__MODULE__{} = demo) do
+    {:ok, spec} = Loader.load(primary_skill_path())
+
+    demo
+    |> Map.put(:file_manifest, spec)
+    |> append_log("Manifest load", "Loaded #{spec.name} from #{demo.primary_skill_source_path}.")
+    |> refresh()
+  end
+
+  @doc "Registers the module-backed demo skill into the runtime registry."
+  @spec register_module_skill(t()) :: t()
+  def register_module_skill(%__MODULE__{} = demo) do
+    spec = Skill.manifest(CalculatorSkill)
+    :ok = Registry.register(spec)
+
+    demo
+    |> Map.put(:module_manifest, spec)
+    |> append_log("Module register", "Registered #{spec.name} into the runtime registry.")
+    |> refresh()
+  end
+
+  @doc "Loads the checked-in SKILL.md fixtures from the demo skills directory."
+  @spec load_runtime_skills(t()) :: t()
+  def load_runtime_skills(%__MODULE__{} = demo) do
+    {:ok, count} = Registry.load_from_paths([skills_root_path()])
+
+    demo
+    |> Map.put(:loaded_count, count)
+    |> append_log("Registry load", "Loaded #{count} SKILL.md file(s) from #{demo.skills_root_source_path}.")
+    |> refresh()
+  end
+
+  @doc "Renders the combined prompt for the currently registered demo skills."
+  @spec render_prompt(t()) :: t()
+  def render_prompt(%__MODULE__{} = demo) do
+    demo = refresh(demo)
+
+    case demo.registry_specs do
+      [] ->
+        demo
+        |> Map.put(:prompt, "")
+        |> Map.put(:allowed_tools, [])
+        |> append_log("Prompt render", "Register the demo skills before rendering the prompt.")
+        |> refresh()
+
+      specs ->
+        prompt = Prompt.render(specs, include_body: true)
+        allowed_tools = Prompt.collect_allowed_tools(specs)
+
+        demo
+        |> Map.put(:prompt, prompt)
+        |> Map.put(:allowed_tools, allowed_tools)
+        |> append_log(
+          "Prompt render",
+          "Rendered a prompt for #{length(specs)} skill(s) with #{length(allowed_tools)} allowed tool(s)."
+        )
+        |> refresh()
+    end
+  end
+
+  @doc "Removes the demo skills from the registry and restores the initial state."
+  @spec reset(t()) :: t()
+  def reset(%__MODULE__{}) do
+    cleanup_demo_skills()
+
+    %__MODULE__{}
+    |> append_log("Reset", "Cleared the demo skills from the runtime registry.")
+    |> refresh()
+  end
+
+  defp refresh(%__MODULE__{} = demo) do
+    registry_specs =
+      @demo_skill_names
+      |> Enum.flat_map(fn name ->
+        case Registry.lookup(name) do
+          {:ok, spec} -> [spec]
+          {:error, _reason} -> []
+        end
+      end)
+
+    %{demo | registry_specs: registry_specs}
+  end
+
+  defp cleanup_demo_skills do
+    :ok = Registry.ensure_started()
+
+    Enum.each(@demo_skill_names, fn name ->
+      try do
+        case Registry.unregister(name) do
+          :ok -> :ok
+          {:error, _reason} -> :ok
+        end
+      catch
+        :exit, _reason -> :ok
+      end
+    end)
+  end
+
+  defp primary_skill_path, do: Path.join(@project_root, @primary_skill_source_path)
+  defp skills_root_path, do: Path.join(@project_root, @skills_root_source_path)
+
+  defp append_log(%__MODULE__{} = demo, label, detail) do
+    entry = %{label: label, detail: detail}
+    %{demo | log: [entry | demo.log] |> Enum.take(30)}
+  end
+end

--- a/lib/agent_jido_web/examples/simulated_showcase_live.ex
+++ b/lib/agent_jido_web/examples/simulated_showcase_live.ex
@@ -376,26 +376,6 @@ defmodule AgentJidoWeb.Examples.SimulatedShowcaseLive do
     }
   end
 
-  defp scenario_for("jido-ai-skills-runtime-foundations") do
-    %{
-      title: "Jido.AI Skills Runtime Foundations",
-      steps: [
-        %{label: "Manifest load", detail: "Loaded module and file skill manifests"},
-        %{label: "Registry bootstrap", detail: "Registered runtime skills from configured paths"},
-        %{label: "Prompt render", detail: "Rendered composed skill prompt for agent usage"},
-        %{label: "Validation", detail: "Verified manifest and prompt expectations"}
-      ],
-      result: """
-      {
-        "model": "simulated:haiku",
-        "module_skills": 1,
-        "file_skills": 1,
-        "registry_ready": true
-      }
-      """
-    }
-  end
-
   defp scenario_for("jido-ai-skills-multi-agent-orchestration") do
     %{
       title: "Jido.AI Skills Multi-Agent Orchestration",

--- a/lib/agent_jido_web/examples/skills_runtime_foundations_live.ex
+++ b/lib/agent_jido_web/examples/skills_runtime_foundations_live.ex
@@ -1,0 +1,229 @@
+defmodule AgentJidoWeb.Examples.SkillsRuntimeFoundationsLive do
+  @moduledoc """
+  Interactive skills runtime foundations demo backed by real module and SKILL.md fixtures.
+  """
+
+  use AgentJidoWeb, :live_view
+
+  alias AgentJido.Demos.SkillsRuntimeFoundations.RuntimeDemo
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {:ok, assign_demo(socket, RuntimeDemo.new())}
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div id="skills-runtime-foundations-demo" class="rounded-lg border border-border bg-card p-6 space-y-6">
+      <div class="flex items-center justify-between gap-4">
+        <div>
+          <div class="text-sm font-semibold text-foreground">Jido.AI Skills Runtime Foundations</div>
+          <div class="text-[11px] text-muted-foreground">
+            Real manifest loading, registry population, and prompt rendering with checked-in `SKILL.md` files
+          </div>
+        </div>
+        <div class="text-[10px] font-mono text-muted-foreground bg-elevated px-2 py-1 rounded border border-border">
+          registry: {@registry_count} skill(s)
+        </div>
+      </div>
+
+      <div class="grid gap-3 sm:grid-cols-4">
+        <div class="rounded-md border border-border bg-elevated p-3 text-center">
+          <div class="text-[10px] uppercase tracking-wider text-muted-foreground">File Manifest</div>
+          <div class="text-sm font-semibold text-foreground mt-2">
+            {if @demo.file_manifest, do: "loaded", else: "pending"}
+          </div>
+        </div>
+        <div class="rounded-md border border-border bg-elevated p-3 text-center">
+          <div class="text-[10px] uppercase tracking-wider text-muted-foreground">Module Skill</div>
+          <div class="text-sm font-semibold text-foreground mt-2">
+            {if @demo.module_manifest, do: "registered", else: "pending"}
+          </div>
+        </div>
+        <div class="rounded-md border border-border bg-elevated p-3 text-center">
+          <div class="text-[10px] uppercase tracking-wider text-muted-foreground">Allowed Tools</div>
+          <div class="text-sm font-semibold text-foreground mt-2">{length(@demo.allowed_tools)}</div>
+        </div>
+        <div class="rounded-md border border-border bg-elevated p-3 text-center">
+          <div class="text-[10px] uppercase tracking-wider text-muted-foreground">Prompt Ready</div>
+          <div class="text-sm font-semibold text-foreground mt-2">
+            {if @demo.prompt != "", do: "yes", else: "no"}
+          </div>
+        </div>
+      </div>
+
+      <div class="flex gap-3 flex-wrap">
+        <button
+          id="skills-load-file-btn"
+          phx-click="load_file_manifest"
+          class="px-4 py-2 rounded-md bg-primary/10 border border-primary/30 text-primary hover:bg-primary/20 transition-colors text-sm font-semibold"
+        >
+          Load File Manifest
+        </button>
+        <button
+          id="skills-register-module-btn"
+          phx-click="register_module_skill"
+          class="px-4 py-2 rounded-md bg-emerald-500/10 border border-emerald-500/30 text-emerald-300 hover:bg-emerald-500/20 transition-colors text-sm font-semibold"
+        >
+          Register Module Skill
+        </button>
+        <button
+          id="skills-load-registry-btn"
+          phx-click="load_runtime_skills"
+          class="px-4 py-2 rounded-md bg-accent-cyan/10 border border-accent-cyan/30 text-accent-cyan hover:bg-accent-cyan/20 transition-colors text-sm font-semibold"
+        >
+          Load Runtime Directory
+        </button>
+        <button
+          id="skills-render-prompt-btn"
+          phx-click="render_prompt"
+          class="px-4 py-2 rounded-md bg-amber-500/10 border border-amber-500/30 text-amber-300 hover:bg-amber-500/20 transition-colors text-sm font-semibold"
+        >
+          Render Prompt
+        </button>
+        <button
+          id="skills-reset-btn"
+          phx-click="reset_demo"
+          class="px-3 py-2 rounded-md bg-elevated border border-border text-muted-foreground hover:text-foreground hover:border-primary/40 transition-colors text-xs"
+        >
+          Reset
+        </button>
+      </div>
+
+      <div class="grid gap-4 xl:grid-cols-[1.1fr_0.9fr]">
+        <div class="space-y-4">
+          <div class="rounded-md border border-border bg-elevated p-4">
+            <div class="text-[10px] uppercase tracking-wider text-muted-foreground mb-2">File-Backed Manifest</div>
+
+            <div :if={is_nil(@demo.file_manifest)} class="text-xs text-muted-foreground">
+              No file manifest loaded yet.
+            </div>
+
+            <div :if={@demo.file_manifest} id="skills-file-manifest" class="space-y-2 text-[11px] text-foreground">
+              <div><span class="font-semibold">name:</span> {@demo.file_manifest.name}</div>
+              <div><span class="font-semibold">path:</span> {@demo.primary_skill_source_path}</div>
+              <div><span class="font-semibold">description:</span> {@demo.file_manifest.description}</div>
+              <div>
+                <span class="font-semibold">allowed tools:</span>
+                {Enum.join(@demo.file_manifest.allowed_tools, ", ")}
+              </div>
+            </div>
+          </div>
+
+          <div class="rounded-md border border-border bg-elevated p-4">
+            <div class="text-[10px] uppercase tracking-wider text-muted-foreground mb-2">Module Skill Manifest</div>
+
+            <div :if={is_nil(@demo.module_manifest)} class="text-xs text-muted-foreground">
+              No module skill registered yet.
+            </div>
+
+            <div :if={@demo.module_manifest} id="skills-module-manifest" class="space-y-2 text-[11px] text-foreground">
+              <div><span class="font-semibold">name:</span> {@demo.module_manifest.name}</div>
+              <div><span class="font-semibold">module:</span> {inspect(elem(@demo.module_manifest.source, 1))}</div>
+              <div><span class="font-semibold">description:</span> {@demo.module_manifest.description}</div>
+              <div>
+                <span class="font-semibold">allowed tools:</span>
+                {Enum.join(@demo.module_manifest.allowed_tools, ", ")}
+              </div>
+            </div>
+          </div>
+
+          <div class="rounded-md border border-border bg-elevated p-4">
+            <div class="flex items-center justify-between mb-2">
+              <div class="text-[10px] uppercase tracking-wider text-muted-foreground">Registry Contents</div>
+              <div id="skills-registry-count" class="text-[10px] text-muted-foreground">
+                {@registry_count} skill(s)
+              </div>
+            </div>
+
+            <div :if={@demo.registry_specs == []} class="text-xs text-muted-foreground">
+              Register the module skill or load the runtime directory to populate the registry.
+            </div>
+
+            <div :if={@demo.registry_specs != []} id="skills-registry-list" class="space-y-2">
+              <%= for spec <- @demo.registry_specs do %>
+                <div class="rounded-md border border-border bg-background/70 p-3">
+                  <div class="text-xs font-semibold text-foreground">{spec.name}</div>
+                  <div class="text-[11px] text-muted-foreground mt-1">{spec.description}</div>
+                  <div class="text-[11px] text-muted-foreground mt-2">
+                    source: {render_source(spec.source)}
+                  </div>
+                </div>
+              <% end %>
+            </div>
+          </div>
+        </div>
+
+        <div class="space-y-4">
+          <div class="rounded-md border border-border bg-elevated p-4">
+            <div class="text-[10px] uppercase tracking-wider text-muted-foreground mb-2">Allowed Tool Union</div>
+            <div id="skills-allowed-tools" class="text-[11px] text-foreground whitespace-pre-wrap">
+              {if @demo.allowed_tools == [], do: "No rendered prompt yet.", else: Enum.join(@demo.allowed_tools, ", ")}
+            </div>
+          </div>
+
+          <div class="rounded-md border border-border bg-elevated p-4">
+            <div class="text-[10px] uppercase tracking-wider text-muted-foreground mb-2">Rendered Prompt</div>
+            <pre id="skills-prompt-output" class="text-[11px] text-foreground whitespace-pre-wrap font-mono"><%= if @demo.prompt == "", do: "Render the prompt to inspect the combined skill instructions.", else: @demo.prompt %></pre>
+          </div>
+
+          <div class="rounded-md border border-border bg-elevated p-4">
+            <div class="flex items-center justify-between mb-2">
+              <div class="text-[10px] uppercase tracking-wider text-muted-foreground">Activity Log</div>
+              <div class="text-[10px] text-muted-foreground">{length(@demo.log)} event(s)</div>
+            </div>
+
+            <div :if={@demo.log == []} class="text-xs text-muted-foreground">
+              Use the controls above to inspect manifest loading, registry population, and prompt rendering.
+            </div>
+
+            <div :if={@demo.log != []} class="space-y-2 max-h-[28rem] overflow-y-auto">
+              <%= for entry <- @demo.log do %>
+                <div class="rounded-md border border-border bg-background/70 px-3 py-2">
+                  <div class="text-[11px] font-semibold text-foreground">{entry.label}</div>
+                  <div class="text-[11px] text-muted-foreground">{entry.detail}</div>
+                </div>
+              <% end %>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  @impl true
+  def handle_event("load_file_manifest", _params, socket) do
+    {:noreply, assign_demo(socket, RuntimeDemo.load_file_manifest(socket.assigns.demo))}
+  end
+
+  def handle_event("register_module_skill", _params, socket) do
+    {:noreply, assign_demo(socket, RuntimeDemo.register_module_skill(socket.assigns.demo))}
+  end
+
+  def handle_event("load_runtime_skills", _params, socket) do
+    {:noreply, assign_demo(socket, RuntimeDemo.load_runtime_skills(socket.assigns.demo))}
+  end
+
+  def handle_event("render_prompt", _params, socket) do
+    {:noreply, assign_demo(socket, RuntimeDemo.render_prompt(socket.assigns.demo))}
+  end
+
+  def handle_event("reset_demo", _params, socket) do
+    {:noreply, assign_demo(socket, RuntimeDemo.reset(socket.assigns.demo))}
+  end
+
+  defp assign_demo(socket, demo) do
+    assign(socket,
+      demo: demo,
+      registry_count: length(demo.registry_specs)
+    )
+  end
+
+  defp render_source({:module, module}), do: inspect(module)
+
+  defp render_source({:file, path}) do
+    Path.relative_to(path, File.cwd!())
+  end
+end

--- a/priv/examples/jido-ai-skills-runtime-foundations.md
+++ b/priv/examples/jido-ai-skills-runtime-foundations.md
@@ -1,7 +1,7 @@
 %{
   title: "Jido.AI Skills Runtime Foundations",
-  description: "Skill manifest, loader, registry, and prompt rendering fundamentals in one deterministic walkthrough.",
-  tags: ["primary", "showcase", "simulated", "ai", "l2", "ai-tool-use", "skills", "jido_ai"],
+  description: "Real skill manifest loading, registry setup, and prompt rendering with checked-in `SKILL.md` fixtures.",
+  tags: ["primary", "showcase", "ai", "l2", "ai-tool-use", "skills", "runtime", "jido_ai"],
   category: :ai,
   emoji: "📚",
   related_resources: [
@@ -17,31 +17,57 @@
       href: "https://github.com/agentjido/jido_ai/blob/main/lib/examples/scripts/demo/skills_runtime_foundations_demo.exs",
       kind: "Source",
       description: "Manifest, registry, and prompt rendering checks."
+    },
+    %{
+      type: :external,
+      label: "skills system guide",
+      href: "https://github.com/agentjido/jido_ai/blob/main/guides/developer/skills_system.md",
+      kind: "Guide",
+      description: "Loader, registry, and prompt APIs for file-backed and module-backed skills."
     }
   ],
   source_files: [
-    "lib/agent_jido_web/examples/simulated_showcase_live.ex"
+    "lib/agent_jido/demos/skills_runtime_foundations/calculator_skill.ex",
+    "lib/agent_jido/demos/skills_runtime_foundations/runtime_demo.ex",
+    "lib/agent_jido_web/examples/skills_runtime_foundations_live.ex",
+    "priv/skills/skills-runtime-foundations/demo-code-review/SKILL.md",
+    "priv/skills/skills-runtime-foundations/demo-release-notes/SKILL.md"
   ],
-  live_view_module: "AgentJidoWeb.Examples.SimulatedShowcaseLive",
+  live_view_module: "AgentJidoWeb.Examples.SkillsRuntimeFoundationsLive",
   difficulty: :intermediate,
   status: :live,
   scenario_cluster: :ai_tool_use,
   wave: :l2,
   journey_stage: :evaluation,
-  content_intent: :tutorial,
+  content_intent: :reference,
   capability_theme: :ai_intelligence,
   evidence_surface: :runnable_example,
-  demo_mode: :simulated,
+  demo_mode: :real,
   sort_order: 23
 }
 ---
 
 ## What you'll learn
 
-- How module and file-backed skills are loaded into one runtime registry
-- How manifests and prompt rendering compose into practical agent instructions
-- How to communicate skills flow with deterministic, testable output
+- How `Jido.AI.Skill.Loader.load/1` parses checked-in `SKILL.md` files into runtime manifests
+- How `Jido.AI.Skill.Registry.load_from_paths/1` and `Jido.AI.Skill.Registry.register/1` populate one deterministic registry
+- How `Jido.AI.Skill.Prompt.render/2` turns those registered skills into reusable prompt instructions
 
-## Demo note
+## How this demo stays truthful
 
-This walkthrough replays fixed registry/prompt outputs from fixtures to keep behavior stable.
+This page runs **real skills runtime code**.
+
+- One skill is defined as an Elixir module with `use Jido.AI.Skill`.
+- Two skills are loaded from checked-in `priv/skills/.../SKILL.md` files.
+- The demo registers only those three demo skills, renders the combined prompt, and never calls external services.
+
+No API keys, LLM providers, or network access are required for this example.
+
+## Pull the pattern into your own app
+
+Keep the same runtime steps in your own project:
+
+- define stable module-backed skills for core workflows
+- add file-backed `SKILL.md` assets when you want editable runtime instructions
+- register those skills into the runtime registry
+- render the combined prompt text once your agent or workflow needs it

--- a/priv/skills/skills-runtime-foundations/demo-code-review/SKILL.md
+++ b/priv/skills/skills-runtime-foundations/demo-code-review/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: demo-code-review
+description: Reviews changed files for correctness, safety, and test gaps in the skills runtime demo.
+license: Apache-2.0
+compatibility: Jido.AI >= 2.0
+allowed-tools: read_file grep git_diff
+metadata:
+  author: agent-jido-demo
+  version: "1.0.0"
+tags:
+  - demo
+  - code-review
+  - runtime
+---
+
+# Demo Code Review
+
+Use this skill when you want a deterministic review checklist for changed files.
+
+## Workflow
+
+1. Read the modified files.
+2. Compare the code against the requested behavior.
+3. Flag correctness issues, missing tests, and risky assumptions.
+4. Summarize the highest-priority findings first.
+
+## Response Format
+
+1. One-sentence summary of the change
+2. Findings ordered by severity
+3. Remaining test or rollout risks

--- a/priv/skills/skills-runtime-foundations/demo-release-notes/SKILL.md
+++ b/priv/skills/skills-runtime-foundations/demo-release-notes/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: demo-release-notes
+description: Drafts concise release notes from a list of validated changes in the skills runtime demo.
+license: Apache-2.0
+allowed-tools: read_file summarize_changes format_release_notes
+metadata:
+  author: agent-jido-demo
+  version: "1.0.0"
+tags:
+  - demo
+  - release
+  - docs
+---
+
+# Demo Release Notes
+
+Use this skill when you need a short changelog from already-verified work items.
+
+## Workflow
+
+1. Gather the validated changes or merged pull requests.
+2. Group the updates by user-facing theme.
+3. Write concise bullets with scope, impact, and follow-up if needed.
+4. Keep the final output easy to scan.
+
+## Response Format
+
+- Features
+- Fixes
+- Follow-up or operational notes

--- a/test/agent_jido/demos/skills_runtime_foundations_runtime_demo_test.exs
+++ b/test/agent_jido/demos/skills_runtime_foundations_runtime_demo_test.exs
@@ -1,0 +1,64 @@
+defmodule AgentJido.Demos.SkillsRuntimeFoundationsRuntimeDemoTest do
+  use ExUnit.Case, async: false
+
+  alias AgentJido.Demos.SkillsRuntimeFoundations.RuntimeDemo
+  alias Jido.AI.Skill
+
+  setup do
+    demo = RuntimeDemo.new()
+
+    on_exit(fn ->
+      RuntimeDemo.reset(demo)
+    end)
+
+    %{demo: demo}
+  end
+
+  test "loads the checked-in file-backed manifest without mutating the registry", %{demo: demo} do
+    demo = RuntimeDemo.load_file_manifest(demo)
+
+    assert demo.file_manifest.name == "demo-code-review"
+    assert demo.file_manifest.description =~ "skills runtime demo"
+    assert demo.file_manifest.allowed_tools == ["read_file", "grep", "git_diff"]
+    assert demo.registry_specs == []
+  end
+
+  test "registers the module-backed skill into the runtime registry", %{demo: demo} do
+    demo = RuntimeDemo.register_module_skill(demo)
+
+    assert demo.module_manifest.name == "demo-runtime-calculator"
+    assert Enum.map(demo.registry_specs, & &1.name) == ["demo-runtime-calculator"]
+    assert {:ok, spec} = Skill.resolve("demo-runtime-calculator")
+    assert spec.description =~ "arithmetic"
+  end
+
+  test "loads the file-backed skill directory into the runtime registry", %{demo: demo} do
+    demo =
+      demo
+      |> RuntimeDemo.register_module_skill()
+      |> RuntimeDemo.load_runtime_skills()
+
+    assert demo.loaded_count == 2
+
+    assert Enum.map(demo.registry_specs, & &1.name) == [
+             "demo-runtime-calculator",
+             "demo-code-review",
+             "demo-release-notes"
+           ]
+  end
+
+  test "renders a combined prompt and tool union from the registered demo skills", %{demo: demo} do
+    demo =
+      demo
+      |> RuntimeDemo.register_module_skill()
+      |> RuntimeDemo.load_runtime_skills()
+      |> RuntimeDemo.render_prompt()
+
+    assert demo.prompt =~ "You have access to the following skills:"
+    assert demo.prompt =~ "demo-runtime-calculator"
+    assert demo.prompt =~ "demo-code-review"
+    assert demo.prompt =~ "demo-release-notes"
+    assert "add" in demo.allowed_tools
+    assert "format_release_notes" in demo.allowed_tools
+  end
+end

--- a/test/agent_jido/examples_test.exs
+++ b/test/agent_jido/examples_test.exs
@@ -21,7 +21,7 @@ defmodule AgentJido.ExamplesTest do
     {"jido-ai-browser-web-workflow", "AgentJidoWeb.Examples.BrowserDocsScoutAgentLive"},
     {"jido-ai-weather-multi-turn-context", "AgentJidoWeb.Examples.SimulatedShowcaseLive"},
     {"jido-ai-task-execution-workflow", "AgentJidoWeb.Examples.TaskExecutionWorkflowLive"},
-    {"jido-ai-skills-runtime-foundations", "AgentJidoWeb.Examples.SimulatedShowcaseLive"},
+    {"jido-ai-skills-runtime-foundations", "AgentJidoWeb.Examples.SkillsRuntimeFoundationsLive"},
     {"jido-ai-skills-multi-agent-orchestration", "AgentJidoWeb.Examples.SimulatedShowcaseLive"},
     {"jido-ai-weather-reasoning-strategy-suite", "AgentJidoWeb.Examples.SimulatedShowcaseLive"},
     {"jido-ai-operational-agents-pack", "AgentJidoWeb.Examples.SimulatedShowcaseLive"}

--- a/test/agent_jido_web/live/jido_example_live_test.exs
+++ b/test/agent_jido_web/live/jido_example_live_test.exs
@@ -13,7 +13,6 @@ defmodule AgentJidoWeb.JidoExampleLiveTest do
     {"runic-structured-llm-branching", "Runic Structured LLM Branching"},
     {"runic-delegating-orchestrator", "Runic Delegating Orchestrator"},
     {"jido-ai-weather-multi-turn-context", "Jido.AI Weather Multi-Turn Context"},
-    {"jido-ai-skills-runtime-foundations", "Jido.AI Skills Runtime Foundations"},
     {"jido-ai-skills-multi-agent-orchestration", "Jido.AI Skills Multi-Agent Orchestration"},
     {"jido-ai-weather-reasoning-strategy-suite", "Jido.AI Weather Reasoning Strategy Suite"},
     {"jido-ai-operational-agents-pack", "Jido.AI Operational Agents Pack"}
@@ -420,6 +419,89 @@ defmodule AgentJidoWeb.JidoExampleLiveTest do
       assert example.source_files == [
                "lib/agent_jido/demos/task_execution/workflow.ex",
                "lib/agent_jido_web/examples/task_execution_workflow_live.ex"
+             ]
+
+      assert Enum.map(example.sources, & &1.path) == example.source_files
+    end
+  end
+
+  describe "/examples/jido-ai-skills-runtime-foundations" do
+    test "renders explanation tab with real skills runtime guidance", %{conn: conn} do
+      {:ok, _view, html} = live(conn, "/examples/jido-ai-skills-runtime-foundations?tab=explanation")
+
+      assert html =~ "Jido.AI Skills Runtime Foundations"
+      assert html =~ "Jido.AI.Skill.Loader.load/1"
+      assert html =~ "Jido.AI.Skill.Registry.load_from_paths/1"
+      assert html =~ "Jido.AI.Skill.Prompt.render/2"
+      assert html =~ "No API keys, LLM providers, or network access are required for this example."
+    end
+
+    test "renders source tab for the dedicated skills runtime example", %{conn: conn} do
+      {:ok, _view, html} = live(conn, "/examples/jido-ai-skills-runtime-foundations?tab=source")
+
+      assert html =~ "calculator_skill.ex"
+      assert html =~ "runtime_demo.ex"
+      assert html =~ "skills_runtime_foundations_live.ex"
+      assert html =~ "SKILL.md"
+      refute html =~ "simulated_showcase_live.ex"
+    end
+
+    test "demo tab runs the deterministic skills runtime flow", %{conn: conn} do
+      {:ok, view, html} = live(conn, "/examples/jido-ai-skills-runtime-foundations?tab=demo")
+
+      assert html =~ "Jido.AI Skills Runtime Foundations"
+      refute html =~ "Simulated demo"
+
+      demo_view = find_live_child(view, "demo-jido-ai-skills-runtime-foundations")
+
+      html =
+        demo_view
+        |> element("#skills-runtime-foundations-demo button[phx-click='load_file_manifest']")
+        |> render_click()
+
+      assert html =~ "demo-code-review"
+      assert html =~ "git_diff"
+
+      html =
+        demo_view
+        |> element("#skills-runtime-foundations-demo button[phx-click='register_module_skill']")
+        |> render_click()
+
+      assert html =~ "demo-runtime-calculator"
+      assert html =~ "Registered demo-runtime-calculator"
+
+      html =
+        demo_view
+        |> element("#skills-runtime-foundations-demo button[phx-click='load_runtime_skills']")
+        |> render_click()
+
+      assert html =~ "Loaded 2 SKILL.md file(s)"
+      assert html =~ "demo-release-notes"
+      assert html =~ "3 skill(s)"
+
+      html =
+        demo_view
+        |> element("#skills-runtime-foundations-demo button[phx-click='render_prompt']")
+        |> render_click()
+
+      assert html =~ "You have access to the following skills:"
+      assert html =~ "demo-runtime-calculator"
+      assert html =~ "demo-code-review"
+      assert html =~ "format_release_notes"
+    end
+
+    test "example registry metadata resolves new skills runtime source files", %{conn: _conn} do
+      example = Examples.get_example!("jido-ai-skills-runtime-foundations")
+
+      assert example.title == "Jido.AI Skills Runtime Foundations"
+      assert example.live_view_module == "AgentJidoWeb.Examples.SkillsRuntimeFoundationsLive"
+
+      assert example.source_files == [
+               "lib/agent_jido/demos/skills_runtime_foundations/calculator_skill.ex",
+               "lib/agent_jido/demos/skills_runtime_foundations/runtime_demo.ex",
+               "lib/agent_jido_web/examples/skills_runtime_foundations_live.ex",
+               "priv/skills/skills-runtime-foundations/demo-code-review/SKILL.md",
+               "priv/skills/skills-runtime-foundations/demo-release-notes/SKILL.md"
              ]
 
       assert Enum.map(example.sources, & &1.path) == example.source_files


### PR DESCRIPTION
## Summary
- replace the simulated skills runtime foundations example with a dedicated runtime demo
- add checked-in `SKILL.md` fixtures plus a module-backed skill for manifest, registry, and prompt rendering coverage
- add unit and LiveView regression tests for the real example surface

## Testing
- ASDF_ELIXIR_VERSION=1.18.4-otp-27 ASDF_ERLANG_VERSION=27.3 mix test test/agent_jido/demos/skills_runtime_foundations_runtime_demo_test.exs test/agent_jido/examples_test.exs test/agent_jido_web/live/jido_example_live_test.exs
- ASDF_ELIXIR_VERSION=1.18.4-otp-27 ASDF_ERLANG_VERSION=27.3 mix test

## Notes
- This PR is stacked on #77 and should be retargeted to `main` after #77 merges.

Closes #61
