### PR TITLE
Replace simulated skills multi-agent orchestration demo

### DIFF
--- a/lib/agent_jido/demos/skills_multi_agent_orchestration/arithmetic_skill.ex
+++ b/lib/agent_jido/demos/skills_multi_agent_orchestration/arithmetic_skill.ex
@@ -1,0 +1,39 @@
+defmodule AgentJido.Demos.SkillsMultiAgentOrchestration.ArithmeticSkill do
+  @moduledoc """
+  Module-backed arithmetic specialist for the multi-skill orchestration demo.
+  """
+
+  use Jido.AI.Skill,
+    name: "demo-orchestrator-arithmetic",
+    description: "Handles arithmetic-only requests in the deterministic orchestration demo.",
+    license: "Apache-2.0",
+    allowed_tools: ~w(multiply add),
+    tags: ["demo", "skills", "math", "orchestration"],
+    body: """
+    # Demo Arithmetic Specialist
+
+    Use arithmetic tools to break a compound math expression into ordered steps.
+
+    ## Workflow
+    1. Multiply first.
+    2. Add the final offset.
+    3. Return the final result with the intermediate values.
+    """
+
+  @doc "Executes the fixed arithmetic request used by the public orchestration demo."
+  @spec run_demo_request() :: map()
+  def run_demo_request do
+    multiplied = 42 * 17
+    total = multiplied + 100
+
+    %{
+      skill_name: manifest().name,
+      tool_trace: [
+        %{tool: "multiply", input: "42 * 17", output: Integer.to_string(multiplied)},
+        %{tool: "add", input: "#{multiplied} + 100", output: Integer.to_string(total)}
+      ],
+      response: "Arithmetic specialist computed 42 * 17 + 100 = #{total}.",
+      value: total
+    }
+  end
+end

--- a/lib/agent_jido/demos/skills_multi_agent_orchestration/conversion_specialist.ex
+++ b/lib/agent_jido/demos/skills_multi_agent_orchestration/conversion_specialist.ex
@@ -1,0 +1,49 @@
+defmodule AgentJido.Demos.SkillsMultiAgentOrchestration.ConversionSpecialist do
+  @moduledoc """
+  Deterministic conversion helpers used by the file-backed unit conversion skill.
+  """
+
+  @doc "Converts the demo temperature request from Fahrenheit to Celsius."
+  @spec convert_demo_temperature() :: map()
+  def convert_demo_temperature do
+    fahrenheit = 98.6
+    celsius = Float.round((fahrenheit - 32.0) * 5.0 / 9.0, 1)
+
+    %{
+      skill_name: "demo-unit-converter",
+      tool_trace: [
+        %{
+          tool: "convert_temperature",
+          input: "98.6 Fahrenheit -> Celsius",
+          output: "#{format_float(celsius, 1)} Celsius"
+        }
+      ],
+      response: "Conversion specialist converted 98.6°F to #{format_float(celsius, 1)}°C.",
+      celsius: celsius
+    }
+  end
+
+  @doc "Converts the demo distance request from kilometers to miles."
+  @spec convert_demo_distance() :: map()
+  def convert_demo_distance do
+    kilometers = 5.0
+    miles = Float.round(kilometers * 0.621_371, 2)
+
+    %{
+      skill_name: "demo-unit-converter",
+      tool_trace: [
+        %{
+          tool: "convert_distance",
+          input: "5.0 kilometers -> miles",
+          output: "#{format_float(miles, 2)} miles"
+        }
+      ],
+      response: "Conversion specialist converted 5.0 kilometers to #{format_float(miles, 2)} miles.",
+      miles: miles
+    }
+  end
+
+  defp format_float(value, decimals) do
+    :erlang.float_to_binary(value, decimals: decimals)
+  end
+end

--- a/lib/agent_jido/demos/skills_multi_agent_orchestration/endurance_planner_skill.ex
+++ b/lib/agent_jido/demos/skills_multi_agent_orchestration/endurance_planner_skill.ex
@@ -1,0 +1,46 @@
+defmodule AgentJido.Demos.SkillsMultiAgentOrchestration.EndurancePlannerSkill do
+  @moduledoc """
+  Module-backed endurance specialist for the multi-skill orchestration demo.
+  """
+
+  use Jido.AI.Skill,
+    name: "demo-endurance-planner",
+    description: "Estimates calories and follow-up guidance after a distance conversion in the orchestration demo.",
+    license: "Apache-2.0",
+    allowed_tools: ~w(estimate_calories summarize_effort),
+    tags: ["demo", "skills", "fitness", "orchestration"],
+    body: """
+    # Demo Endurance Planner
+
+    Use converted mileage to estimate energy burn for a simple running scenario.
+
+    ## Workflow
+    1. Accept the converted distance in miles.
+    2. Multiply by the calories-per-mile assumption.
+    3. Return a concise planning note with the calorie estimate.
+    """
+
+  @doc "Estimates calories for the demo combined orchestration request."
+  @spec estimate_demo_run(float(), pos_integer()) :: map()
+  def estimate_demo_run(miles, calories_per_mile) when is_float(miles) and is_integer(calories_per_mile) do
+    calories = round(miles * calories_per_mile)
+
+    %{
+      skill_name: manifest().name,
+      tool_trace: [
+        %{
+          tool: "estimate_calories",
+          input: "#{format_float(miles, 2)} miles at #{calories_per_mile} calories/mile",
+          output: "#{calories} calories"
+        }
+      ],
+      response:
+        "Endurance planner estimated about #{calories} calories for #{format_float(miles, 2)} miles at #{calories_per_mile} calories per mile.",
+      calories: calories
+    }
+  end
+
+  defp format_float(value, decimals) do
+    :erlang.float_to_binary(value, decimals: decimals)
+  end
+end

--- a/lib/agent_jido/demos/skills_multi_agent_orchestration/orchestrator.ex
+++ b/lib/agent_jido/demos/skills_multi_agent_orchestration/orchestrator.ex
@@ -1,0 +1,203 @@
+defmodule AgentJido.Demos.SkillsMultiAgentOrchestration.Orchestrator do
+  @moduledoc """
+  Deterministic orchestration walkthrough backed by module and file-loaded skills.
+  """
+
+  alias AgentJido.Demos.SkillsMultiAgentOrchestration.{
+    ArithmeticSkill,
+    ConversionSpecialist,
+    EndurancePlannerSkill
+  }
+
+  alias Jido.AI.Skill
+  alias Jido.AI.Skill.{Prompt, Registry, Spec}
+
+  @project_root Path.expand("../../../..", __DIR__)
+  @skills_root_source_path "priv/skills/skills-multi-agent-orchestration"
+  @unit_converter_source_path Path.join(@skills_root_source_path, "demo-unit-converter/SKILL.md")
+  @demo_skill_names ["demo-orchestrator-arithmetic", "demo-unit-converter", "demo-endurance-planner"]
+
+  @scenario_requests %{
+    arithmetic: %{
+      label: "Arithmetic",
+      question: "What is 42 * 17 + 100?"
+    },
+    conversion: %{
+      label: "Conversion",
+      question: "Convert 98.6 degrees Fahrenheit to Celsius."
+    },
+    combined: %{
+      label: "Combined",
+      question: "If I run 5 kilometers, how many miles is that? Then estimate calories at 100 calories per mile."
+    }
+  }
+
+  defstruct registry_specs: [],
+            loaded_count: 0,
+            last_run: nil,
+            history: [],
+            skills_root_source_path: @skills_root_source_path,
+            unit_converter_source_path: @unit_converter_source_path
+
+  @type log_entry :: %{
+          required(:label) => String.t(),
+          required(:detail) => String.t()
+        }
+
+  @type run_result :: %{
+          required(:scenario) => atom(),
+          required(:label) => String.t(),
+          required(:question) => String.t(),
+          required(:route) => String.t(),
+          required(:selected_skills) => [Spec.t()],
+          required(:selected_skill_names) => [String.t()],
+          required(:tool_trace) => [map()],
+          required(:response) => String.t(),
+          required(:prompt) => String.t()
+        }
+
+  @type t :: %__MODULE__{
+          registry_specs: [Spec.t()],
+          loaded_count: non_neg_integer(),
+          last_run: run_result() | nil,
+          history: [log_entry()],
+          skills_root_source_path: String.t(),
+          unit_converter_source_path: String.t()
+        }
+
+  @doc "Builds a new orchestrator state with the demo specialist skills preloaded."
+  @spec new() :: t()
+  def new do
+    cleanup_demo_skills()
+
+    %__MODULE__{}
+    |> bootstrap_demo_skills()
+    |> append_history("Bootstrap", "Registered 2 module skills and loaded 1 file-backed conversion skill.")
+    |> refresh()
+  end
+
+  @doc "Runs one of the fixed public demo scenarios through the deterministic router."
+  @spec run_scenario(t(), :arithmetic | :conversion | :combined) :: t()
+  def run_scenario(%__MODULE__{} = demo, scenario) when scenario in [:arithmetic, :conversion, :combined] do
+    demo = ensure_bootstrapped(demo)
+    request = Map.fetch!(@scenario_requests, scenario)
+
+    {selected_skill_names, route, tool_trace, response} =
+      case scenario do
+        :arithmetic ->
+          arithmetic = ArithmeticSkill.run_demo_request()
+
+          {
+            [arithmetic.skill_name],
+            "Router matched an arithmetic-only request and delegated it to the arithmetic specialist.",
+            arithmetic.tool_trace,
+            arithmetic.response
+          }
+
+        :conversion ->
+          conversion = ConversionSpecialist.convert_demo_temperature()
+
+          {
+            [conversion.skill_name],
+            "Router matched a unit conversion request and delegated it to the file-backed unit converter skill.",
+            conversion.tool_trace,
+            conversion.response
+          }
+
+        :combined ->
+          conversion = ConversionSpecialist.convert_demo_distance()
+          endurance = EndurancePlannerSkill.estimate_demo_run(conversion.miles, 100)
+          miles = :erlang.float_to_binary(conversion.miles, decimals: 2)
+
+          {
+            [conversion.skill_name, endurance.skill_name],
+            "Router detected a compound request and composed the unit converter with the endurance planner specialist.",
+            conversion.tool_trace ++ endurance.tool_trace,
+            "Combined route converted 5.0 kilometers to #{miles} miles and estimated about #{endurance.calories} calories at 100 calories per mile."
+          }
+      end
+
+    selected_specs = Enum.map(selected_skill_names, &Skill.manifest/1)
+
+    last_run = %{
+      scenario: scenario,
+      label: request.label,
+      question: request.question,
+      route: route,
+      selected_skills: selected_specs,
+      selected_skill_names: selected_skill_names,
+      tool_trace: tool_trace,
+      response: response,
+      prompt:
+        Prompt.render(selected_specs,
+          include_body: false,
+          header: "Selected skills for this request:"
+        )
+    }
+
+    demo
+    |> Map.put(:last_run, last_run)
+    |> append_history(request.label, response)
+    |> refresh()
+  end
+
+  @doc "Restores the initial bootstrapped orchestrator state."
+  @spec reset(t()) :: t()
+  def reset(%__MODULE__{}) do
+    cleanup_demo_skills()
+
+    %__MODULE__{}
+    |> bootstrap_demo_skills()
+    |> append_history("Reset", "Reset the orchestrator and reloaded the demo specialist skills.")
+    |> refresh()
+  end
+
+  defp ensure_bootstrapped(%__MODULE__{registry_specs: []} = demo), do: bootstrap_demo_skills(demo)
+  defp ensure_bootstrapped(%__MODULE__{} = demo), do: demo
+
+  defp bootstrap_demo_skills(%__MODULE__{} = demo) do
+    :ok = Registry.ensure_started()
+    :ok = Registry.register(Skill.manifest(ArithmeticSkill))
+    :ok = Registry.register(Skill.manifest(EndurancePlannerSkill))
+    {:ok, count} = Registry.load_from_paths([unit_converter_root_path()])
+
+    demo
+    |> Map.put(:loaded_count, count)
+    |> refresh()
+  end
+
+  defp refresh(%__MODULE__{} = demo) do
+    registry_specs =
+      @demo_skill_names
+      |> Enum.flat_map(fn name ->
+        case Registry.lookup(name) do
+          {:ok, spec} -> [spec]
+          {:error, _reason} -> []
+        end
+      end)
+
+    %{demo | registry_specs: registry_specs}
+  end
+
+  defp cleanup_demo_skills do
+    :ok = Registry.ensure_started()
+
+    Enum.each(@demo_skill_names, fn name ->
+      try do
+        case Registry.unregister(name) do
+          :ok -> :ok
+          {:error, _reason} -> :ok
+        end
+      catch
+        :exit, _reason -> :ok
+      end
+    end)
+  end
+
+  defp unit_converter_root_path, do: Path.join(@project_root, @skills_root_source_path)
+
+  defp append_history(%__MODULE__{} = demo, label, detail) do
+    entry = %{label: label, detail: detail}
+    %{demo | history: [entry | demo.history] |> Enum.take(30)}
+  end
+end

--- a/lib/agent_jido_web/examples/simulated_showcase_live.ex
+++ b/lib/agent_jido_web/examples/simulated_showcase_live.ex
@@ -376,25 +376,6 @@ defmodule AgentJidoWeb.Examples.SimulatedShowcaseLive do
     }
   end
 
-  defp scenario_for("jido-ai-skills-multi-agent-orchestration") do
-    %{
-      title: "Jido.AI Skills Multi-Agent Orchestration",
-      steps: [
-        %{label: "Arithmetic request", detail: "Resolved expression using calculator skill pathway"},
-        %{label: "Conversion request", detail: "Routed to unit conversion skill and tools"},
-        %{label: "Combined request", detail: "Composed conversion + derived calorie estimate response"},
-        %{label: "Semantic checks", detail: "Validated key outputs (814, 37C, ~3.1 miles)"}
-      ],
-      result: """
-      {
-        "model": "simulated:haiku",
-        "question_classes": 3,
-        "skills_selected_correctly": true
-      }
-      """
-    }
-  end
-
   defp scenario_for("jido-ai-weather-reasoning-strategy-suite") do
     %{
       title: "Jido.AI Weather Reasoning Strategy Suite",

--- a/lib/agent_jido_web/examples/skills_multi_agent_orchestration_live.ex
+++ b/lib/agent_jido_web/examples/skills_multi_agent_orchestration_live.ex
@@ -1,0 +1,204 @@
+defmodule AgentJidoWeb.Examples.SkillsMultiAgentOrchestrationLive do
+  @moduledoc """
+  Interactive multi-skill orchestration demo backed by deterministic local specialists.
+  """
+
+  use AgentJidoWeb, :live_view
+
+  alias AgentJido.Demos.SkillsMultiAgentOrchestration.Orchestrator
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {:ok, assign_demo(socket, Orchestrator.new())}
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div id="skills-multi-agent-orchestration-demo" class="rounded-lg border border-border bg-card p-6 space-y-6">
+      <div class="flex items-center justify-between gap-4">
+        <div>
+          <div class="text-sm font-semibold text-foreground">Jido.AI Skills Multi-Agent Orchestration</div>
+          <div class="text-[11px] text-muted-foreground">
+            Real deterministic routing across module-backed and file-backed specialist skills
+          </div>
+        </div>
+        <div class="text-[10px] font-mono text-muted-foreground bg-elevated px-2 py-1 rounded border border-border">
+          registry: {@registry_count} skill(s)
+        </div>
+      </div>
+
+      <div class="grid gap-3 sm:grid-cols-4">
+        <div class="rounded-md border border-border bg-elevated p-3 text-center">
+          <div class="text-[10px] uppercase tracking-wider text-muted-foreground">File Skills</div>
+          <div class="text-sm font-semibold text-foreground mt-2">{@demo.loaded_count}</div>
+        </div>
+        <div class="rounded-md border border-border bg-elevated p-3 text-center">
+          <div class="text-[10px] uppercase tracking-wider text-muted-foreground">Module Skills</div>
+          <div class="text-sm font-semibold text-foreground mt-2">{@registry_count - @demo.loaded_count}</div>
+        </div>
+        <div class="rounded-md border border-border bg-elevated p-3 text-center">
+          <div class="text-[10px] uppercase tracking-wider text-muted-foreground">Last Route</div>
+          <div id="skills-orchestration-last-route" class="text-sm font-semibold text-foreground mt-2">
+            {if @demo.last_run, do: @demo.last_run.label, else: "idle"}
+          </div>
+        </div>
+        <div class="rounded-md border border-border bg-elevated p-3 text-center">
+          <div class="text-[10px] uppercase tracking-wider text-muted-foreground">Prompt Ready</div>
+          <div class="text-sm font-semibold text-foreground mt-2">
+            {if @demo.last_run && @demo.last_run.prompt != "", do: "yes", else: "no"}
+          </div>
+        </div>
+      </div>
+
+      <div class="flex gap-3 flex-wrap">
+        <button
+          id="skills-run-arithmetic-btn"
+          phx-click="run_arithmetic"
+          class="px-4 py-2 rounded-md bg-primary/10 border border-primary/30 text-primary hover:bg-primary/20 transition-colors text-sm font-semibold"
+        >
+          Run Arithmetic
+        </button>
+        <button
+          id="skills-run-conversion-btn"
+          phx-click="run_conversion"
+          class="px-4 py-2 rounded-md bg-emerald-500/10 border border-emerald-500/30 text-emerald-300 hover:bg-emerald-500/20 transition-colors text-sm font-semibold"
+        >
+          Run Conversion
+        </button>
+        <button
+          id="skills-run-combined-btn"
+          phx-click="run_combined"
+          class="px-4 py-2 rounded-md bg-accent-cyan/10 border border-accent-cyan/30 text-accent-cyan hover:bg-accent-cyan/20 transition-colors text-sm font-semibold"
+        >
+          Run Combined Request
+        </button>
+        <button
+          id="skills-orchestration-reset-btn"
+          phx-click="reset_demo"
+          class="px-3 py-2 rounded-md bg-elevated border border-border text-muted-foreground hover:text-foreground hover:border-primary/40 transition-colors text-xs"
+        >
+          Reset
+        </button>
+      </div>
+
+      <div class="grid gap-4 xl:grid-cols-[1.05fr_0.95fr]">
+        <div class="space-y-4">
+          <div class="rounded-md border border-border bg-elevated p-4">
+            <div class="flex items-center justify-between mb-2">
+              <div class="text-[10px] uppercase tracking-wider text-muted-foreground">Specialist Registry</div>
+              <div class="text-[10px] text-muted-foreground">{@registry_count} skill(s)</div>
+            </div>
+
+            <div id="skills-orchestration-registry" class="space-y-2">
+              <%= for spec <- @demo.registry_specs do %>
+                <div class="rounded-md border border-border bg-background/70 p-3">
+                  <div class="text-xs font-semibold text-foreground">{spec.name}</div>
+                  <div class="text-[11px] text-muted-foreground mt-1">{spec.description}</div>
+                  <div class="text-[11px] text-muted-foreground mt-2">
+                    tools: {Enum.join(spec.allowed_tools, ", ")}
+                  </div>
+                </div>
+              <% end %>
+            </div>
+          </div>
+
+          <div class="rounded-md border border-border bg-elevated p-4">
+            <div class="text-[10px] uppercase tracking-wider text-muted-foreground mb-2">Route Decision</div>
+
+            <div :if={is_nil(@demo.last_run)} class="text-xs text-muted-foreground">
+              Run one of the fixed requests to inspect the router decision and selected specialists.
+            </div>
+
+            <div :if={@demo.last_run} id="skills-route-decision" class="space-y-3">
+              <div class="text-[11px] text-foreground">
+                <span class="font-semibold">question:</span> {@demo.last_run.question}
+              </div>
+              <div class="text-[11px] text-muted-foreground">{@demo.last_run.route}</div>
+              <div class="flex gap-2 flex-wrap">
+                <%= for spec <- @demo.last_run.selected_skills do %>
+                  <span class="text-[10px] px-2 py-1 rounded bg-primary/10 border border-primary/30 text-primary">
+                    {spec.name}
+                  </span>
+                <% end %>
+              </div>
+            </div>
+          </div>
+
+          <div class="rounded-md border border-border bg-elevated p-4">
+            <div class="text-[10px] uppercase tracking-wider text-muted-foreground mb-2">Selected Prompt</div>
+            <pre id="skills-selected-prompt" class="text-[11px] text-foreground whitespace-pre-wrap font-mono"><%= if @demo.last_run, do: @demo.last_run.prompt, else: "Prompt output appears after a routed request." %></pre>
+          </div>
+        </div>
+
+        <div class="space-y-4">
+          <div class="rounded-md border border-border bg-elevated p-4">
+            <div class="text-[10px] uppercase tracking-wider text-muted-foreground mb-2">Tool Trace</div>
+
+            <div :if={is_nil(@demo.last_run)} class="text-xs text-muted-foreground">
+              No orchestration steps have executed yet.
+            </div>
+
+            <div :if={@demo.last_run} id="skills-tool-trace" class="space-y-2">
+              <%= for step <- @demo.last_run.tool_trace do %>
+                <div class="rounded-md border border-border bg-background/70 p-3">
+                  <div class="text-[11px] font-semibold text-foreground">{step.tool}</div>
+                  <div class="text-[11px] text-muted-foreground mt-1">input: {step.input}</div>
+                  <div class="text-[11px] text-foreground mt-1">output: {step.output}</div>
+                </div>
+              <% end %>
+            </div>
+          </div>
+
+          <div class="rounded-md border border-border bg-elevated p-4">
+            <div class="text-[10px] uppercase tracking-wider text-muted-foreground mb-2">Response</div>
+            <div id="skills-orchestration-response" class="text-[11px] text-foreground whitespace-pre-wrap">
+              {if @demo.last_run, do: @demo.last_run.response, else: "Run a request to inspect the final response."}
+            </div>
+          </div>
+
+          <div class="rounded-md border border-border bg-elevated p-4">
+            <div class="flex items-center justify-between mb-2">
+              <div class="text-[10px] uppercase tracking-wider text-muted-foreground">History</div>
+              <div class="text-[10px] text-muted-foreground">{length(@demo.history)} event(s)</div>
+            </div>
+
+            <div id="skills-orchestration-history" class="space-y-2 max-h-[26rem] overflow-y-auto">
+              <%= for entry <- @demo.history do %>
+                <div class="rounded-md border border-border bg-background/70 px-3 py-2">
+                  <div class="text-[11px] font-semibold text-foreground">{entry.label}</div>
+                  <div class="text-[11px] text-muted-foreground">{entry.detail}</div>
+                </div>
+              <% end %>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  @impl true
+  def handle_event("run_arithmetic", _params, socket) do
+    {:noreply, assign_demo(socket, Orchestrator.run_scenario(socket.assigns.demo, :arithmetic))}
+  end
+
+  def handle_event("run_conversion", _params, socket) do
+    {:noreply, assign_demo(socket, Orchestrator.run_scenario(socket.assigns.demo, :conversion))}
+  end
+
+  def handle_event("run_combined", _params, socket) do
+    {:noreply, assign_demo(socket, Orchestrator.run_scenario(socket.assigns.demo, :combined))}
+  end
+
+  def handle_event("reset_demo", _params, socket) do
+    {:noreply, assign_demo(socket, Orchestrator.reset(socket.assigns.demo))}
+  end
+
+  defp assign_demo(socket, demo) do
+    assign(socket,
+      demo: demo,
+      registry_count: length(demo.registry_specs)
+    )
+  end
+end

--- a/priv/examples/jido-ai-skills-multi-agent-orchestration.md
+++ b/priv/examples/jido-ai-skills-multi-agent-orchestration.md
@@ -1,7 +1,7 @@
 %{
   title: "Jido.AI Skills Multi-Agent Orchestration",
-  description: "Multi-question orchestration demo combining arithmetic, conversion, and compound skill usage.",
-  tags: ["primary", "showcase", "simulated", "ai", "l2", "ai-tool-use", "skills", "jido_ai", "multi-agent"],
+  description: "Real deterministic routing across arithmetic, conversion, and combined skill specialists.",
+  tags: ["primary", "showcase", "ai", "l2", "ai-tool-use", "skills", "jido_ai", "multi-agent", "orchestration"],
   category: :ai,
   emoji: "🤝",
   related_resources: [
@@ -17,31 +17,55 @@
       href: "https://github.com/agentjido/jido_ai/blob/main/lib/examples/scripts/demo/skills_multi_agent_orchestration_demo.exs",
       kind: "Source",
       description: "Three-question orchestration flow with semantic checks."
+    },
+    %{
+      type: :external,
+      label: "skills system guide",
+      href: "https://github.com/agentjido/jido_ai/blob/main/guides/developer/skills_system.md",
+      kind: "Guide",
+      description: "Registry and prompt APIs used by the orchestration demo."
     }
   ],
   source_files: [
-    "lib/agent_jido_web/examples/simulated_showcase_live.ex"
+    "lib/agent_jido/demos/skills_multi_agent_orchestration/arithmetic_skill.ex",
+    "lib/agent_jido/demos/skills_multi_agent_orchestration/conversion_specialist.ex",
+    "lib/agent_jido/demos/skills_multi_agent_orchestration/endurance_planner_skill.ex",
+    "lib/agent_jido/demos/skills_multi_agent_orchestration/orchestrator.ex",
+    "lib/agent_jido_web/examples/skills_multi_agent_orchestration_live.ex",
+    "priv/skills/skills-multi-agent-orchestration/demo-unit-converter/SKILL.md"
   ],
-  live_view_module: "AgentJidoWeb.Examples.SimulatedShowcaseLive",
+  live_view_module: "AgentJidoWeb.Examples.SkillsMultiAgentOrchestrationLive",
   difficulty: :advanced,
   status: :live,
   scenario_cluster: :ai_tool_use,
   wave: :l2,
   journey_stage: :evaluation,
-  content_intent: :tutorial,
+  content_intent: :reference,
   capability_theme: :coordination_orchestration,
   evidence_surface: :runnable_example,
-  demo_mode: :simulated,
+  demo_mode: :real,
   sort_order: 24
 }
 ---
 
 ## What you'll learn
 
-- How one agent flow can route between multiple skills and tools by question class
-- How to validate orchestration quality with deterministic semantic assertions
-- How to present mixed-skill execution in a compact interactive trace
+- How deterministic routing chooses one or more specialists based on question class
+- How module-backed and file-backed skills work together in one orchestration pass
+- How `Jido.AI.Skill.Prompt.render/2` can describe the exact skills selected for a request
 
-## Demo note
+## How this demo works
 
-All question/response outputs on this page are fixture-driven for deterministic behavior.
+This page runs **real local orchestration code**.
+
+- It registers two module-backed specialists and loads one checked-in `SKILL.md` file with `Jido.AI.Skill.Registry.load_from_paths/1`.
+- The router chooses an arithmetic, conversion, or combined specialist set for each fixed request.
+- Each specialist executes local deterministic helper code, so every response is repeatable and copy-pasteable.
+
+No API keys, LLM providers, or network access are required for this example.
+
+## Pull the pattern into your own app
+
+- Keep specialist skills small and explicit so routing decisions stay legible.
+- Use file-backed skills when you want editable runtime instructions for one specialist.
+- Render the selected skill prompt before execution if you need an auditable orchestration trace.

--- a/priv/skills/skills-multi-agent-orchestration/demo-unit-converter/SKILL.md
+++ b/priv/skills/skills-multi-agent-orchestration/demo-unit-converter/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: demo-unit-converter
+description: Converts temperature and distance inputs for the deterministic multi-skill orchestration demo.
+license: Apache-2.0
+allowed-tools: convert_temperature convert_distance
+metadata:
+  author: agent-jido-demo
+  version: "1.0.0"
+tags:
+  - demo
+  - conversion
+  - orchestration
+---
+
+# Demo Unit Converter
+
+Use this skill when the request is about temperature or distance conversions.
+
+## Workflow
+
+1. Identify the source and destination units.
+2. Run the matching conversion helper.
+3. Return the normalized result for any downstream specialist.
+
+## Example Uses
+
+- Convert 98.6 Fahrenheit to Celsius
+- Convert 5 kilometers to miles

--- a/test/agent_jido/demos/skills_multi_agent_orchestration_orchestrator_test.exs
+++ b/test/agent_jido/demos/skills_multi_agent_orchestration_orchestrator_test.exs
@@ -1,0 +1,53 @@
+defmodule AgentJido.Demos.SkillsMultiAgentOrchestrationOrchestratorTest do
+  use ExUnit.Case, async: false
+
+  alias AgentJido.Demos.SkillsMultiAgentOrchestration.Orchestrator
+
+  setup do
+    demo = Orchestrator.new()
+
+    on_exit(fn ->
+      Orchestrator.reset(demo)
+    end)
+
+    %{demo: demo}
+  end
+
+  test "boots the specialist registry with module and file skills", %{demo: demo} do
+    assert demo.loaded_count == 1
+
+    assert Enum.map(demo.registry_specs, & &1.name) == [
+             "demo-orchestrator-arithmetic",
+             "demo-unit-converter",
+             "demo-endurance-planner"
+           ]
+  end
+
+  test "routes arithmetic requests to the arithmetic specialist", %{demo: demo} do
+    demo = Orchestrator.run_scenario(demo, :arithmetic)
+
+    assert demo.last_run.selected_skill_names == ["demo-orchestrator-arithmetic"]
+    assert Enum.map(demo.last_run.tool_trace, & &1.tool) == ["multiply", "add"]
+    assert demo.last_run.response =~ "814"
+    assert demo.last_run.prompt =~ "demo-orchestrator-arithmetic"
+  end
+
+  test "routes conversion requests to the file-backed unit converter", %{demo: demo} do
+    demo = Orchestrator.run_scenario(demo, :conversion)
+
+    assert demo.last_run.selected_skill_names == ["demo-unit-converter"]
+    assert Enum.map(demo.last_run.tool_trace, & &1.tool) == ["convert_temperature"]
+    assert demo.last_run.response =~ "37.0"
+    assert demo.last_run.prompt =~ "demo-unit-converter"
+  end
+
+  test "routes combined requests through conversion and endurance specialists", %{demo: demo} do
+    demo = Orchestrator.run_scenario(demo, :combined)
+
+    assert demo.last_run.selected_skill_names == ["demo-unit-converter", "demo-endurance-planner"]
+    assert Enum.map(demo.last_run.tool_trace, & &1.tool) == ["convert_distance", "estimate_calories"]
+    assert demo.last_run.response =~ "3.11 miles"
+    assert demo.last_run.response =~ "311 calories"
+    assert demo.last_run.prompt =~ "demo-endurance-planner"
+  end
+end

--- a/test/agent_jido/examples_test.exs
+++ b/test/agent_jido/examples_test.exs
@@ -22,7 +22,7 @@ defmodule AgentJido.ExamplesTest do
     {"jido-ai-weather-multi-turn-context", "AgentJidoWeb.Examples.SimulatedShowcaseLive"},
     {"jido-ai-task-execution-workflow", "AgentJidoWeb.Examples.TaskExecutionWorkflowLive"},
     {"jido-ai-skills-runtime-foundations", "AgentJidoWeb.Examples.SkillsRuntimeFoundationsLive"},
-    {"jido-ai-skills-multi-agent-orchestration", "AgentJidoWeb.Examples.SimulatedShowcaseLive"},
+    {"jido-ai-skills-multi-agent-orchestration", "AgentJidoWeb.Examples.SkillsMultiAgentOrchestrationLive"},
     {"jido-ai-weather-reasoning-strategy-suite", "AgentJidoWeb.Examples.SimulatedShowcaseLive"},
     {"jido-ai-operational-agents-pack", "AgentJidoWeb.Examples.SimulatedShowcaseLive"}
   ]

--- a/test/agent_jido_web/live/jido_example_live_test.exs
+++ b/test/agent_jido_web/live/jido_example_live_test.exs
@@ -13,7 +13,6 @@ defmodule AgentJidoWeb.JidoExampleLiveTest do
     {"runic-structured-llm-branching", "Runic Structured LLM Branching"},
     {"runic-delegating-orchestrator", "Runic Delegating Orchestrator"},
     {"jido-ai-weather-multi-turn-context", "Jido.AI Weather Multi-Turn Context"},
-    {"jido-ai-skills-multi-agent-orchestration", "Jido.AI Skills Multi-Agent Orchestration"},
     {"jido-ai-weather-reasoning-strategy-suite", "Jido.AI Weather Reasoning Strategy Suite"},
     {"jido-ai-operational-agents-pack", "Jido.AI Operational Agents Pack"}
   ]
@@ -502,6 +501,89 @@ defmodule AgentJidoWeb.JidoExampleLiveTest do
                "lib/agent_jido_web/examples/skills_runtime_foundations_live.ex",
                "priv/skills/skills-runtime-foundations/demo-code-review/SKILL.md",
                "priv/skills/skills-runtime-foundations/demo-release-notes/SKILL.md"
+             ]
+
+      assert Enum.map(example.sources, & &1.path) == example.source_files
+    end
+  end
+
+  describe "/examples/jido-ai-skills-multi-agent-orchestration" do
+    test "renders explanation tab with real orchestration guidance", %{conn: conn} do
+      {:ok, _view, html} = live(conn, "/examples/jido-ai-skills-multi-agent-orchestration?tab=explanation")
+
+      assert html =~ "Jido.AI Skills Multi-Agent Orchestration"
+      assert html =~ "Jido.AI.Skill.Registry.load_from_paths/1"
+      assert html =~ "Jido.AI.Skill.Prompt.render/2"
+      assert html =~ "No API keys, LLM providers, or network access are required for this example."
+    end
+
+    test "renders source tab for the dedicated orchestration example", %{conn: conn} do
+      {:ok, _view, html} = live(conn, "/examples/jido-ai-skills-multi-agent-orchestration?tab=source")
+
+      assert html =~ "arithmetic_skill.ex"
+      assert html =~ "conversion_specialist.ex"
+      assert html =~ "endurance_planner_skill.ex"
+      assert html =~ "orchestrator.ex"
+      assert html =~ "skills_multi_agent_orchestration_live.ex"
+      assert html =~ "SKILL.md"
+      refute html =~ "simulated_showcase_live.ex"
+    end
+
+    test "demo tab runs deterministic routing across the three fixed scenarios", %{conn: conn} do
+      {:ok, view, html} = live(conn, "/examples/jido-ai-skills-multi-agent-orchestration?tab=demo")
+
+      assert html =~ "Jido.AI Skills Multi-Agent Orchestration"
+      refute html =~ "Simulated demo"
+      assert html =~ "registry: 3 skill(s)"
+
+      demo_view = find_live_child(view, "demo-jido-ai-skills-multi-agent-orchestration")
+
+      html =
+        demo_view
+        |> element("#skills-multi-agent-orchestration-demo button[phx-click='run_arithmetic']")
+        |> render_click()
+
+      assert html =~ "42 * 17 + 100"
+      assert html =~ "demo-orchestrator-arithmetic"
+      assert html =~ "multiply"
+      assert html =~ "814"
+
+      html =
+        demo_view
+        |> element("#skills-multi-agent-orchestration-demo button[phx-click='run_conversion']")
+        |> render_click()
+
+      assert html =~ "98.6 degrees Fahrenheit"
+      assert html =~ "demo-unit-converter"
+      assert html =~ "convert_temperature"
+      assert html =~ "37.0"
+
+      html =
+        demo_view
+        |> element("#skills-multi-agent-orchestration-demo button[phx-click='run_combined']")
+        |> render_click()
+
+      assert html =~ "5 kilometers"
+      assert html =~ "demo-endurance-planner"
+      assert html =~ "convert_distance"
+      assert html =~ "estimate_calories"
+      assert html =~ "3.11 miles"
+      assert html =~ "311 calories"
+    end
+
+    test "example registry metadata resolves new orchestration source files", %{conn: _conn} do
+      example = Examples.get_example!("jido-ai-skills-multi-agent-orchestration")
+
+      assert example.title == "Jido.AI Skills Multi-Agent Orchestration"
+      assert example.live_view_module == "AgentJidoWeb.Examples.SkillsMultiAgentOrchestrationLive"
+
+      assert example.source_files == [
+               "lib/agent_jido/demos/skills_multi_agent_orchestration/arithmetic_skill.ex",
+               "lib/agent_jido/demos/skills_multi_agent_orchestration/conversion_specialist.ex",
+               "lib/agent_jido/demos/skills_multi_agent_orchestration/endurance_planner_skill.ex",
+               "lib/agent_jido/demos/skills_multi_agent_orchestration/orchestrator.ex",
+               "lib/agent_jido_web/examples/skills_multi_agent_orchestration_live.ex",
+               "priv/skills/skills-multi-agent-orchestration/demo-unit-converter/SKILL.md"
              ]
 
       assert Enum.map(example.sources, & &1.path) == example.source_files


### PR DESCRIPTION
## Summary
- replace the simulated skills multi-agent orchestration page with a dedicated deterministic orchestration demo
- add module-backed and file-backed specialist skills plus a real router that handles arithmetic, conversion, and combined requests
- add orchestrator, example registry, and LiveView regression coverage for the new surface

## Testing
- ASDF_ELIXIR_VERSION=1.18.4-otp-27 ASDF_ERLANG_VERSION=27.3 mix test test/agent_jido/demos/skills_multi_agent_orchestration_orchestrator_test.exs test/agent_jido/examples_test.exs test/agent_jido_web/live/jido_example_live_test.exs
- ASDF_ELIXIR_VERSION=1.18.4-otp-27 ASDF_ERLANG_VERSION=27.3 mix test

## Notes
- This PR is stacked on #78 and should be retargeted to `main` after the parent branch lands.

Closes #62
