### PR TITLE
Phase 2: repair Dialyzer contract drift warnings

### DIFF
--- a/lib/agent_jido/community/showcase.ex
+++ b/lib/agent_jido/community/showcase.ex
@@ -37,13 +37,13 @@ defmodule AgentJido.Community.Showcase do
   @doc """
   Returns all live showcase projects.
   """
-  @spec all_projects() :: [Project.t()]
+  @spec all_projects() :: nonempty_list(Project.t())
   def all_projects, do: @projects
 
   @doc """
   Returns showcase projects with optional draft inclusion.
   """
-  @spec all_projects(keyword()) :: [Project.t()]
+  @spec all_projects(keyword()) :: nonempty_list(Project.t())
   def all_projects(opts) when is_list(opts) do
     if include_drafts?(opts), do: @all_projects, else: @projects
   end

--- a/lib/agent_jido/community/showcase/project.ex
+++ b/lib/agent_jido/community/showcase/project.ex
@@ -26,7 +26,21 @@ defmodule AgentJido.Community.Showcase.Project do
             coerce: true
           )
 
-  @type t :: unquote(Zoi.type_spec(@schema))
+  @type t :: %__MODULE__{
+          slug: String.t(),
+          title: String.t(),
+          description: String.t(),
+          project_url: String.t(),
+          repo_url: String.t() | nil,
+          logo_url: String.t() | nil,
+          tags: [String.t()],
+          featured: boolean(),
+          status: :draft | :live,
+          sort_order: integer(),
+          body: String.t(),
+          path: String.t(),
+          source_path: String.t()
+        }
 
   @enforce_keys Zoi.Struct.enforce_keys(@schema)
   defstruct Zoi.Struct.struct_fields(@schema)
@@ -34,7 +48,7 @@ defmodule AgentJido.Community.Showcase.Project do
   @doc """
   Returns the schema used to validate showcase project metadata.
   """
-  @spec schema() :: Zoi.t()
+  @spec schema() :: Zoi.schema()
   def schema, do: @schema
 
   @doc """

--- a/lib/agent_jido/demos/emit_directive/emit_directive_agent.ex
+++ b/lib/agent_jido/demos/emit_directive/emit_directive_agent.ex
@@ -23,4 +23,8 @@ defmodule AgentJido.Demos.EmitDirectiveAgent do
       {"process_payment", ProcessPaymentAction},
       {"multi_emit", MultiEmitAction}
     ]
+
+  @doc false
+  @spec plugin_specs() :: nonempty_list(Jido.Plugin.Spec.t())
+  def plugin_specs, do: super()
 end

--- a/lib/agent_jido/demos/persistence_storage/persistence_storage_agent.ex
+++ b/lib/agent_jido/demos/persistence_storage/persistence_storage_agent.ex
@@ -17,4 +17,8 @@ defmodule AgentJido.Demos.PersistenceStorageAgent do
       {"counter.increment", IncrementAction},
       {"notes.add", AddNoteAction}
     ]
+
+  @doc false
+  @spec plugin_specs() :: nonempty_list(Jido.Plugin.Spec.t())
+  def plugin_specs, do: super()
 end

--- a/lib/agent_jido/demos/plugin_basics/plugin_basics_agent.ex
+++ b/lib/agent_jido/demos/plugin_basics/plugin_basics_agent.ex
@@ -12,4 +12,8 @@ defmodule AgentJido.Demos.PluginBasicsAgent do
       status: [type: :atom, default: :ready]
     ],
     plugins: [{NotesPlugin, %{label: "demo"}}]
+
+  @doc false
+  @spec plugin_specs() :: nonempty_list(Jido.Plugin.Spec.t())
+  def plugin_specs, do: super()
 end

--- a/lib/agent_jido/demos/schedule_directive/schedule_directive_agent.ex
+++ b/lib/agent_jido/demos/schedule_directive/schedule_directive_agent.ex
@@ -37,4 +37,12 @@ defmodule AgentJido.Demos.ScheduleDirectiveAgent do
       {"cron.tick", HandleCronTickAction},
       {"cron.hourly", HandleCronTickAction}
     ]
+
+  @doc false
+  @spec plugin_specs() :: nonempty_list(Jido.Plugin.Spec.t())
+  def plugin_specs, do: super()
+
+  @doc false
+  @spec plugin_schedules() :: nonempty_list(Jido.Plugin.Schedules.schedule_spec())
+  def plugin_schedules, do: super()
 end

--- a/lib/agent_jido/demos/signal_routing/signal_routing_agent.ex
+++ b/lib/agent_jido/demos/signal_routing/signal_routing_agent.ex
@@ -22,4 +22,8 @@ defmodule AgentJido.Demos.SignalRoutingAgent do
       {"set_name", SetNameAction},
       {"record_event", RecordEventAction}
     ]
+
+  @doc false
+  @spec plugin_specs() :: nonempty_list(Jido.Plugin.Spec.t())
+  def plugin_specs, do: super()
 end

--- a/lib/agent_jido/demos/state_ops/state_ops_agent.ex
+++ b/lib/agent_jido/demos/state_ops/state_ops_agent.ex
@@ -30,4 +30,8 @@ defmodule AgentJido.Demos.StateOpsAgent do
       {"state.set_nested", SetNestedValueAction},
       {"state.delete_nested", DeleteNestedValueAction}
     ]
+
+  @doc false
+  @spec plugin_specs() :: nonempty_list(Jido.Plugin.Spec.t())
+  def plugin_specs, do: super()
 end


### PR DESCRIPTION
## Summary
- implement Phase 2 of the Dialyzer remediation plan from `specs/planning`
- tighten helper return specs for showcase and demo-agent plugin accessors
- replace the showcase project's Zoi-derived struct alias with an explicit `Project.t()` type

## Why
After Phase 1, Dialyzer warnings were concentrated in the contract-drift group:
- `lib/agent_jido/community/showcase.ex`
- `lib/agent_jido/community/showcase/project.ex`
- the generated `plugin_specs/0` helpers on several demo agents
- the generated `plugin_schedules/0` helper on `ScheduleDirectiveAgent`

The common issue was mismatched declared types versus the concrete non-empty values returned by compile-time data and generated plugin helpers.

## Changes
- `Showcase.all_projects/0` and `all_projects/1` now declare `nonempty_list(Project.t())`
- `Showcase.Project.schema/0` now uses `Zoi.schema()`
- `Showcase.Project.t()` is now an explicit struct type Dialyzer can reason about directly
- the affected demo agents override `plugin_specs/0` with `nonempty_list(Jido.Plugin.Spec.t())`
- `ScheduleDirectiveAgent` also overrides `plugin_schedules/0` with `nonempty_list(Jido.Plugin.Schedules.schedule_spec())`

## Verification
- `ASDF_ELIXIR_VERSION=1.18.4-otp-27 ASDF_ERLANG_VERSION=27.3 CONTENTOPS_CHAT_ENABLED=false mix format --check-formatted`
- `ASDF_ELIXIR_VERSION=1.18.4-otp-27 ASDF_ERLANG_VERSION=27.3 CONTENTOPS_CHAT_ENABLED=false mix compile --warnings-as-errors`
- `ASDF_ELIXIR_VERSION=1.18.4-otp-27 ASDF_ERLANG_VERSION=27.3 CONTENTOPS_CHAT_ENABLED=false mix test`
- `ASDF_ELIXIR_VERSION=1.18.4-otp-27 ASDF_ERLANG_VERSION=27.3 CONTENTOPS_CHAT_ENABLED=false mix dialyzer --quiet-with-result --ignore-exit-status`

## Result
The Dialyzer warning set dropped from 13 project-file warnings after Phase 1 to 3 residual warnings after Phase 2. The remaining groups are the Phase 3-4 targets:
- `lib/agent_jido/analytics/composite.ex`
- `lib/agent_jido_web/live/jido_ecosystem_package_live.ex`
- `lib/agent_jido_web/plugs/analytics_identity.ex`
