### PR TITLE
Phase 3: clear residual Dialyzer mismatch warnings

### DIFF
--- a/lib/agent_jido/analytics/composite.ex
+++ b/lib/agent_jido/analytics/composite.ex
@@ -40,14 +40,10 @@ defmodule AgentJido.Analytics.Composite do
   @spec track_event(term(), map() | keyword()) ::
           {:ok, AnalyticsEvent.t() | :excluded_admin} | {:error, term()}
   def track_event(current_scope, attrs) do
-    case Analytics.track_event(current_scope, attrs) do
-      {:ok, %AnalyticsEvent{} = event} = result ->
-        PostHog.capture_analytics_event_safe(current_scope, event)
-        result
-
-      other ->
-        other
-    end
+    normalized_attrs = normalize_attrs(attrs)
+    result = Analytics.track_event(current_scope, normalized_attrs)
+    maybe_capture_posthog(current_scope, normalized_attrs, result)
+    result
   end
 
   @spec track_event_safe(term(), map() | keyword()) :: :ok
@@ -73,4 +69,14 @@ defmodule AgentJido.Analytics.Composite do
   defp normalize_attrs(attrs) when is_map(attrs), do: attrs
   defp normalize_attrs(attrs) when is_list(attrs), do: Enum.into(attrs, %{})
   defp normalize_attrs(_attrs), do: %{}
+
+  defp maybe_capture_posthog(current_scope, attrs, result) do
+    event_name = Map.get(attrs, "event") || Map.get(attrs, :event)
+
+    if is_binary(event_name) and match?({:ok, _}, result) and not match?({:ok, :excluded_admin}, result) do
+      PostHog.capture_event_safe(current_scope, event_name, attrs)
+    else
+      :ok
+    end
+  end
 end

--- a/lib/agent_jido_web/live/jido_ecosystem_package_live.ex
+++ b/lib/agent_jido_web/live/jido_ecosystem_package_live.ex
@@ -602,33 +602,32 @@ defmodule AgentJidoWeb.JidoEcosystemPackageLive do
 
   defp cta_link_class(_), do: "border-border bg-elevated text-foreground hover:text-primary"
 
-  defp issue_queue_url(nil), do: nil
-  defp issue_queue_url(""), do: nil
-
   defp issue_queue_url(github_url) when is_binary(github_url) do
     trimmed = String.trim(github_url)
 
-    case URI.parse(trimmed) do
-      %URI{scheme: scheme, host: host, path: path}
-      when scheme in ["http", "https"] and host in ["github.com", "www.github.com"] ->
-        path
-        |> to_string()
-        |> String.trim("/")
-        |> String.split("/", trim: true)
-        |> case do
-          [owner, repo | _rest] when owner != "" and repo != "" ->
-            "https://github.com/#{owner}/#{String.trim_trailing(repo, ".git")}/issues"
+    if trimmed == "" do
+      nil
+    else
+      case URI.parse(trimmed) do
+        %URI{scheme: scheme, host: host, path: path}
+        when scheme in ["http", "https"] and host in ["github.com", "www.github.com"] ->
+          path
+          |> to_string()
+          |> String.trim("/")
+          |> String.split("/", trim: true)
+          |> case do
+            [owner, repo | _rest] when owner != "" and repo != "" ->
+              "https://github.com/#{owner}/#{String.trim_trailing(repo, ".git")}/issues"
 
-          _other ->
-            nil
-        end
+            _other ->
+              nil
+          end
 
-      _other ->
-        nil
+        _other ->
+          nil
+      end
     end
   end
-
-  defp issue_queue_url(_github_url), do: nil
 
   defp present?(nil), do: false
   defp present?(""), do: false

--- a/lib/agent_jido_web/plugs/analytics_identity.ex
+++ b/lib/agent_jido_web/plugs/analytics_identity.ex
@@ -69,12 +69,11 @@ defmodule AgentJidoWeb.Plugs.AnalyticsIdentity do
     end
   end
 
-  defp uuid_v7?(value) when is_binary(value) do
+  @spec uuid_v7?(String.t()) :: boolean()
+  defp uuid_v7?(value) do
     case UUIDv7.decode(value) do
       <<_timestamp::big-unsigned-48, 7::4, _rest::bitstring>> -> true
       _other -> false
     end
   end
-
-  defp uuid_v7?(_value), do: false
 end


### PR DESCRIPTION
## Summary
- implement Phase 3 of the Dialyzer remediation plan from `specs/planning`
- remove the remaining project-owned mismatch warnings in analytics, ecosystem package live rendering, and analytics identity handling
- leave only the external `Nostrum.Consumer` callback-info warning for the dependency-boundary phase

## Why
After Phase 2, the remaining project-owned warnings were all small control-flow mismatches:
- an impossible result branch in `AgentJido.Analytics.Composite`
- a dead fallback path in `AgentJidoWeb.JidoEcosystemPackageLive.issue_queue_url/1`
- an unreachable non-binary fallback in `AgentJidoWeb.Plugs.AnalyticsIdentity.uuid_v7?/1`

## Changes
- simplify `Composite.track_event/2` to normalize attrs once, keep the analytics result intact, and mirror PostHog via result-state checks instead of impossible struct matches
- simplify `issue_queue_url/1` to accept the binary shape actually used by the live view and remove dead fallback branches
- narrow `uuid_v7?/1` to the binary input it is actually called with

## Verification
- `ASDF_ELIXIR_VERSION=1.18.4-otp-27 ASDF_ERLANG_VERSION=27.3 CONTENTOPS_CHAT_ENABLED=false mix format --check-formatted`
- `ASDF_ELIXIR_VERSION=1.18.4-otp-27 ASDF_ERLANG_VERSION=27.3 CONTENTOPS_CHAT_ENABLED=false mix compile --warnings-as-errors`
- `ASDF_ELIXIR_VERSION=1.18.4-otp-27 ASDF_ERLANG_VERSION=27.3 CONTENTOPS_CHAT_ENABLED=false mix test`
- `ASDF_ELIXIR_VERSION=1.18.4-otp-27 ASDF_ERLANG_VERSION=27.3 CONTENTOPS_CHAT_ENABLED=false mix dialyzer --quiet-with-result --ignore-exit-status`

## Result
The only remaining Dialyzer output is:
- `/home/build/elixir/lib/elixir/lib/gen_server.ex:1:callback_info_missing`
- `Callback info about the Nostrum.Consumer behaviour is not available.`

That residual warning is the Phase 4 dependency-boundary item.
