### PR TITLE
Phase 4: quarantine Dialyzer dependency-boundary warning

### DIFF
--- a/.dialyzer_ignore.exs
+++ b/.dialyzer_ignore.exs
@@ -1,5 +1,6 @@
 [
-  {"/home/runner/work/elixir/elixir/lib/elixir/lib/gen_server.ex", :callback_info_missing},
+  # Nostrum's generated consumer callback metadata is not available in all build environments.
+  ~r/Callback info about the Nostrum\.Consumer behaviour is not available\./,
   {"deps/nostrum/lib/nostrum/consumer.ex", :unknown_function},
   {"lib/agent_jido/analytics.ex", :call},
   {"lib/agent_jido/analytics.ex", :unused_fun},


### PR DESCRIPTION
## Summary
- implement Phase 4 of the Dialyzer remediation plan from `specs/planning`
- replace the brittle, path-specific Nostrum callback ignore entry with an environment-stable regex filter
- make `mix dialyzer` pass cleanly after the project-owned warnings were removed in the earlier phases

## Why
After Phase 3, the only remaining Dialyzer output was the external warning:

`Callback info about the Nostrum.Consumer behaviour is not available.`

This comes from dependency callback metadata, not from a project implementation bug. The repo already had an ignore entry, but it was keyed to a specific CI file path and legacy warning shape, so it did not match the warning emitted in this environment.

## Changes
- update [.dialyzer_ignore.exs](/Users/Pascal/code/agentjido/jido_run/.dialyzer_ignore.exs) to use a regex filter on the warning text instead of a hard-coded CI path and legacy atom form
- document in the ignore file that this warning is coming from Nostrum callback metadata availability across build environments

## Verification
- `ASDF_ELIXIR_VERSION=1.18.4-otp-27 ASDF_ERLANG_VERSION=27.3 CONTENTOPS_CHAT_ENABLED=false mix format --check-formatted`
- `ASDF_ELIXIR_VERSION=1.18.4-otp-27 ASDF_ERLANG_VERSION=27.3 CONTENTOPS_CHAT_ENABLED=false mix compile --warnings-as-errors`
- `ASDF_ELIXIR_VERSION=1.18.4-otp-27 ASDF_ERLANG_VERSION=27.3 CONTENTOPS_CHAT_ENABLED=false mix test`
- `ASDF_ELIXIR_VERSION=1.18.4-otp-27 ASDF_ERLANG_VERSION=27.3 CONTENTOPS_CHAT_ENABLED=false mix dialyzer --quiet-with-result --ignore-exit-status`

## Result
`mix dialyzer` now ends with:

`done (passed successfully)`

This completes the current phased remediation sequence.
