### PR TITLE
Phase 5: enforce Dialyzer in the push quality gate

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -184,7 +184,8 @@ if config_env() == :dev do
       ],
       pre_push: [
         tasks: [
-          {:mix_task, :test}
+          {:mix_task, :test},
+          {:mix_task, :dialyzer}
         ]
       ]
     ]


### PR DESCRIPTION
## Summary
- implement the final phase of the Dialyzer remediation plan from `specs/planning`
- promote `mix dialyzer` into the managed `pre_push` hook now that the warning baseline is clean
- keep the gate pragmatic: `pre_push` runs `mix test` and `mix dialyzer`

## Why
Phases 1 through 4 removed the project-owned Dialyzer warnings and quarantined the remaining dependency-boundary warning, so `mix dialyzer` now passes cleanly. The final step is to turn that clean run into an enforced quality gate so new type regressions are blocked before push.

## Changes
- update [config/config.exs](/Users/Pascal/code/agentjido/jido_run/config/config.exs) so the managed `pre_push` hook runs:
  - `mix test`
  - `mix dialyzer`

## Verification
- `ASDF_ELIXIR_VERSION=1.18.4-otp-27 ASDF_ERLANG_VERSION=27.3 CONTENTOPS_CHAT_ENABLED=false mix format --check-formatted`
- `ASDF_ELIXIR_VERSION=1.18.4-otp-27 ASDF_ERLANG_VERSION=27.3 CONTENTOPS_CHAT_ENABLED=false mix compile --warnings-as-errors`
- `ASDF_ELIXIR_VERSION=1.18.4-otp-27 ASDF_ERLANG_VERSION=27.3 CONTENTOPS_CHAT_ENABLED=false mix test`
- `ASDF_ELIXIR_VERSION=1.18.4-otp-27 ASDF_ERLANG_VERSION=27.3 CONTENTOPS_CHAT_ENABLED=false mix dialyzer --quiet-with-result --ignore-exit-status`
- `ASDF_ELIXIR_VERSION=1.18.4-otp-27 ASDF_ERLANG_VERSION=27.3 CONTENTOPS_CHAT_ENABLED=false mix git_hooks.install`
- `ASDF_ELIXIR_VERSION=1.18.4-otp-27 ASDF_ERLANG_VERSION=27.3 CONTENTOPS_CHAT_ENABLED=false mix git_hooks.run pre_push`

## Note
I did not promote `credo --strict` into a blocking hook because the repo still has a large existing Credo baseline; making that mandatory today would block every commit. This PR only enforces the gate that is now clean and stable.
