### PR TITLE
Credo Phase 4: reduce complexity hotspots

### DIFF
--- a/lib/agent_jido/analytics/posthog/runtime_config.ex
+++ b/lib/agent_jido/analytics/posthog/runtime_config.ex
@@ -24,41 +24,26 @@ defmodule AgentJido.Analytics.PostHog.RuntimeConfig do
     enabled = env_boolean(env_reader, "POSTHOG_ENABLED", false)
     browser_enabled = enabled and env_boolean(env_reader, "POSTHOG_BROWSER_ENABLED", false)
     server_enabled = enabled and env_boolean(env_reader, "POSTHOG_SERVER_ENABLED", false)
-    autocapture_enabled = browser_enabled and env_boolean(env_reader, "POSTHOG_AUTOCAPTURE_ENABLED", false)
 
-    session_replay_enabled =
-      browser_enabled and env_boolean(env_reader, "POSTHOG_SESSION_REPLAY_ENABLED", false)
+    config =
+      %{
+        enabled: enabled,
+        browser_enabled: browser_enabled,
+        server_enabled: server_enabled,
+        autocapture_enabled: browser_enabled and env_boolean(env_reader, "POSTHOG_AUTOCAPTURE_ENABLED", false),
+        session_replay_enabled: browser_enabled and env_boolean(env_reader, "POSTHOG_SESSION_REPLAY_ENABLED", false),
+        session_replay_sample_rate: env_float(env_reader, "POSTHOG_SESSION_REPLAY_SAMPLE_RATE", @default_session_replay_sample_rate),
+        api_key: env_string(env_reader, "POSTHOG_API_KEY"),
+        api_host: env_string(env_reader, "POSTHOG_API_HOST") || @default_api_host
+      }
 
-    session_replay_sample_rate =
-      env_float(
-        env_reader,
-        "POSTHOG_SESSION_REPLAY_SAMPLE_RATE",
-        @default_session_replay_sample_rate
-      )
+    browser_api_host = env_string(env_reader, "POSTHOG_BROWSER_API_HOST") || config.api_host
+    ui_host = env_string(env_reader, "POSTHOG_UI_HOST") || infer_ui_host(config.api_host, browser_api_host)
 
-    api_key = env_string(env_reader, "POSTHOG_API_KEY")
-    api_host = env_string(env_reader, "POSTHOG_API_HOST") || @default_api_host
-    browser_api_host = env_string(env_reader, "POSTHOG_BROWSER_API_HOST") || api_host
-    ui_host = env_string(env_reader, "POSTHOG_UI_HOST") || infer_ui_host(api_host, browser_api_host)
-
-    if (browser_enabled or server_enabled) and blank?(api_key) do
-      raise """
-      POSTHOG_API_KEY is required when POSTHOG_BROWSER_ENABLED or POSTHOG_SERVER_ENABLED is enabled.
-      """
-    end
-
-    %{
-      enabled: enabled,
-      browser_enabled: browser_enabled,
-      server_enabled: server_enabled,
-      autocapture_enabled: autocapture_enabled,
-      session_replay_enabled: session_replay_enabled,
-      session_replay_sample_rate: session_replay_sample_rate,
-      api_key: api_key,
-      api_host: api_host,
-      browser_api_host: browser_api_host,
-      ui_host: ui_host
-    }
+    config
+    |> Map.put(:browser_api_host, browser_api_host)
+    |> Map.put(:ui_host, ui_host)
+    |> validate_api_key!()
   end
 
   @spec posthog_options(resolved_config()) :: keyword()
@@ -86,6 +71,16 @@ defmodule AgentJido.Analytics.PostHog.RuntimeConfig do
       nil -> default
       value -> value in ["1", "true", "TRUE", "True", "on", "ON", "yes", "YES"]
     end
+  end
+
+  defp validate_api_key!(%{browser_enabled: browser_enabled, server_enabled: server_enabled, api_key: api_key} = config) do
+    if (browser_enabled or server_enabled) and blank?(api_key) do
+      raise """
+      POSTHOG_API_KEY is required when POSTHOG_BROWSER_ENABLED or POSTHOG_SERVER_ENABLED is enabled.
+      """
+    end
+
+    config
   end
 
   defp env_float(env_reader, key, default) do

--- a/lib/agent_jido/blog/taxonomy.ex
+++ b/lib/agent_jido/blog/taxonomy.ex
@@ -108,7 +108,7 @@ defmodule AgentJido.Blog.Taxonomy do
           acc
 
         canonical ->
-          if Enum.member?(acc, canonical), do: acc, else: acc ++ [canonical]
+          append_unique(acc, canonical)
       end
     end)
   end
@@ -208,18 +208,27 @@ defmodule AgentJido.Blog.Taxonomy do
   defp infer_content_intent(_), do: :explanation
 
   defp infer_capability_theme(tags) do
-    cond do
-      has_any?(tags, ["signals", "workflow", "workflows", "directives"]) -> :coordination_orchestration
-      has_any?(tags, ["telemetry", "observability", "tracing", "ops"]) -> :operations_observability
-      has_any?(tags, ["llm", "req_llm", "langchain", "ai", "memory"]) -> :ai_intelligence
-      has_any?(tags, ["integration", "interop", "adapters", "phoenix", "liveview"]) -> :integration_interop
-      has_any?(tags, ["shell", "vfs", "sandbox", "workspace"]) -> :execution_tooling
-      has_any?(tags, ["adoption", "architecture", "decision"]) -> :adoption_architecture
-      has_any?(tags, ["training", "learning"]) -> :learning_enablement
-      has_any?(tags, ["community", "case-study"]) -> :community_adoption
-      has_any?(tags, ["reliability", "supervision", "otp"]) -> :reliability_architecture
-      true -> :runtime_foundations
-    end
+    Enum.find_value(capability_theme_rules(), :runtime_foundations, fn {theme, matches} ->
+      if has_any?(tags, matches), do: theme
+    end)
+  end
+
+  defp append_unique(items, item) do
+    if Enum.member?(items, item), do: items, else: items ++ [item]
+  end
+
+  defp capability_theme_rules do
+    [
+      {:coordination_orchestration, ["signals", "workflow", "workflows", "directives"]},
+      {:operations_observability, ["telemetry", "observability", "tracing", "ops"]},
+      {:ai_intelligence, ["llm", "req_llm", "langchain", "ai", "memory"]},
+      {:integration_interop, ["integration", "interop", "adapters", "phoenix", "liveview"]},
+      {:execution_tooling, ["shell", "vfs", "sandbox", "workspace"]},
+      {:adoption_architecture, ["adoption", "architecture", "decision"]},
+      {:learning_enablement, ["training", "learning"]},
+      {:community_adoption, ["community", "case-study"]},
+      {:reliability_architecture, ["reliability", "supervision", "otp"]}
+    ]
   end
 
   defp infer_journey_stage(:tutorial, _post_type), do: :activation

--- a/lib/agent_jido/content_assistant.ex
+++ b/lib/agent_jido/content_assistant.ex
@@ -221,17 +221,7 @@ defmodule AgentJido.ContentAssistant do
     results
     |> Enum.reduce(%{}, fn
       %Result{url: url, score: score} = result, acc ->
-        case Map.get(acc, url) do
-          nil ->
-            Map.put(acc, url, result)
-
-          %Result{score: existing_score} = existing ->
-            if score_value(score) > score_value(existing_score) do
-              Map.put(acc, url, result)
-            else
-              Map.put(acc, url, existing)
-            end
-        end
+        Map.update(acc, url, result, &best_result(&1, result, score))
 
       _, acc ->
         acc
@@ -241,6 +231,10 @@ defmodule AgentJido.ContentAssistant do
   end
 
   defp dedupe_results(_results), do: []
+
+  defp best_result(%Result{score: existing_score} = existing, result, score) do
+    if score_value(score) > score_value(existing_score), do: result, else: existing
+  end
 
   defp score_value(score) when is_number(score), do: score * 1.0
   defp score_value(_score), do: 0.0

--- a/lib/agent_jido/content_assistant/retrieval.ex
+++ b/lib/agent_jido/content_assistant/retrieval.ex
@@ -553,24 +553,10 @@ defmodule AgentJido.ContentAssistant.Retrieval do
 
   defp canonical_route(collection, metadata, source_id) do
     case normalize_collection(collection) do
-      "site_docs" ->
-        normalize_internal_url(string_value(metadata, :path)) ||
-          docs_route_from_source_id(source_id)
-
-      "site_blog" ->
-        case string_value(metadata, :id) || source_id_suffix(source_id, "blog:") do
-          nil -> nil
-          id -> normalize_internal_url("/blog/" <> id)
-        end
-
-      "site_ecosystem" ->
-        case string_value(metadata, :id) || source_id_suffix(source_id, "ecosystem:") do
-          nil -> nil
-          id -> normalize_internal_url("/ecosystem/" <> id)
-        end
-
-      _ ->
-        nil
+      "site_docs" -> normalize_internal_url(string_value(metadata, :path)) || docs_route_from_source_id(source_id)
+      "site_blog" -> route_from_collection_id(metadata, source_id, "blog:", "/blog/")
+      "site_ecosystem" -> route_from_collection_id(metadata, source_id, "ecosystem:", "/ecosystem/")
+      _other -> nil
     end
   end
 
@@ -621,20 +607,29 @@ defmodule AgentJido.ContentAssistant.Retrieval do
         normalize_path(candidate)
 
       true ->
-        case URI.parse(candidate) do
-          %URI{scheme: scheme, host: host, path: path, query: query, fragment: fragment}
-          when scheme in ["http", "https"] and is_binary(path) ->
-            if internal_host?(host) do
-              normalize_path_with_parts(path, query, fragment)
-            end
-
-          _ ->
-            nil
-        end
+        normalize_internal_http_url(candidate)
     end
   end
 
   defp normalize_internal_url(_url), do: nil
+
+  defp route_from_collection_id(metadata, source_id, prefix, route_prefix) do
+    case string_value(metadata, :id) || source_id_suffix(source_id, prefix) do
+      nil -> nil
+      id -> normalize_internal_url(route_prefix <> id)
+    end
+  end
+
+  defp normalize_internal_http_url(candidate) do
+    case URI.parse(candidate) do
+      %URI{scheme: scheme, host: host, path: path, query: query, fragment: fragment}
+      when scheme in ["http", "https"] and is_binary(path) and is_binary(host) ->
+        if internal_host?(host), do: normalize_path_with_parts(path, query, fragment)
+
+      _other ->
+        nil
+    end
+  end
 
   defp normalize_path(path) when is_binary(path) do
     case URI.parse(path) do

--- a/lib/agent_jido/content_assistant/url.ex
+++ b/lib/agent_jido/content_assistant/url.ex
@@ -32,15 +32,11 @@ defmodule AgentJido.ContentAssistant.URL do
         path = uri.path || "/"
         query = uri.query
         fragment = uri.fragment
+        path_with_parts = normalize_path_with_parts(path, query, fragment)
 
-        if internal_host?(normalized_host) do
-          normalize_path_with_parts(path, query, fragment)
-        else
-          normalize_path_with_parts(path, query, fragment)
-          |> case do
-            nil -> nil
-            path_with_parts -> "#{normalized_scheme}://#{normalized_host}#{path_with_parts}"
-          end
+        case internal_host?(normalized_host) do
+          true -> path_with_parts
+          false -> external_absolute_url(normalized_scheme, normalized_host, path_with_parts)
         end
 
       _ ->
@@ -77,6 +73,9 @@ defmodule AgentJido.ContentAssistant.URL do
   end
 
   defp normalize_path_with_parts(_path, _query, _fragment), do: nil
+
+  defp external_absolute_url(_scheme, _host, nil), do: nil
+  defp external_absolute_url(scheme, host, path_with_parts), do: "#{scheme}://#{host}#{path_with_parts}"
 
   defp internal_host?(host) when is_binary(host) do
     host in AgentJido.Site.internal_hosts()

--- a/lib/agent_jido/content_gen/actions/audit_and_gate.ex
+++ b/lib/agent_jido/content_gen/actions/audit_and_gate.ex
@@ -22,126 +22,120 @@ defmodule AgentJido.ContentGen.Actions.AuditAndGate do
 
     audit_errors = length(audit.errors)
 
-    base_entry_result =
-      Helpers.base_entry_result(context)
-      |> Map.merge(%{
-        parse_mode: context.parse_mode,
-        audit: audit,
-        diff: context.diff,
-        citations: context.candidate.citations,
-        audit_notes: context.candidate.audit_notes,
-        content_hash: Helpers.content_hash(context.candidate.raw),
-        candidate_path: context.candidate_path,
-        backend_meta: context.backend_meta
-      })
-
+    base_entry_result = base_entry_result(context, audit)
     context = Map.put(context, :audit, audit)
 
+    handle_audit_gate(context, base_entry_result, audit, audit_errors)
+  end
+
+  defp base_entry_result(context, audit) do
+    Helpers.base_entry_result(context)
+    |> Map.merge(%{
+      parse_mode: context.parse_mode,
+      audit: audit,
+      diff: context.diff,
+      citations: context.candidate.citations,
+      audit_notes: context.candidate.audit_notes,
+      content_hash: Helpers.content_hash(context.candidate.raw),
+      candidate_path: context.candidate_path,
+      backend_meta: context.backend_meta
+    })
+  end
+
+  defp handle_audit_gate(context, base_entry_result, audit, audit_errors) do
     cond do
       context.update_mode == :audit_only ->
         audit_only_context(context, base_entry_result, audit_errors)
 
       context.fail_on_audit and audit_errors > 0 ->
-        verification = Helpers.verification_for_audit_failure(context, audit)
-
         {:ok,
-         %{
-           context
-           | status: :audit_failed,
-             reason: "audit gates failed",
-             verification: verification,
-             halted?: true,
-             entry_result:
-               Map.merge(base_entry_result, %{
-                 status: :audit_failed,
-                 reason: "audit gates failed",
-                 verification: verification
-               })
-         }}
+         halted_context(
+           context,
+           base_entry_result,
+           :audit_failed,
+           "audit gates failed",
+           Helpers.verification_for_audit_failure(context, audit)
+         )}
 
       true ->
-        case Writer.churn_guard(context.existing, context.candidate.raw, audit_errors) do
-          {:error, reason} ->
-            verification =
-              if context.verify? do
-                Helpers.skipped_verification("verification skipped: churn guard blocked write")
-              else
-                Helpers.default_verification()
-              end
+        run_write_gate(context, base_entry_result, audit_errors)
+    end
+  end
 
-            {:ok,
-             %{
-               context
-               | status: :churn_blocked,
-                 reason: reason,
-                 verification: verification,
-                 halted?: true,
-                 entry_result:
-                   Map.merge(base_entry_result, %{
-                     status: :churn_blocked,
-                     reason: reason,
-                     verification: verification
-                   })
-             }}
+  defp run_write_gate(context, base_entry_result, audit_errors) do
+    case Writer.churn_guard(context.existing, context.candidate.raw, audit_errors) do
+      {:error, reason} ->
+        {:ok,
+         halted_context(
+           context,
+           base_entry_result,
+           :churn_blocked,
+           reason,
+           skipped_or_default_verification(context, "verification skipped: churn guard blocked write")
+         )}
 
-          :ok ->
-            cond do
-              Writer.noop?(Helpers.existing_raw(context.existing), context.candidate.raw) ->
-                verification =
-                  if context.verify? do
-                    Helpers.skipped_verification("verification skipped: generated output is a no-op")
-                  else
-                    Helpers.default_verification()
-                  end
+      :ok ->
+        finalize_candidate_state(context, base_entry_result)
+    end
+  end
 
-                {:ok,
-                 %{
-                   context
-                   | status: :skipped_noop,
-                     reason: "generated output matches existing content",
-                     verification: verification,
-                     halted?: true,
-                     entry_result:
-                       Map.merge(base_entry_result, %{
-                         status: :skipped_noop,
-                         reason: "generated output matches existing content",
-                         verification: verification
-                       })
-                 }}
+  defp finalize_candidate_state(context, base_entry_result) do
+    cond do
+      Writer.noop?(Helpers.existing_raw(context.existing), context.candidate.raw) ->
+        {:ok,
+         halted_context(
+           context,
+           base_entry_result,
+           :skipped_noop,
+           "generated output matches existing content",
+           skipped_or_default_verification(context, "verification skipped: generated output is a no-op")
+         )}
 
-              context.apply? ->
-                {:ok,
-                 %{
-                   context
-                   | status: :ready_to_persist,
-                     reason: "candidate ready",
-                     entry_result: base_entry_result
-                 }}
+      context.apply? ->
+        {:ok, ready_to_persist_context(context, base_entry_result)}
 
-              true ->
-                verification =
-                  if context.verify? do
-                    Helpers.skipped_verification("verification skipped: rerun with --apply")
-                  else
-                    Helpers.default_verification()
-                  end
+      true ->
+        {:ok,
+         halted_context(
+           context,
+           base_entry_result,
+           :dry_run_candidate,
+           "dry-run (not applied)",
+           skipped_or_default_verification(context, "verification skipped: rerun with --apply")
+         )}
+    end
+  end
 
-                {:ok,
-                 %{
-                   context
-                   | status: :dry_run_candidate,
-                     reason: "dry-run (not applied)",
-                     verification: verification,
-                     halted?: true,
-                     entry_result:
-                       Map.merge(base_entry_result, %{
-                         status: :dry_run_candidate,
-                         reason: "dry-run (not applied)",
-                         verification: verification
-                       })
-                 }}
-            end
-        end
+  defp ready_to_persist_context(context, base_entry_result) do
+    %{
+      context
+      | status: :ready_to_persist,
+        reason: "candidate ready",
+        entry_result: base_entry_result
+    }
+  end
+
+  defp halted_context(context, base_entry_result, status, reason, verification) do
+    %{
+      context
+      | status: status,
+        reason: reason,
+        verification: verification,
+        halted?: true,
+        entry_result:
+          Map.merge(base_entry_result, %{
+            status: status,
+            reason: reason,
+            verification: verification
+          })
+    }
+  end
+
+  defp skipped_or_default_verification(context, skipped_reason) do
+    if context.verify? do
+      Helpers.skipped_verification(skipped_reason)
+    else
+      Helpers.default_verification()
     end
   end
 

--- a/lib/agent_jido/content_gen/actions/generate_structure_plan.ex
+++ b/lib/agent_jido/content_gen/actions/generate_structure_plan.ex
@@ -31,41 +31,14 @@ defmodule AgentJido.ContentGen.Actions.GenerateStructurePlan do
 
     case generate_object(backend_module, prompt, backend_opts) do
       {:ok, %{object: raw_structure, meta: planner_meta}} ->
-        case Helpers.normalize_structure_plan(raw_structure) do
-          {:ok, structure_plan} ->
-            {:ok,
-             context
-             |> Map.put(:backend_decision, backend_decision)
-             |> Map.put(:backend_module, backend_module)
-             |> Map.put(:prompt_opts, prompt_opts)
-             |> Map.put(:planner_meta, planner_meta)
-             |> Map.put(:structure_plan, structure_plan)}
-
-          {:error, reason} ->
-            case fallback_structure_plan(raw_structure, context.entry, context.target) do
-              {:ok, fallback_plan} ->
-                {:ok,
-                 context
-                 |> Map.put(:backend_decision, backend_decision)
-                 |> Map.put(:backend_module, backend_module)
-                 |> Map.put(:prompt_opts, prompt_opts)
-                 |> Map.put(:planner_meta, Map.put(planner_meta || %{}, :structure_fallback, reason))
-                 |> Map.put(:structure_plan, fallback_plan)}
-
-              {:error, fallback_reason} ->
-                failed =
-                  context
-                  |> Map.put(:backend_decision, backend_decision)
-                  |> Map.put(:backend_module, backend_module)
-                  |> Helpers.halt_with_entry_result(
-                    :generation_failed,
-                    "invalid structure response: #{reason}; fallback failed: #{fallback_reason}",
-                    "generate_structure_plan"
-                  )
-
-                {:ok, failed}
-            end
-        end
+        normalize_generated_structure(
+          context,
+          backend_decision,
+          backend_module,
+          prompt_opts,
+          raw_structure,
+          planner_meta
+        )
 
       {:error, reason} ->
         planner_model = backend_decision.planner_model || "unknown"
@@ -101,6 +74,53 @@ defmodule AgentJido.ContentGen.Actions.GenerateStructurePlan do
   defp with_generation_defaults(opts, defaults) when is_list(defaults) do
     generation_opts = opts |> Keyword.get(:generation_opts, []) |> List.wrap()
     Keyword.put(opts, :generation_opts, Keyword.merge(defaults, generation_opts))
+  end
+
+  defp normalize_generated_structure(
+         context,
+         backend_decision,
+         backend_module,
+         prompt_opts,
+         raw_structure,
+         planner_meta
+       ) do
+    base_context =
+      context
+      |> Map.put(:backend_decision, backend_decision)
+      |> Map.put(:backend_module, backend_module)
+      |> Map.put(:prompt_opts, prompt_opts)
+
+    case Helpers.normalize_structure_plan(raw_structure) do
+      {:ok, structure_plan} ->
+        {:ok,
+         base_context
+         |> Map.put(:planner_meta, planner_meta)
+         |> Map.put(:structure_plan, structure_plan)}
+
+      {:error, reason} ->
+        handle_structure_fallback(base_context, raw_structure, planner_meta, reason)
+    end
+  end
+
+  defp handle_structure_fallback(base_context, raw_structure, planner_meta, reason) do
+    case fallback_structure_plan(raw_structure, base_context.entry, base_context.target) do
+      {:ok, fallback_plan} ->
+        {:ok,
+         base_context
+         |> Map.put(:planner_meta, Map.put(planner_meta || %{}, :structure_fallback, reason))
+         |> Map.put(:structure_plan, fallback_plan)}
+
+      {:error, fallback_reason} ->
+        failed =
+          Helpers.halt_with_entry_result(
+            base_context,
+            :generation_failed,
+            "invalid structure response: #{reason}; fallback failed: #{fallback_reason}",
+            "generate_structure_plan"
+          )
+
+        {:ok, failed}
+    end
   end
 
   defp format_error(%{__exception__: true} = error), do: Exception.message(error)

--- a/lib/agent_jido/content_gen/actions/persist_and_finalize.ex
+++ b/lib/agent_jido/content_gen/actions/persist_and_finalize.ex
@@ -58,40 +58,10 @@ defmodule AgentJido.ContentGen.Actions.PersistAndFinalize do
   defp after_write(context) do
     verify_after_persist? = Map.get(context, :verify_after_persist?, false)
 
-    verification =
-      cond do
-        verify_after_persist? ->
-          run_verification(context)
-
-        context.verify? ->
-          context.verification || Helpers.default_verification()
-
-        true ->
-          context.verification || Helpers.default_verification()
-      end
+    verification = verification_for_persist(context, verify_after_persist?)
 
     if verify_after_persist? and Helpers.verification_failed?(verification) do
-      case Helpers.rollback_failed_conversion(context.target) do
-        :ok ->
-          %{
-            context
-            | status: :verification_failed,
-              reason: "verification checks failed",
-              halted?: true,
-              verification: verification
-          }
-
-        {:error, rollback_reason} ->
-          %{
-            context
-            | status: :generation_failed,
-              reason:
-                "#{verification.command_output_excerpt || "verification failed"} " <>
-                  "(rollback failed: #{rollback_reason})",
-              halted?: true,
-              verification: verification
-          }
-      end
+      verification_failure_context(context, verification)
     else
       case Helpers.maybe_cleanup_converted_source(context.target, verification) do
         :ok ->
@@ -139,32 +109,67 @@ defmodule AgentJido.ContentGen.Actions.PersistAndFinalize do
       context.entry_result ||
         Helpers.base_entry_result(context)
 
-    verification =
-      context.verification ||
-        base[:verification] ||
-        Helpers.default_verification()
-
     base
     |> Map.put(:status, context.status || base[:status] || :unknown)
     |> Map.put(:reason, context.reason || base[:reason])
-    |> Map.put(:verification, verification)
+    |> Map.put(:verification, finalized_verification(context, base))
     |> Map.put(:workflow_step_failures, context.step_failures || [])
-    |> maybe_put(:route, context.target && context.target.route)
-    |> maybe_put(:target_path, context.target && context.target.target_path)
-    |> maybe_put(:read_path, context.target && context.target.read_path)
-    |> maybe_put(:conversion_source_path, context.target && context.target.conversion_source_path)
-    |> maybe_put(:format, context.target && context.target.format)
-    |> maybe_put(:parse_mode, context.parse_mode)
-    |> maybe_put(:backend_meta, context.backend_meta)
-    |> maybe_put(:candidate_path, context.candidate_path)
-    |> maybe_put(:audit, context.audit)
-    |> maybe_put(:diff, context.diff)
-    |> maybe_put(:content_hash, context.candidate && Helpers.content_hash(context.candidate.raw))
-    |> maybe_put(:citations, context.candidate && context.candidate.citations)
-    |> maybe_put(:audit_notes, context.candidate && context.candidate.audit_notes)
-    |> maybe_put(:output_excerpt, context.output_excerpt)
+    |> maybe_put_optional_result_fields(context)
   end
 
   defp maybe_put(map, _key, nil), do: map
   defp maybe_put(map, key, value), do: Map.put(map, key, value)
+
+  defp verification_for_persist(context, true), do: run_verification(context)
+  defp verification_for_persist(context, false), do: context.verification || Helpers.default_verification()
+
+  defp verification_failure_context(context, verification) do
+    case Helpers.rollback_failed_conversion(context.target) do
+      :ok ->
+        %{
+          context
+          | status: :verification_failed,
+            reason: "verification checks failed",
+            halted?: true,
+            verification: verification
+        }
+
+      {:error, rollback_reason} ->
+        %{
+          context
+          | status: :generation_failed,
+            reason:
+              "#{verification.command_output_excerpt || "verification failed"} " <>
+                "(rollback failed: #{rollback_reason})",
+            halted?: true,
+            verification: verification
+        }
+    end
+  end
+
+  defp finalized_verification(context, base) do
+    context.verification ||
+      base[:verification] ||
+      Helpers.default_verification()
+  end
+
+  defp maybe_put_optional_result_fields(result, context) do
+    [
+      {:route, context.target && context.target.route},
+      {:target_path, context.target && context.target.target_path},
+      {:read_path, context.target && context.target.read_path},
+      {:conversion_source_path, context.target && context.target.conversion_source_path},
+      {:format, context.target && context.target.format},
+      {:parse_mode, context.parse_mode},
+      {:backend_meta, context.backend_meta},
+      {:candidate_path, context.candidate_path},
+      {:audit, context.audit},
+      {:diff, context.diff},
+      {:content_hash, context.candidate && Helpers.content_hash(context.candidate.raw)},
+      {:citations, context.candidate && context.candidate.citations},
+      {:audit_notes, context.candidate && context.candidate.audit_notes},
+      {:output_excerpt, context.output_excerpt}
+    ]
+    |> Enum.reduce(result, fn {key, value}, acc -> maybe_put(acc, key, value) end)
+  end
 end

--- a/lib/agent_jido/content_gen/contract.ex
+++ b/lib/agent_jido/content_gen/contract.ex
@@ -4,6 +4,13 @@ defmodule AgentJido.ContentGen.Contract do
   """
 
   @docs_hub_tags [:hub_getting_started, :hub_concepts, :hub_guides, :hub_reference, :hub_operations]
+  @docs_profiles %{
+    :hub_reference => :docs_reference,
+    :hub_guides => :docs_guide,
+    :hub_concepts => :docs_concept,
+    :hub_operations => :docs_operations,
+    :hub_getting_started => :docs_getting_started
+  }
 
   @type profile ::
           :docs_concept
@@ -35,14 +42,15 @@ defmodule AgentJido.ContentGen.Contract do
   def profile(entry, target) do
     hub = docs_hub(entry)
 
-    cond do
-      entry.section == "docs" and hub == :hub_reference -> :docs_reference
-      entry.section == "docs" and hub == :hub_guides -> :docs_guide
-      entry.section == "docs" and hub == :hub_concepts -> :docs_concept
-      entry.section == "docs" and hub == :hub_operations -> :docs_operations
-      entry.section == "docs" and hub == :hub_getting_started -> :docs_getting_started
-      target.format == :livemd -> :livebook_general
-      true -> :general
+    case {entry.section, hub, target.format} do
+      {"docs", docs_hub, _format} when docs_hub in @docs_hub_tags ->
+        Map.fetch!(@docs_profiles, docs_hub)
+
+      {_section, _hub, :livemd} ->
+        :livebook_general
+
+      _other ->
+        :general
     end
   end
 

--- a/lib/agent_jido/content_gen/output_parser.ex
+++ b/lib/agent_jido/content_gen/output_parser.ex
@@ -128,18 +128,20 @@ defmodule AgentJido.ContentGen.OutputParser do
 
   defp normalize_frontmatter(frontmatter) do
     frontmatter
-    |> Enum.reduce(%{}, fn {key, value}, acc ->
-      atom_key = normalize_frontmatter_key(key)
+    |> Enum.reduce(%{}, &normalize_frontmatter_entry/2)
+  end
 
-      if atom_key do
+  defp normalize_frontmatter_entry({key, value}, acc) do
+    case normalize_frontmatter_key(key) do
+      nil ->
+        acc
+
+      atom_key ->
         case normalize_frontmatter_value(atom_key, value) do
           nil -> acc
           normalized -> Map.put(acc, atom_key, normalized)
         end
-      else
-        acc
-      end
-    end)
+    end
   end
 
   defp normalize_frontmatter_key(key) when is_atom(key), do: Map.get(@allowed_frontmatter_keys, Atom.to_string(key))

--- a/lib/agent_jido/content_gen/report.ex
+++ b/lib/agent_jido/content_gen/report.ex
@@ -72,27 +72,30 @@ defmodule AgentJido.ContentGen.Report do
   end
 
   defp accumulate_stats(report, %{status: status}) do
-    key =
-      case status do
-        :written -> :written
-        :dry_run_candidate -> :dry_run_candidates
-        :skipped_noop -> :skipped_noop
-        :skipped_non_file_target -> :skipped_non_file_target
-        :skipped_missing_for_audit -> :skipped_missing_for_audit
-        :audit_only_passed -> :audit_only_passed
-        :audit_failed -> :audit_failed
-        :generation_failed -> :generation_failed
-        :parse_failed -> :parse_failed
-        :churn_blocked -> :churn_blocked
-        :verification_failed -> :verification_failed
-        _other -> nil
-      end
+    key = status_stat_key(status)
 
     if key do
       update_in(report, [:stats, key], &(&1 + 1))
     else
       report
     end
+  end
+
+  defp status_stat_key(status) do
+    %{
+      written: :written,
+      dry_run_candidate: :dry_run_candidates,
+      skipped_noop: :skipped_noop,
+      skipped_non_file_target: :skipped_non_file_target,
+      skipped_missing_for_audit: :skipped_missing_for_audit,
+      audit_only_passed: :audit_only_passed,
+      audit_failed: :audit_failed,
+      generation_failed: :generation_failed,
+      parse_failed: :parse_failed,
+      churn_blocked: :churn_blocked,
+      verification_failed: :verification_failed
+    }
+    |> Map.get(status)
   end
 
   defp accumulate_change_requests(report, %{status: status, target_path: target_path, content_hash: content_hash} = entry_result)

--- a/lib/agent_jido/content_gen/run.ex
+++ b/lib/agent_jido/content_gen/run.ex
@@ -141,12 +141,19 @@ defmodule AgentJido.ContentGen.Run do
 
   defp blocking_failures?(report, apply?, fail_on_audit) do
     stats = report.stats || %{}
+    counts = failure_counts(stats)
 
-    generation_or_parse_failed? = (stats.generation_failed || 0) > 0 or (stats.parse_failed || 0) > 0
-    audit_blocking? = apply? and fail_on_audit and (stats.audit_failed || 0) > 0
-    verification_failed? = (stats.verification_failed || 0) > 0
+    counts.generation_or_parse_failed? or
+      (apply? and fail_on_audit and counts.audit_failed?) or
+      counts.verification_failed?
+  end
 
-    generation_or_parse_failed? or audit_blocking? or verification_failed?
+  defp failure_counts(stats) do
+    %{
+      generation_or_parse_failed?: (stats.generation_failed || 0) > 0 or (stats.parse_failed || 0) > 0,
+      audit_failed?: (stats.audit_failed || 0) > 0,
+      verification_failed?: (stats.verification_failed || 0) > 0
+    }
   end
 
   defp default_run_id do

--- a/lib/agent_jido/content_gen/runic_entry_runner.ex
+++ b/lib/agent_jido/content_gen/runic_entry_runner.ex
@@ -81,24 +81,22 @@ defmodule AgentJido.ContentGen.RunicEntryRunner do
         strat = StratState.get(server_state.agent)
         productions = Workflow.raw_productions(strat.workflow)
 
-        case locate_entry_result(productions) do
-          nil ->
-            case completion do
-              %{status: :failed} ->
-                {:error, "runic workflow failed before producing entry_result"}
-
-              _other ->
-                {:error, "runic workflow completed without entry_result production"}
-            end
-
-          entry_result ->
-            {:ok, normalize_entry_result(entry_result)}
-        end
+        extract_produced_entry_result(productions, completion)
 
       {:error, reason} ->
         {:error, "failed to inspect runic workflow state: #{inspect(reason)}"}
     end
   end
+
+  defp extract_produced_entry_result(productions, completion) do
+    case locate_entry_result(productions) do
+      nil -> missing_entry_result_error(completion)
+      entry_result -> {:ok, normalize_entry_result(entry_result)}
+    end
+  end
+
+  defp missing_entry_result_error(%{status: :failed}), do: {:error, "runic workflow failed before producing entry_result"}
+  defp missing_entry_result_error(_completion), do: {:error, "runic workflow completed without entry_result production"}
 
   defp locate_entry_result(productions) do
     candidates =
@@ -207,33 +205,35 @@ defmodule AgentJido.ContentGen.RunicEntryRunner do
 
   defp status_rank(candidate) do
     status = Map.get(candidate, :status) || Map.get(candidate, "status")
+    Map.get(status_ranks(), status, 50)
+  end
 
-    case status do
-      :written -> 100
-      "written" -> 100
-      :verification_failed -> 95
-      "verification_failed" -> 95
-      :audit_failed -> 90
-      "audit_failed" -> 90
-      :parse_failed -> 90
-      "parse_failed" -> 90
-      :generation_failed -> 90
-      "generation_failed" -> 90
-      :dry_run_candidate -> 80
-      "dry_run_candidate" -> 80
-      :audit_only_passed -> 75
-      "audit_only_passed" -> 75
-      :skipped_noop -> 70
-      "skipped_noop" -> 70
-      :skipped_non_file_target -> 70
-      "skipped_non_file_target" -> 70
-      :ready_to_persist -> 10
-      "ready_to_persist" -> 10
-      :unknown -> 0
-      "unknown" -> 0
-      nil -> 0
-      _other -> 50
-    end
+  defp status_ranks do
+    %{
+      :written => 100,
+      "written" => 100,
+      :verification_failed => 95,
+      "verification_failed" => 95,
+      :audit_failed => 90,
+      "audit_failed" => 90,
+      :parse_failed => 90,
+      "parse_failed" => 90,
+      :generation_failed => 90,
+      "generation_failed" => 90,
+      :dry_run_candidate => 80,
+      "dry_run_candidate" => 80,
+      :audit_only_passed => 75,
+      "audit_only_passed" => 75,
+      :skipped_noop => 70,
+      "skipped_noop" => 70,
+      :skipped_non_file_target => 70,
+      "skipped_non_file_target" => 70,
+      :ready_to_persist => 10,
+      "ready_to_persist" => 10,
+      :unknown => 0,
+      "unknown" => 0,
+      nil => 0
+    }
   end
 
   defp normalize_entry_result(result) do

--- a/lib/agent_jido/content_gen/simple_orchestrator.ex
+++ b/lib/agent_jido/content_gen/simple_orchestrator.ex
@@ -162,30 +162,40 @@ defmodule AgentJido.ContentGen.SimpleOrchestrator do
 
     case ReqLLMBackend.generate(prompt, backend_opts) do
       {:ok, %{text: text}} ->
-        case OutputParser.parse(to_string(text || "")) do
-          {:ok, envelope} ->
-            {:ok, envelope, envelope.parse_mode, writer_model, warnings}
-
-          {:error, parse_reason} ->
-            trimmed = to_string(text || "") |> String.trim()
-
-            if trimmed == "" do
-              {:error, "writer returned empty output and parser failed: #{parse_reason}"}
-            else
-              envelope = %{
-                frontmatter: %{},
-                body_markdown: trimmed <> "\n",
-                citations: [],
-                audit_notes: ["writer_raw_text_fallback"],
-                parse_mode: :fallback_markdown
-              }
-
-              {:ok, envelope, :fallback_markdown, writer_model, warnings ++ ["writer parse fallback used: #{parse_reason}"]}
-            end
-        end
+        parse_generated_draft(text, writer_model, warnings)
 
       {:error, reason} ->
         {:error, "writer call failed: #{normalize_error(reason)}"}
+    end
+  end
+
+  defp parse_generated_draft(text, writer_model, warnings) do
+    raw_text = to_string(text || "")
+
+    case OutputParser.parse(raw_text) do
+      {:ok, envelope} ->
+        {:ok, envelope, envelope.parse_mode, writer_model, warnings}
+
+      {:error, parse_reason} ->
+        fallback_draft(raw_text, parse_reason, writer_model, warnings)
+    end
+  end
+
+  defp fallback_draft(raw_text, parse_reason, writer_model, warnings) do
+    trimmed = String.trim(raw_text)
+
+    if trimmed == "" do
+      {:error, "writer returned empty output and parser failed: #{parse_reason}"}
+    else
+      envelope = %{
+        frontmatter: %{},
+        body_markdown: trimmed <> "\n",
+        citations: [],
+        audit_notes: ["writer_raw_text_fallback"],
+        parse_mode: :fallback_markdown
+      }
+
+      {:ok, envelope, :fallback_markdown, writer_model, warnings ++ ["writer parse fallback used: #{parse_reason}"]}
     end
   end
 

--- a/lib/agent_jido/content_gen/two_pass.ex
+++ b/lib/agent_jido/content_gen/two_pass.ex
@@ -46,30 +46,15 @@ defmodule AgentJido.ContentGen.TwoPass do
           {:ok, structure_plan} ->
             writer_prompt = PromptBuilder.build_writing_pass(entry, target, prompt_opts, structure_plan)
 
-            writer_opts =
-              backend_opts
-              |> Keyword.put(:model, writer_model)
-              |> Keyword.put(:system_prompt, @writer_system_prompt)
-              |> with_generation_defaults(temperature: 0.2)
-
-            case backend_module.generate(writer_prompt, writer_opts) do
-              {:ok, %{text: text, meta: writer_meta}} ->
-                meta =
-                  writer_meta
-                  |> Map.merge(%{
-                    backend: :req_llm,
-                    mode: :two_pass,
-                    planner_model: planner_model_used,
-                    writer_model: writer_model,
-                    planner_meta: planner_meta,
-                    structure_plan: structure_plan
-                  })
-
-                {:ok, %{text: text, meta: meta}}
-
-              {:error, reason} ->
-                {:error, "writing pass failed: #{format_error(reason)}"}
-            end
+            run_writer_pass(
+              backend_module,
+              writer_prompt,
+              backend_opts,
+              writer_model,
+              planner_model_used,
+              planner_meta,
+              structure_plan
+            )
 
           {:error, reason} ->
             run_single_pass_fallback(
@@ -120,6 +105,41 @@ defmodule AgentJido.ContentGen.TwoPass do
 
       {:error, fallback_reason} ->
         {:error, "#{reason}; single-pass fallback failed: #{format_error(fallback_reason)}"}
+    end
+  end
+
+  defp run_writer_pass(
+         backend_module,
+         writer_prompt,
+         backend_opts,
+         writer_model,
+         planner_model_used,
+         planner_meta,
+         structure_plan
+       ) do
+    writer_opts =
+      backend_opts
+      |> Keyword.put(:model, writer_model)
+      |> Keyword.put(:system_prompt, @writer_system_prompt)
+      |> with_generation_defaults(temperature: 0.2)
+
+    case backend_module.generate(writer_prompt, writer_opts) do
+      {:ok, %{text: text, meta: writer_meta}} ->
+        meta =
+          writer_meta
+          |> Map.merge(%{
+            backend: :req_llm,
+            mode: :two_pass,
+            planner_model: planner_model_used,
+            writer_model: writer_model,
+            planner_meta: planner_meta,
+            structure_plan: structure_plan
+          })
+
+        {:ok, %{text: text, meta: meta}}
+
+      {:error, reason} ->
+        {:error, "writing pass failed: #{format_error(reason)}"}
     end
   end
 

--- a/lib/agent_jido/content_gen/verify.ex
+++ b/lib/agent_jido/content_gen/verify.ex
@@ -121,6 +121,11 @@ defmodule AgentJido.ContentGen.Verify do
         {"failed", nil, "livebook verification requires at least one ```elixir code cell"}
 
       true ->
+        livebook_test_result = fn
+          _output, 0, livebook_test_file -> {"passed", livebook_test_file, nil}
+          output, _exit_code, livebook_test_file -> {"failed", livebook_test_file, excerpt_output(output)}
+        end
+
         case test_generator.ensure_test_file(target.target_path, target.route) do
           {:error, reason} ->
             {"failed", nil, reason}
@@ -134,11 +139,7 @@ defmodule AgentJido.ContentGen.Verify do
                 stderr_to_stdout: true
               )
 
-            if exit_code == 0 do
-              {"passed", livebook_test_file, nil}
-            else
-              {"failed", livebook_test_file, excerpt_output(output)}
-            end
+            livebook_test_result.(output, exit_code, livebook_test_file)
         end
     end
   end

--- a/lib/agent_jido/content_ingest/ingestor.ex
+++ b/lib/agent_jido/content_ingest/ingestor.ex
@@ -296,15 +296,15 @@ defmodule AgentJido.ContentIngest.Ingestor do
         value
 
       :error ->
-        Enum.find_value(metadata, fn
-          {atom_key, value} when is_atom(atom_key) ->
-            if Atom.to_string(atom_key) == key, do: value
-
-          _other ->
-            nil
-        end)
+        Enum.find_value(metadata, &string_key_value(&1, key))
     end
   end
+
+  defp string_key_value({atom_key, value}, key) when is_atom(atom_key) do
+    if Atom.to_string(atom_key) == key, do: value
+  end
+
+  defp string_key_value(_entry, _key), do: nil
 
   defp require_repo!(opts) do
     Keyword.get(opts, :repo) ||

--- a/lib/agent_jido/content_ontology/exporter.ex
+++ b/lib/agent_jido/content_ontology/exporter.ex
@@ -527,30 +527,12 @@ defmodule AgentJido.ContentOntology.Exporter do
       doc_qn = Map.fetch!(web_doc_uri_by_id, doc.id)
       source_qn = Map.get(source_uri_by_path, doc.source_path)
 
-      acc =
-        if source_qn do
-          acc
-          |> add_obj(doc_qn, "ajc:hasSourceDocument", source_qn)
-          |> add_obj(source_qn, "ajc:isSourceFor", doc_qn)
-        else
-          acc
-        end
+      acc = maybe_link_source_document(acc, doc_qn, source_qn)
 
       route = normalize_route(doc.route)
       entries = Map.get(plan_by_route, route, [])
 
-      Enum.reduce(entries, acc, fn entry, inner ->
-        plan_qn = Map.get(plan_uri_by_id, entry.id)
-
-        if plan_qn do
-          inner
-          |> maybe_promote_to_generated(doc_qn)
-          |> add_obj(doc_qn, "ajc:generatedFromPlanEntry", plan_qn)
-          |> add_obj(plan_qn, "ajc:isSourceFor", doc_qn)
-        else
-          inner
-        end
-      end)
+      Enum.reduce(entries, acc, &link_plan_entry(&2, &1, plan_uri_by_id, doc_qn))
     end)
   end
 
@@ -760,22 +742,7 @@ defmodule AgentJido.ContentOntology.Exporter do
         doc_qn = Map.fetch!(web_doc_uri_by_id, doc.id)
         source_qn = Map.get(source_uri_by_path, doc.source_path)
 
-        Enum.reduce(doc.tags, acc, fn tag, inner ->
-          tag_qn = tag_qname(tag)
-
-          inner =
-            inner
-            |> add_obj(doc_qn, "ajc:hasTag", tag_qn)
-            |> add_obj(tag_qn, "ajc:tagsResource", doc_qn)
-
-          if source_qn do
-            inner
-            |> add_obj(source_qn, "ajc:hasTag", tag_qn)
-            |> add_obj(tag_qn, "ajc:tagsResource", source_qn)
-          else
-            inner
-          end
-        end)
+        Enum.reduce(doc.tags, acc, &attach_doc_tag(&2, &1, doc_qn, source_qn))
       end)
 
     Enum.reduce(plan_entries, set, fn entry, acc ->
@@ -1031,12 +998,7 @@ defmodule AgentJido.ContentOntology.Exporter do
         |> Enum.reject(&is_nil/1)
         |> Enum.uniq()
 
-      Enum.find_value(route_candidates, fn route ->
-        case Map.get(web_by_route, route) do
-          nil -> nil
-          doc -> Map.get(web_doc_uri_by_id, doc.id)
-        end
-      end)
+      Enum.find_value(route_candidates, &package_target_qname(&1, web_by_route, web_doc_uri_by_id))
     end
   end
 
@@ -1085,35 +1047,51 @@ defmodule AgentJido.ContentOntology.Exporter do
   defp collection_qname(_), do: "ajc:collection_priv_pages"
 
   defp concept_qname(prefix, value, _class_qname) do
-    base = "ajc:#{prefix}_#{safe_token(to_string(value))}"
+    "ajc:#{prefix}_#{safe_token(to_string(value))}"
+  end
 
-    case base do
-      "ajc:doc_type_guide" -> "ajc:doc_type_guide"
-      "ajc:doc_type_reference" -> "ajc:doc_type_reference"
-      "ajc:doc_type_tutorial" -> "ajc:doc_type_tutorial"
-      "ajc:doc_type_explanation" -> "ajc:doc_type_explanation"
-      "ajc:doc_type_cookbook" -> "ajc:doc_type_cookbook"
-      "ajc:audience_beginner" -> "ajc:audience_beginner"
-      "ajc:audience_intermediate" -> "ajc:audience_intermediate"
-      "ajc:audience_advanced" -> "ajc:audience_advanced"
-      "ajc:audience_general" -> "ajc:audience_general"
-      "ajc:difficulty_beginner" -> "ajc:difficulty_beginner"
-      "ajc:difficulty_intermediate" -> "ajc:difficulty_intermediate"
-      "ajc:difficulty_advanced" -> "ajc:difficulty_advanced"
-      "ajc:track_foundations" -> "ajc:track_foundations"
-      "ajc:track_coordination" -> "ajc:track_coordination"
-      "ajc:track_integration" -> "ajc:track_integration"
-      "ajc:track_operations" -> "ajc:track_operations"
-      "ajc:status_planned" -> "ajc:status_planned"
-      "ajc:status_outline" -> "ajc:status_outline"
-      "ajc:status_draft" -> "ajc:status_draft"
-      "ajc:status_review" -> "ajc:status_review"
-      "ajc:status_published" -> "ajc:status_published"
-      "ajc:priority_critical" -> "ajc:priority_critical"
-      "ajc:priority_high" -> "ajc:priority_high"
-      "ajc:priority_medium" -> "ajc:priority_medium"
-      "ajc:priority_low" -> "ajc:priority_low"
-      _ -> base
+  defp maybe_link_source_document(acc, _doc_qn, nil), do: acc
+
+  defp maybe_link_source_document(acc, doc_qn, source_qn) do
+    acc
+    |> add_obj(doc_qn, "ajc:hasSourceDocument", source_qn)
+    |> add_obj(source_qn, "ajc:isSourceFor", doc_qn)
+  end
+
+  defp link_plan_entry(inner, entry, plan_uri_by_id, doc_qn) do
+    case Map.get(plan_uri_by_id, entry.id) do
+      nil ->
+        inner
+
+      plan_qn ->
+        inner
+        |> maybe_promote_to_generated(doc_qn)
+        |> add_obj(doc_qn, "ajc:generatedFromPlanEntry", plan_qn)
+        |> add_obj(plan_qn, "ajc:isSourceFor", doc_qn)
+    end
+  end
+
+  defp attach_doc_tag(inner, tag, doc_qn, source_qn) do
+    tag_qn = tag_qname(tag)
+
+    inner
+    |> add_obj(doc_qn, "ajc:hasTag", tag_qn)
+    |> add_obj(tag_qn, "ajc:tagsResource", doc_qn)
+    |> maybe_attach_source_tag(source_qn, tag_qn)
+  end
+
+  defp maybe_attach_source_tag(inner, nil, _tag_qn), do: inner
+
+  defp maybe_attach_source_tag(inner, source_qn, tag_qn) do
+    inner
+    |> add_obj(source_qn, "ajc:hasTag", tag_qn)
+    |> add_obj(tag_qn, "ajc:tagsResource", source_qn)
+  end
+
+  defp package_target_qname(route, web_by_route, web_doc_uri_by_id) do
+    case Map.get(web_by_route, route) do
+      nil -> nil
+      doc -> Map.get(web_doc_uri_by_id, doc.id)
     end
   end
 
@@ -1192,18 +1170,8 @@ defmodule AgentJido.ContentOntology.Exporter do
   end
 
   defp normalize_package_version_requirement(entry) when is_map(entry) do
-    package_ref =
-      map_value(entry, :package) ||
-        map_value(entry, :package_id) ||
-        map_value(entry, :id) ||
-        map_value(entry, :name) ||
-        map_value(entry, :library)
-
-    constraint =
-      map_value(entry, :version) ||
-        map_value(entry, :constraint) ||
-        map_value(entry, :requirement) ||
-        map_value(entry, :min_version)
+    package_ref = requirement_package_ref(entry)
+    constraint = requirement_constraint(entry)
 
     cond do
       package_ref ->
@@ -1292,31 +1260,9 @@ defmodule AgentJido.ContentOntology.Exporter do
         nil
 
       true ->
-        route =
-          case URI.parse(trimmed) do
-            %URI{path: nil} -> trimmed
-            %URI{path: path} -> path
-          end
-
-        route =
-          route
-          |> String.replace(~r/[?#].*$/, "")
-          |> case do
-            "" ->
-              "/"
-
-            "/" = root ->
-              root
-
-            path ->
-              if String.starts_with?(path, "/") do
-                String.trim_trailing(path, "/")
-              else
-                "/" <> String.trim_trailing(path, "/")
-              end
-          end
-
-        if route == "", do: "/", else: route
+        trimmed
+        |> route_path_from_uri()
+        |> normalize_route_path()
     end
   end
 
@@ -1341,13 +1287,7 @@ defmodule AgentJido.ContentOntology.Exporter do
       {:ok, nodes} ->
         nodes
         |> Floki.find("a[href]")
-        |> Enum.map(fn {_tag, attrs, _children} ->
-          attrs
-          |> Enum.find_value(fn
-            {"href", href} -> href
-            _ -> nil
-          end)
-        end)
+        |> Enum.map(&extract_href/1)
         |> Enum.map(&normalize_internal_href/1)
         |> Enum.reject(&is_nil/1)
 
@@ -1357,6 +1297,48 @@ defmodule AgentJido.ContentOntology.Exporter do
   end
 
   defp extract_internal_routes(_), do: []
+
+  defp requirement_package_ref(entry) do
+    map_value(entry, :package) ||
+      map_value(entry, :package_id) ||
+      map_value(entry, :id) ||
+      map_value(entry, :name) ||
+      map_value(entry, :library)
+  end
+
+  defp requirement_constraint(entry) do
+    map_value(entry, :version) ||
+      map_value(entry, :constraint) ||
+      map_value(entry, :requirement) ||
+      map_value(entry, :min_version)
+  end
+
+  defp route_path_from_uri(trimmed) do
+    case URI.parse(trimmed) do
+      %URI{path: nil} -> trimmed
+      %URI{path: path} -> path
+    end
+  end
+
+  defp normalize_route_path(route) do
+    route
+    |> String.replace(~r/[?#].*$/, "")
+    |> case do
+      "" -> "/"
+      "/" = root -> root
+      path -> ensure_leading_slash(String.trim_trailing(path, "/"))
+    end
+  end
+
+  defp ensure_leading_slash("/" <> _ = path), do: path
+  defp ensure_leading_slash(path), do: "/" <> path
+
+  defp extract_href({_tag, attrs, _children}) do
+    Enum.find_value(attrs, fn
+      {"href", href} -> href
+      _ -> nil
+    end)
+  end
 
   defp normalize_internal_href(nil), do: nil
 

--- a/lib/agent_jido/content_ops/chat/bridge.ex
+++ b/lib/agent_jido/content_ops/chat/bridge.ex
@@ -68,11 +68,7 @@ defmodule AgentJido.ContentOps.Chat.Bridge do
       text = format_message(message)
 
       unless text == "" do
-        Enum.each(bindings, fn binding ->
-          if should_forward?(binding, origin_channel) do
-            send_to_binding(binding, text, state)
-          end
-        end)
+        Enum.each(bindings, &maybe_forward_binding(&1, origin_channel, text, state))
       end
     end
 
@@ -83,6 +79,12 @@ defmodule AgentJido.ContentOps.Chat.Bridge do
 
   defp should_forward?(binding, origin_channel) do
     binding.enabled != false and normalize_channel(binding.channel) != origin_channel
+  end
+
+  defp maybe_forward_binding(binding, origin_channel, text, state) do
+    if should_forward?(binding, origin_channel) do
+      send_to_binding(binding, text, state)
+    end
   end
 
   defp send_to_binding(%{channel: :telegram, external_room_id: external_id}, text, state) do

--- a/lib/agent_jido/content_ops/chat/router.ex
+++ b/lib/agent_jido/content_ops/chat/router.ex
@@ -49,25 +49,9 @@ defmodule AgentJido.ContentOps.Chat.Router do
           | {:error, :unknown}
   def parse_command(text, prefix) when is_binary(text) and is_binary(prefix) do
     if command_message?(text, prefix) do
-      args =
-        text
-        |> String.trim()
-        |> String.trim_leading(prefix)
-        |> String.trim()
-        |> String.split(~r/\s+/, trim: true)
-
-      case args do
-        [] -> {:ok, :help}
-        ["help"] -> {:ok, :help}
-        ["status"] -> {:ok, :status}
-        ["recent-runs"] -> {:ok, :recent_runs}
-        ["coverage"] -> {:ok, :coverage}
-        ["issue" | rest] when rest != [] -> {:ok, {:issue, Enum.join(rest, " ")}}
-        ["note" | rest] when rest != [] -> {:ok, {:note, Enum.join(rest, " ")}}
-        ["ask" | rest] when rest != [] -> {:ok, {:ask, Enum.join(rest, " ")}}
-        ["run", mode] -> parse_mode(mode)
-        _other -> {:error, :unknown}
-      end
+      text
+      |> command_args(prefix)
+      |> parse_command_args()
     else
       {:error, :unknown}
     end
@@ -80,39 +64,56 @@ defmodule AgentJido.ContentOps.Chat.Router do
   defp parse_mode(_other), do: {:error, :unknown}
 
   defp handle_command_message(text, message, context, cfg) do
-    case parse_command(text, cfg.command_prefix) do
-      {:ok, :help} ->
-        {:reply, help_text(cfg.command_prefix)}
-
-      {:ok, :status} ->
-        {:reply, status_text()}
-
-      {:ok, :recent_runs} ->
-        {:reply, recent_runs_text()}
-
-      {:ok, :coverage} ->
-        {:reply, coverage_text()}
-
-      {:ok, {:run, mode}} ->
-        run_command(mode, context)
-
-      {:ok, {:issue, request}} ->
-        prompt = "Create a GitHub issue for this project using this request:\n\n#{request}"
-        handle_ops_message(prompt, message, context, cfg)
-
-      {:ok, {:note, request}} ->
-        prompt =
-          "Add a documentation note. If a page reference is ambiguous, ask for clarification.\n\n#{request}"
-
-        handle_ops_message(prompt, message, context, cfg)
-
-      {:ok, {:ask, prompt}} ->
-        handle_ops_message(prompt, message, context, cfg)
-
-      {:error, :unknown} ->
-        {:reply, "Unknown command. Try #{cfg.command_prefix} help"}
-    end
+    text
+    |> parse_command(cfg.command_prefix)
+    |> command_response(message, context, cfg)
   end
+
+  defp command_args(text, prefix) do
+    text
+    |> String.trim()
+    |> String.trim_leading(prefix)
+    |> String.trim()
+    |> String.split(~r/\s+/, trim: true)
+  end
+
+  defp parse_command_args([]), do: {:ok, :help}
+  defp parse_command_args(["help"]), do: {:ok, :help}
+  defp parse_command_args(["status"]), do: {:ok, :status}
+  defp parse_command_args(["recent-runs"]), do: {:ok, :recent_runs}
+  defp parse_command_args(["coverage"]), do: {:ok, :coverage}
+  defp parse_command_args(["issue" | rest]) when rest != [], do: {:ok, {:issue, Enum.join(rest, " ")}}
+  defp parse_command_args(["note" | rest]) when rest != [], do: {:ok, {:note, Enum.join(rest, " ")}}
+  defp parse_command_args(["ask" | rest]) when rest != [], do: {:ok, {:ask, Enum.join(rest, " ")}}
+  defp parse_command_args(["run", mode]), do: parse_mode(mode)
+  defp parse_command_args(_args), do: {:error, :unknown}
+
+  defp handle_ops_request(prefix, request, message, context, cfg) do
+    handle_ops_message(prefix <> request, message, context, cfg)
+  end
+
+  defp command_response({:ok, :help}, _message, _context, cfg), do: {:reply, help_text(cfg.command_prefix)}
+  defp command_response({:ok, :status}, _message, _context, _cfg), do: {:reply, status_text()}
+  defp command_response({:ok, :recent_runs}, _message, _context, _cfg), do: {:reply, recent_runs_text()}
+  defp command_response({:ok, :coverage}, _message, _context, _cfg), do: {:reply, coverage_text()}
+  defp command_response({:ok, {:run, mode}}, _message, context, _cfg), do: run_command(mode, context)
+
+  defp command_response({:ok, {:issue, request}}, message, context, cfg) do
+    handle_ops_request("Create a GitHub issue for this project using this request:\n\n", request, message, context, cfg)
+  end
+
+  defp command_response({:ok, {:note, request}}, message, context, cfg) do
+    handle_ops_request(
+      "Add a documentation note. If a page reference is ambiguous, ask for clarification.\n\n",
+      request,
+      message,
+      context,
+      cfg
+    )
+  end
+
+  defp command_response({:ok, {:ask, prompt}}, message, context, cfg), do: handle_ops_message(prompt, message, context, cfg)
+  defp command_response({:error, :unknown}, _message, _context, cfg), do: {:reply, "Unknown command. Try #{cfg.command_prefix} help"}
 
   defp handle_ops_message(prompt, message, context, cfg) do
     tool_context = build_tool_context(message, context, cfg)

--- a/lib/agent_jido/github_stars_tracker.ex
+++ b/lib/agent_jido/github_stars_tracker.ex
@@ -269,33 +269,7 @@ defmodule AgentJido.GithubStarsTracker do
             {state.stars_map, 0, 0, false, state},
             fn {package_id, repo_ref}, {acc, success, failure, _halted, state_acc} ->
               {result, state_after_fetch} = fetch_repo_stars(state_acc, repo_ref)
-
-              case result do
-                {:ok, stars} when is_integer(stars) and stars >= 0 ->
-                  updated_entry = %{stars: stars, updated_at: now}
-
-                  {:cont, {Map.put(acc, package_id, updated_entry), success + 1, failure, false, state_after_fetch}}
-
-                {:error, reason} ->
-                  Logger.warning(
-                    "[GithubStarsTracker] fetch failed package=#{package_id} repo=#{repo_ref.owner}/#{repo_ref.repo} reason=#{inspect(reason)}"
-                  )
-
-                  if rate_limited_reason?(reason) do
-                    cooldown_until =
-                      System.monotonic_time(:millisecond) +
-                        state_after_fetch.rate_limit_cooldown_ms
-
-                    state_with_cooldown = %{
-                      state_after_fetch
-                      | rate_limit_reset_monotonic_ms: cooldown_until
-                    }
-
-                    {:halt, {acc, success, failure + 1, true, state_with_cooldown}}
-                  else
-                    {:cont, {acc, success, failure + 1, false, state_after_fetch}}
-                  end
-              end
+              handle_refresh_result(result, package_id, repo_ref, now, acc, success, failure, state_after_fetch)
             end
           )
 
@@ -305,6 +279,61 @@ defmodule AgentJido.GithubStarsTracker do
 
         %{next_state | stars_map: next_stars_map, last_refresh_at: now}
     end
+  end
+
+  defp handle_refresh_error(package_id, repo_ref, reason, acc, success, failure, state_after_fetch) do
+    Logger.warning("[GithubStarsTracker] fetch failed package=#{package_id} repo=#{repo_ref.owner}/#{repo_ref.repo} reason=#{inspect(reason)}")
+
+    if rate_limited_reason?(reason) do
+      cooldown_until =
+        System.monotonic_time(:millisecond) +
+          state_after_fetch.rate_limit_cooldown_ms
+
+      state_with_cooldown = %{
+        state_after_fetch
+        | rate_limit_reset_monotonic_ms: cooldown_until
+      }
+
+      {:halt, {acc, success, failure + 1, true, state_with_cooldown}}
+    else
+      {:cont, {acc, success, failure + 1, false, state_after_fetch}}
+    end
+  end
+
+  defp handle_refresh_result(
+         {:ok, stars},
+         package_id,
+         _repo_ref,
+         now,
+         acc,
+         success,
+         failure,
+         state_after_fetch
+       )
+       when is_integer(stars) and stars >= 0 do
+    updated_entry = %{stars: stars, updated_at: now}
+    {:cont, {Map.put(acc, package_id, updated_entry), success + 1, failure, false, state_after_fetch}}
+  end
+
+  defp handle_refresh_result(
+         {:error, reason},
+         package_id,
+         repo_ref,
+         _now,
+         acc,
+         success,
+         failure,
+         state_after_fetch
+       ) do
+    handle_refresh_error(
+      package_id,
+      repo_ref,
+      reason,
+      acc,
+      success,
+      failure,
+      state_after_fetch
+    )
   end
 
   defp build_repo_map(packages, repo_cache_timeout_ms) when is_list(packages) and is_map(repo_cache_timeout_ms) do

--- a/lib/agent_jido/landing_content.ex
+++ b/lib/agent_jido/landing_content.ex
@@ -189,20 +189,23 @@ defmodule AgentJido.LandingContent do
       |> String.downcase()
       |> String.replace("_", " ")
 
-    case normalized do
-      "opentelemetry" -> "observability"
-      "telemetry" -> "observability"
-      "tracing" -> "observability"
-      "discord" -> "messaging"
-      "slack" -> "messaging"
-      "telegram" -> "messaging"
-      "whatsapp" -> "messaging"
-      "chat" -> "messaging"
-      value -> value
-    end
+    Map.get(tag_aliases(), normalized, normalized)
   end
 
   defp normalize_tag(_tag), do: ""
+
+  defp tag_aliases do
+    %{
+      "opentelemetry" => "observability",
+      "telemetry" => "observability",
+      "tracing" => "observability",
+      "discord" => "messaging",
+      "slack" => "messaging",
+      "telegram" => "messaging",
+      "whatsapp" => "messaging",
+      "chat" => "messaging"
+    }
+  end
 
   defp build_links(pkg) do
     %{}

--- a/lib/agent_jido/og_image.ex
+++ b/lib/agent_jido/og_image.ex
@@ -61,21 +61,32 @@ defmodule AgentJido.OGImage do
         generator_fn.()
 
       _table ->
-        case :ets.lookup(@ets_table, cache_key) do
-          [{^cache_key, png_data, expires_at}] when expires_at > now ->
+        case cached_png(cache_key, now) do
+          {:ok, png_data} ->
             {:ok, png_data}
 
-          _ ->
-            case generator_fn.() do
-              {:ok, png_data} ->
-                expires_at = now + cache_ttl_ms()
-                :ets.insert(@ets_table, {cache_key, png_data, expires_at})
-                {:ok, png_data}
-
-              error ->
-                error
-            end
+          :miss ->
+            generate_and_cache_png(cache_key, now, generator_fn)
         end
+    end
+  end
+
+  defp cached_png(cache_key, now) do
+    case :ets.lookup(@ets_table, cache_key) do
+      [{^cache_key, png_data, expires_at}] when expires_at > now -> {:ok, png_data}
+      _other -> :miss
+    end
+  end
+
+  defp generate_and_cache_png(cache_key, now, generator_fn) do
+    case generator_fn.() do
+      {:ok, png_data} ->
+        expires_at = now + cache_ttl_ms()
+        :ets.insert(@ets_table, {cache_key, png_data, expires_at})
+        {:ok, png_data}
+
+      error ->
+        error
     end
   end
 

--- a/lib/agent_jido/og_image/resolver.ex
+++ b/lib/agent_jido/og_image/resolver.ex
@@ -215,42 +215,45 @@ defmodule AgentJido.OGImage.Resolver do
         nil
 
       [_, id] ->
-        case Ecosystem.get_public_package(id) do
-          nil ->
-            nil
-
-          package ->
-            title = package.title |> to_string() |> String.trim()
-
-            subtitle =
-              package.landing_summary
-              |> to_string()
-              |> String.trim()
-              |> case do
-                "" -> package.tagline |> to_string() |> String.trim()
-                value -> value
-              end
-
-            badges =
-              [Atom.to_string(package.category), package.version, Atom.to_string(package.maturity)]
-              |> Enum.reject(&(&1 in [nil, ""]))
-              |> Enum.take(5)
-
-            build_descriptor(%{
-              template: :ecosystem_package,
-              resolved_path: path,
-              title: title,
-              subtitle: subtitle,
-              eyebrow: "ECOSYSTEM PACKAGE",
-              badges: badges,
-              footer_path: path,
-              content_hash: hash_from([path, title, subtitle, package.version || "", inspect(badges)])
-            })
-        end
+        id
+        |> Ecosystem.get_public_package()
+        |> build_ecosystem_package_descriptor(path)
 
       _ ->
         nil
     end
+  end
+
+  defp build_ecosystem_package_descriptor(nil, _path), do: nil
+
+  defp build_ecosystem_package_descriptor(package, path) do
+    title = package.title |> to_string() |> String.trim()
+    subtitle = package_subtitle(package)
+    badges = ecosystem_badges(package)
+
+    build_descriptor(%{
+      template: :ecosystem_package,
+      resolved_path: path,
+      title: title,
+      subtitle: subtitle,
+      eyebrow: "ECOSYSTEM PACKAGE",
+      badges: badges,
+      footer_path: path,
+      content_hash: hash_from([path, title, subtitle, package.version || "", inspect(badges)])
+    })
+  end
+
+  defp package_subtitle(package) do
+    case package.landing_summary |> to_string() |> String.trim() do
+      "" -> package.tagline |> to_string() |> String.trim()
+      value -> value
+    end
+  end
+
+  defp ecosystem_badges(package) do
+    [Atom.to_string(package.category), package.version, Atom.to_string(package.maturity)]
+    |> Enum.reject(&(&1 in [nil, ""]))
+    |> Enum.take(5)
   end
 
   defp page_descriptor(path) do

--- a/lib/agent_jido/og_image/templates.ex
+++ b/lib/agent_jido/og_image/templates.ex
@@ -302,23 +302,34 @@ defmodule AgentJido.OGImage.Templates do
   end
 
   defp layout_text(text, font_sizes, max_width, max_lines) do
-    value = normalize_text(text)
+    case normalize_text(text) do
+      "" ->
+        %{font_size: List.last(font_sizes), lines: []}
 
-    if value == "" do
-      %{font_size: List.last(font_sizes), lines: []}
+      value ->
+        find_best_text_layout(value, font_sizes, max_width, max_lines)
+    end
+  end
+
+  defp find_best_text_layout(value, font_sizes, max_width, max_lines) do
+    case Enum.find_value(font_sizes, &layout_for_font_size(value, &1, max_width, max_lines)) do
+      nil ->
+        smallest = List.last(font_sizes)
+        {lines, _overflow?} = wrap_text(value, smallest, max_width, max_lines, true)
+        %{font_size: smallest, lines: lines}
+
+      layout ->
+        layout
+    end
+  end
+
+  defp layout_for_font_size(value, size, max_width, max_lines) do
+    {lines, overflow?} = wrap_text(value, size, max_width, max_lines, false)
+
+    if overflow? do
+      nil
     else
-      case Enum.find_value(font_sizes, fn size ->
-             {lines, overflow?} = wrap_text(value, size, max_width, max_lines, false)
-             if overflow?, do: nil, else: %{font_size: size, lines: lines}
-           end) do
-        nil ->
-          smallest = List.last(font_sizes)
-          {lines, _overflow?} = wrap_text(value, smallest, max_width, max_lines, true)
-          %{font_size: smallest, lines: lines}
-
-        layout ->
-          layout
-      end
+      %{font_size: size, lines: lines}
     end
   end
 
@@ -351,25 +362,29 @@ defmodule AgentJido.OGImage.Templates do
       {chunks, current} =
         token
         |> String.graphemes()
-        |> Enum.reduce({[], ""}, fn grapheme, {acc, current} ->
-          candidate = current <> grapheme
+        |> Enum.reduce({[], ""}, &split_token_grapheme(&1, &2, font_size, max_width))
 
-          cond do
-            current == "" ->
-              {acc, candidate}
-
-            fits_width?(candidate, font_size, max_width) ->
-              {acc, candidate}
-
-            true ->
-              {[current | acc], grapheme}
-          end
-        end)
-
-      chunks = if current == "", do: chunks, else: [current | chunks]
-      Enum.reverse(chunks)
+      finish_split_token(chunks, current)
     end
   end
+
+  defp split_token_grapheme(grapheme, {acc, current}, font_size, max_width) do
+    candidate = current <> grapheme
+
+    cond do
+      current == "" ->
+        {acc, candidate}
+
+      fits_width?(candidate, font_size, max_width) ->
+        {acc, candidate}
+
+      true ->
+        {[current | acc], grapheme}
+    end
+  end
+
+  defp finish_split_token(chunks, ""), do: Enum.reverse(chunks)
+  defp finish_split_token(chunks, current), do: Enum.reverse([current | chunks])
 
   defp wrap_tokens(tokens, font_size, max_width, max_lines) do
     do_wrap_tokens(tokens, font_size, max_width, max_lines, [], "", 0)

--- a/lib/agent_jido/pages.ex
+++ b/lib/agent_jido/pages.ex
@@ -257,21 +257,19 @@ defmodule AgentJido.Pages do
   def resolve_page_for_path(path) do
     normalized = normalize_path_lookup(path)
 
-    case Map.get(@pages_by_path, normalized) do
-      %Page{} = page ->
-        {:ok, page, :canonical}
+    resolve_page_lookup(normalized, [
+      {@pages_by_path, :canonical},
+      {@pages_by_legacy_path, :legacy},
+      {@pages_by_route, :route_alias}
+    ])
+  end
 
-      nil ->
-        case Map.get(@pages_by_legacy_path, normalized) do
-          %Page{} = page ->
-            {:ok, page, :legacy}
+  defp resolve_page_lookup(_path, []), do: :error
 
-          nil ->
-            case Map.get(@pages_by_route, normalized) do
-              %Page{} = page -> {:ok, page, :route_alias}
-              nil -> :error
-            end
-        end
+  defp resolve_page_lookup(path, [{lookup, match_type} | rest]) do
+    case Map.get(lookup, path) do
+      %Page{} = page -> {:ok, page, match_type}
+      nil -> resolve_page_lookup(path, rest)
     end
   end
 

--- a/lib/agent_jido/pages/livebook_parser.ex
+++ b/lib/agent_jido/pages/livebook_parser.ex
@@ -195,40 +195,41 @@ defmodule AgentJido.Pages.LivebookParser do
       {:learning_outcomes, &is_list/1, "must be a list"}
     ]
 
-    Enum.each(validations, fn {key, validator, message} ->
-      if Map.has_key?(attrs, key) do
-        value = Map.get(attrs, key)
-
-        unless validator.(value) do
-          raise ArgumentError,
-                "Invalid frontmatter in #{inspect(path)}: #{key} #{message}, got: #{inspect(value)}"
-        end
-      end
-    end)
-
-    if Map.has_key?(attrs, :menu_label) do
-      unless is_binary(attrs.menu_label) do
-        raise ArgumentError,
-              "Invalid frontmatter in #{inspect(path)}: menu_label must be a string"
-      end
-    end
-
-    if Map.has_key?(attrs, :og_image) do
-      unless is_binary(attrs.og_image) do
-        raise ArgumentError,
-              "Invalid frontmatter in #{inspect(path)}: og_image must be a string"
-      end
-    end
-
-    if Map.has_key?(attrs, :legacy_paths) do
-      Enum.each(attrs.legacy_paths, fn legacy_path ->
-        unless is_binary(legacy_path) and String.starts_with?(legacy_path, "/") do
-          raise ArgumentError,
-                "Invalid frontmatter in #{inspect(path)}: legacy_paths entries must be strings starting with '/'"
-        end
-      end)
-    end
+    Enum.each(validations, &validate_attr_type(attrs, path, &1))
+    validate_optional_string(attrs, path, :menu_label)
+    validate_optional_string(attrs, path, :og_image)
+    validate_legacy_paths(attrs, path)
 
     attrs
+  end
+
+  defp validate_attr_type(attrs, path, {key, validator, message}) do
+    if Map.has_key?(attrs, key) do
+      value = Map.get(attrs, key)
+
+      unless validator.(value) do
+        raise ArgumentError,
+              "Invalid frontmatter in #{inspect(path)}: #{key} #{message}, got: #{inspect(value)}"
+      end
+    end
+  end
+
+  defp validate_optional_string(attrs, path, key) do
+    if Map.has_key?(attrs, key) and not is_binary(Map.fetch!(attrs, key)) do
+      raise ArgumentError, "Invalid frontmatter in #{inspect(path)}: #{key} must be a string"
+    end
+  end
+
+  defp validate_legacy_paths(attrs, path) do
+    if Map.has_key?(attrs, :legacy_paths) do
+      Enum.each(attrs.legacy_paths, &validate_legacy_path!(&1, path))
+    end
+  end
+
+  defp validate_legacy_path!(legacy_path, path) do
+    unless is_binary(legacy_path) and String.starts_with?(legacy_path, "/") do
+      raise ArgumentError,
+            "Invalid frontmatter in #{inspect(path)}: legacy_paths entries must be strings starting with '/'"
+    end
   end
 end

--- a/lib/agent_jido/release/link_audit.ex
+++ b/lib/agent_jido/release/link_audit.ex
@@ -155,14 +155,12 @@ defmodule AgentJido.Release.LinkAudit do
     |> Stream.with_index(1)
     |> Enum.flat_map(fn {line, line_number} ->
       Regex.scan(regex, line)
-      |> Enum.map(fn [_full, captured] ->
-        link_value =
-          case value_key do
-            :path -> normalize_path(captured)
-            :url -> String.trim(captured)
-          end
+      |> Enum.map(fn
+        [_full, captured] when value_key == :path ->
+          %{path: normalize_path(captured), source: "#{relative}:#{line_number}", kind: kind}
 
-        %{value_key => link_value, source: "#{relative}:#{line_number}", kind: kind}
+        [_full, captured] when value_key == :url ->
+          %{url: String.trim(captured), source: "#{relative}:#{line_number}", kind: kind}
       end)
     end)
   end

--- a/lib/agent_jido_web/components/jido/docs_components.ex
+++ b/lib/agent_jido_web/components/jido/docs_components.ex
@@ -292,30 +292,30 @@ defmodule AgentJidoWeb.Jido.DocsComponents do
 
   defp livebook_notice(doc) do
     livebook_meta = Map.get(doc, :livebook, %{}) || %{}
-    parts = []
 
     parts =
-      case Map.get(livebook_meta, :elixir_version) do
-        v when is_binary(v) and v != "" -> ["Elixir #{v}" | parts]
-        _ -> parts
-      end
-
-    parts =
-      case Map.get(livebook_meta, :required_env_vars, []) do
-        vars when is_list(vars) and vars != [] ->
-          shown = Enum.take(vars, 2) |> Enum.join(", ")
-          extra = if length(vars) > 2, do: " +#{length(vars) - 2} more", else: ""
-          ["Env: #{shown}#{extra}" | parts]
-
-        _ ->
-          parts
-      end
+      []
+      |> maybe_add_elixir_notice(Map.get(livebook_meta, :elixir_version))
+      |> maybe_add_env_notice(Map.get(livebook_meta, :required_env_vars, []))
 
     case parts do
       [] -> nil
-      _ -> Enum.reverse(parts) |> Enum.join(" · ")
+      _ -> Enum.join(parts, " · ")
     end
   end
+
+  defp maybe_add_elixir_notice(parts, version) when is_binary(version) and version != "",
+    do: parts ++ ["Elixir #{version}"]
+
+  defp maybe_add_elixir_notice(parts, _version), do: parts
+
+  defp maybe_add_env_notice(parts, vars) when is_list(vars) and vars != [] do
+    shown = Enum.take(vars, 2) |> Enum.join(", ")
+    extra = if length(vars) > 2, do: " +#{length(vars) - 2} more", else: ""
+    parts ++ ["Env: #{shown}#{extra}"]
+  end
+
+  defp maybe_add_env_notice(parts, _vars), do: parts
 
   defp quick_links(selected_document) do
     doc = selected_document || %{}

--- a/lib/agent_jido_web/content_generator/run_report_store.ex
+++ b/lib/agent_jido_web/content_generator/run_report_store.ex
@@ -296,15 +296,7 @@ defmodule AgentJidoWeb.ContentGenerator.RunReportStore do
 
   defp latest_entry_index(runs) do
     Enum.reduce(runs, %{}, fn run, acc ->
-      Enum.reduce(run.entries, acc, fn entry, entry_acc ->
-        case entry.id do
-          id when is_binary(id) and id != "" ->
-            Map.put_new(entry_acc, id, Map.merge(entry, %{run_id: run.run_id, generated_at: run.generated_at, run_status: run.status}))
-
-          _other ->
-            entry_acc
-        end
-      end)
+      Enum.reduce(run.entries, acc, &put_latest_entry(&2, &1, run))
     end)
   end
 
@@ -340,23 +332,39 @@ defmodule AgentJidoWeb.ContentGenerator.RunReportStore do
   defp normalize_status(value) when is_atom(value), do: value
 
   defp normalize_status(value) when is_binary(value) do
-    case value |> String.trim() |> String.downcase() do
-      "written" -> :written
-      "dry_run_candidate" -> :dry_run_candidate
-      "skipped_noop" -> :skipped_noop
-      "skipped_non_file_target" -> :skipped_non_file_target
-      "skipped_missing_for_audit" -> :skipped_missing_for_audit
-      "audit_only_passed" -> :audit_only_passed
-      "audit_failed" -> :audit_failed
-      "generation_failed" -> :generation_failed
-      "parse_failed" -> :parse_failed
-      "churn_blocked" -> :churn_blocked
-      "verification_failed" -> :verification_failed
-      _other -> :unknown
-    end
+    value
+    |> String.trim()
+    |> String.downcase()
+    |> then(&Map.get(status_aliases(), &1, :unknown))
   end
 
   defp normalize_status(_value), do: :unknown
+
+  defp put_latest_entry(entry_acc, entry, run) do
+    case entry.id do
+      id when is_binary(id) and id != "" ->
+        Map.put_new(entry_acc, id, Map.merge(entry, %{run_id: run.run_id, generated_at: run.generated_at, run_status: run.status}))
+
+      _other ->
+        entry_acc
+    end
+  end
+
+  defp status_aliases do
+    %{
+      "written" => :written,
+      "dry_run_candidate" => :dry_run_candidate,
+      "skipped_noop" => :skipped_noop,
+      "skipped_non_file_target" => :skipped_non_file_target,
+      "skipped_missing_for_audit" => :skipped_missing_for_audit,
+      "audit_only_passed" => :audit_only_passed,
+      "audit_failed" => :audit_failed,
+      "generation_failed" => :generation_failed,
+      "parse_failed" => :parse_failed,
+      "churn_blocked" => :churn_blocked,
+      "verification_failed" => :verification_failed
+    }
+  end
 
   defp normalize_verification_status(value) when is_binary(value) do
     case String.downcase(String.trim(value)) do

--- a/lib/agent_jido_web/controllers/analytics_event_controller.ex
+++ b/lib/agent_jido_web/controllers/analytics_event_controller.ex
@@ -64,17 +64,7 @@ defmodule AgentJidoWeb.AnalyticsEventController do
   end
 
   defp infer_path(conn, properties) do
-    referer_path =
-      case get_req_header(conn, "referer") do
-        [referer | _] ->
-          case URI.parse(referer).path do
-            path when is_binary(path) -> path
-            _ -> nil
-          end
-
-        _ ->
-          nil
-      end
+    referer_path = referer_path(conn)
 
     cond do
       is_binary(referer_path) and String.starts_with?(referer_path, "/") ->
@@ -85,6 +75,22 @@ defmodule AgentJidoWeb.AnalyticsEventController do
 
       true ->
         "/"
+    end
+  end
+
+  defp referer_path(conn) do
+    conn
+    |> get_req_header("referer")
+    |> List.first()
+    |> parse_referer_path()
+  end
+
+  defp parse_referer_path(nil), do: nil
+
+  defp parse_referer_path(referer) do
+    case URI.parse(referer).path do
+      path when is_binary(path) -> path
+      _ -> nil
     end
   end
 

--- a/lib/agent_jido_web/examples/demand_tracker_agent_live.ex
+++ b/lib/agent_jido_web/examples/demand_tracker_agent_live.ex
@@ -237,11 +237,7 @@ defmodule AgentJidoWeb.Examples.DemandTrackerAgentLive do
         new_demand = new_agent.state.demand
         new_ticks = new_agent.state.ticks
 
-        detail =
-          case signal_type do
-            "cleanup.run" -> "ticks #{old_ticks} -> #{new_ticks}"
-            _ -> if(data == %{}, do: "", else: inspect(data))
-          end
+        detail = signal_detail(signal_type, data, old_ticks, new_ticks)
 
         entry = %{
           kind: "signal",
@@ -269,6 +265,10 @@ defmodule AgentJidoWeb.Examples.DemandTrackerAgentLive do
         assign(socket, :history, [entry | socket.assigns.history])
     end
   end
+
+  defp signal_detail("cleanup.run", _data, old_ticks, new_ticks), do: "ticks #{old_ticks} -> #{new_ticks}"
+  defp signal_detail(_signal_type, data, _old_ticks, _new_ticks) when data == %{}, do: ""
+  defp signal_detail(_signal_type, data, _old_ticks, _new_ticks), do: inspect(data)
 
   defp refresh_agent_state(socket) do
     pid = socket.assigns.server_pid

--- a/lib/agent_jido_web/examples/emit_directive_agent_live.ex
+++ b/lib/agent_jido_web/examples/emit_directive_agent_live.ex
@@ -170,23 +170,7 @@ defmodule AgentJidoWeb.Examples.EmitDirectiveAgentLive do
     if order_id in [nil, ""] do
       {:noreply, assign(socket, :last_error, "Create an order first.")}
     else
-      case fetch_server_pid(socket) do
-        {:ok, pid} ->
-          case AgentServer.call(pid, Signal.new!("process_payment", %{order_id: order_id}, source: "/demo")) do
-            {:ok, agent} ->
-              {:noreply,
-               socket
-               |> assign(:agent, agent)
-               |> assign(:last_error, nil)
-               |> append_log("process_payment", order_id)}
-
-            {:error, reason} ->
-              {:noreply, assign(socket, :last_error, inspect(reason))}
-          end
-
-        {:error, reason} ->
-          {:noreply, assign(socket, :last_error, inspect(reason))}
-      end
+      process_payment(socket, order_id)
     end
   end
 
@@ -205,6 +189,20 @@ defmodule AgentJidoWeb.Examples.EmitDirectiveAgentLive do
         {:error, reason} ->
           {:noreply, assign(socket, :last_error, inspect(reason))}
       end
+    else
+      {:error, reason} ->
+        {:noreply, assign(socket, :last_error, inspect(reason))}
+    end
+  end
+
+  defp process_payment(socket, order_id) do
+    with {:ok, pid} <- fetch_server_pid(socket),
+         {:ok, agent} <- AgentServer.call(pid, Signal.new!("process_payment", %{order_id: order_id}, source: "/demo")) do
+      {:noreply,
+       socket
+       |> assign(:agent, agent)
+       |> assign(:last_error, nil)
+       |> append_log("process_payment", order_id)}
     else
       {:error, reason} ->
         {:noreply, assign(socket, :last_error, inspect(reason))}

--- a/lib/agent_jido_web/live/admin_content_generator_live.ex
+++ b/lib/agent_jido_web/live/admin_content_generator_live.ex
@@ -1042,29 +1042,11 @@ defmodule AgentJidoWeb.AdminContentGeneratorLive do
     if ref == socket.assigns[@run_task_ref_key] do
       Process.demonitor(ref, [:flush])
 
-      {flash_type, message, run_id} =
-        case result do
-          {:ok, report} ->
-            if selected_count(report) == 0 do
-              {:error, "Content generation run completed with 0 selected entries. Check status/section filters for the selected entry.",
-               report.run_id}
-            else
-              {:info, "Content generation run completed.", report.run_id}
-            end
-
-          {:error, report} ->
-            {:error, blocking_failure_message(report), report.run_id}
-
-          other ->
-            {:error, "Unexpected run result: #{inspect(other)}", nil}
-        end
+      {flash_type, message, run_id} = result_flash(result)
 
       {:noreply,
        socket
-       |> assign(@running_key, false)
-       |> assign(@run_task_ref_key, nil)
-       |> assign(@active_command_key, nil)
-       |> assign(@run_context_key, nil)
+       |> reset_run_state()
        |> refresh_run_store()
        |> refresh_plan_rows()
        |> refresh_runs()
@@ -1081,10 +1063,7 @@ defmodule AgentJidoWeb.AdminContentGeneratorLive do
     if ref == socket.assigns[@run_task_ref_key] do
       {:noreply,
        socket
-       |> assign(@running_key, false)
-       |> assign(@run_task_ref_key, nil)
-       |> assign(@active_command_key, nil)
-       |> assign(@run_context_key, nil)
+       |> reset_run_state()
        |> refresh_run_store()
        |> refresh_plan_rows()
        |> refresh_runs()
@@ -1258,24 +1237,7 @@ defmodule AgentJidoWeb.AdminContentGeneratorLive do
     artifact_status = filters["artifact_status"] || "all"
     verify_status = filters["verify_status"] || "all"
 
-    Enum.filter(rows, fn row ->
-      matches_q? =
-        if q == "" do
-          true
-        else
-          [row.id, row.title, row.route]
-          |> Enum.map_join(" ", &to_string/1)
-          |> String.downcase()
-          |> String.contains?(q)
-        end
-
-      matches_section? = section == "all" or row.section == section
-      matches_plan_status? = plan_status == "all" or Atom.to_string(row.plan_status) == plan_status
-      matches_artifact_status? = artifact_status == "all" or Atom.to_string(row.status.artifact_status) == artifact_status
-      matches_verify_status? = verify_status == "all" or Atom.to_string(row.status.verify_status) == verify_status
-
-      matches_q? and matches_section? and matches_plan_status? and matches_artifact_status? and matches_verify_status?
-    end)
+    Enum.filter(rows, &plan_row_matches?(&1, q, section, plan_status, artifact_status, verify_status))
   end
 
   defp filter_runs(runs, filters) do
@@ -1284,33 +1246,7 @@ defmodule AgentJidoWeb.AdminContentGeneratorLive do
     window_days = parse_window_days(filters["window"])
     now = DateTime.utc_now()
 
-    Enum.filter(runs, fn run ->
-      matches_q? =
-        if q == "" do
-          true
-        else
-          haystack =
-            run.run_id <> " " <> Enum.map_join(run.entries, " ", fn entry -> entry.id || "" end)
-
-          String.contains?(String.downcase(haystack), q)
-        end
-
-      matches_status? = status_filter == "all" or Atom.to_string(run.status) == status_filter
-
-      matches_window? =
-        case window_days do
-          :all ->
-            true
-
-          days when is_integer(days) ->
-            case run.generated_at do
-              %DateTime{} = generated_at -> DateTime.diff(now, generated_at, :day) <= days
-              _other -> false
-            end
-        end
-
-      matches_q? and matches_status? and matches_window?
-    end)
+    Enum.filter(runs, &run_matches_filters?(&1, q, status_filter, window_days, now))
   end
 
   defp parse_window_days(nil), do: :all
@@ -1408,22 +1344,97 @@ defmodule AgentJidoWeb.AdminContentGeneratorLive do
   end
 
   defp build_mix_command_from_options(options) do
-    params = %{
-      "entry" => options.entry || "",
-      "sections" => Enum.join(options.sections || [], ","),
-      "statuses" => Enum.join(options.statuses || [], ","),
-      "max" => Integer.to_string(options.max || 10),
-      "backend" => options.backend || "auto",
-      "docs_format" => options.docs_format || "tag",
-      "update_mode" => options.update_mode || "improve",
-      "source_root" => options.source_root || "..",
-      "report" => options.report || "",
-      "apply" => if(options.apply, do: "true", else: "false"),
-      "verify" => if(options.verify, do: "true", else: "false"),
-      "fail_on_audit" => if(options.fail_on_audit, do: "true", else: "false")
-    }
+    options
+    |> mix_command_params()
+    |> build_mix_command()
+  end
 
-    build_mix_command(params)
+  defp result_flash({:ok, report}) do
+    if selected_count(report) == 0 do
+      {:error, "Content generation run completed with 0 selected entries. Check status/section filters for the selected entry.", report.run_id}
+    else
+      {:info, "Content generation run completed.", report.run_id}
+    end
+  end
+
+  defp result_flash({:error, report}), do: {:error, blocking_failure_message(report), report.run_id}
+  defp result_flash(other), do: {:error, "Unexpected run result: #{inspect(other)}", nil}
+
+  defp reset_run_state(socket) do
+    socket
+    |> assign(@running_key, false)
+    |> assign(@run_task_ref_key, nil)
+    |> assign(@active_command_key, nil)
+    |> assign(@run_context_key, nil)
+  end
+
+  defp plan_row_matches?(row, q, section, plan_status, artifact_status, verify_status) do
+    plan_row_matches_query?(row, q) and
+      (section == "all" or row.section == section) and
+      (plan_status == "all" or Atom.to_string(row.plan_status) == plan_status) and
+      (artifact_status == "all" or Atom.to_string(row.status.artifact_status) == artifact_status) and
+      (verify_status == "all" or Atom.to_string(row.status.verify_status) == verify_status)
+  end
+
+  defp plan_row_matches_query?(_row, ""), do: true
+
+  defp plan_row_matches_query?(row, q) do
+    [row.id, row.title, row.route]
+    |> Enum.map_join(" ", &to_string/1)
+    |> String.downcase()
+    |> String.contains?(q)
+  end
+
+  defp run_matches_filters?(run, q, status_filter, window_days, now) do
+    run_matches_query?(run, q) and
+      (status_filter == "all" or Atom.to_string(run.status) == status_filter) and
+      run_in_window?(run, window_days, now)
+  end
+
+  defp run_matches_query?(_run, ""), do: true
+
+  defp run_matches_query?(run, q) do
+    haystack = run.run_id <> " " <> Enum.map_join(run.entries, " ", fn entry -> entry.id || "" end)
+    String.contains?(String.downcase(haystack), q)
+  end
+
+  defp run_in_window?(_run, :all, _now), do: true
+
+  defp run_in_window?(run, days, now) when is_integer(days) do
+    case run.generated_at do
+      %DateTime{} = generated_at -> DateTime.diff(now, generated_at, :day) <= days
+      _other -> false
+    end
+  end
+
+  defp mix_command_params(options) do
+    defaults = [
+      {"entry", options.entry, ""},
+      {"sections", Enum.join(options.sections || [], ","), ""},
+      {"statuses", Enum.join(options.statuses || [], ","), ""},
+      {"max", options.max, 10},
+      {"backend", options.backend, "auto"},
+      {"docs_format", options.docs_format, "tag"},
+      {"update_mode", options.update_mode, "improve"},
+      {"source_root", options.source_root, ".."},
+      {"report", options.report, ""}
+    ]
+
+    defaults
+    |> Enum.reduce(%{}, &put_option_param(&2, &1))
+    |> Map.put("apply", boolean_string(options.apply))
+    |> Map.put("verify", boolean_string(options.verify))
+    |> Map.put("fail_on_audit", boolean_string(options.fail_on_audit))
+  end
+
+  defp boolean_string(value), do: if(value, do: "true", else: "false")
+
+  defp put_option_param(params, {"max", value, default}) do
+    Map.put(params, "max", Integer.to_string(value || default))
+  end
+
+  defp put_option_param(params, {key, value, default}) do
+    Map.put(params, key, value || default)
   end
 
   defp build_run_opts(params) do

--- a/lib/agent_jido_web/live/admin_content_ingestion_live.ex
+++ b/lib/agent_jido_web/live/admin_content_ingestion_live.ex
@@ -435,35 +435,29 @@ defmodule AgentJidoWeb.AdminContentIngestionLive do
   end
 
   defp detail_text(issues, ingested) do
-    issue_text =
-      case issues do
-        [] -> "ok"
-        list when is_list(list) -> Enum.map_join(list, ", ", &issue_label/1)
-        _other -> "unknown"
-      end
-
-    chunk_text =
-      case ingested do
-        %{actual_chunk_count: count} when is_integer(count) -> "chunks=#{count}"
-        _ -> "chunks=—"
-      end
-
-    dup_text =
-      case ingested do
-        %{duplicate_count: count} when is_integer(count) -> "dup=#{count}"
-        _ -> "dup=—"
-      end
-
-    error_text =
-      case ingested do
-        %{document_error: error} when is_binary(error) and error != "" -> "error=#{error}"
-        _ -> ""
-      end
+    issue_text = issue_summary(issues)
+    chunk_text = count_summary(ingested, :actual_chunk_count, "chunks")
+    dup_text = count_summary(ingested, :duplicate_count, "dup")
+    error_text = error_summary(ingested)
 
     [issue_text, chunk_text, dup_text, error_text]
     |> Enum.reject(&(&1 == ""))
     |> Enum.join(" • ")
   end
+
+  defp issue_summary([]), do: "ok"
+  defp issue_summary(list) when is_list(list), do: Enum.map_join(list, ", ", &issue_label/1)
+  defp issue_summary(_other), do: "unknown"
+
+  defp count_summary(data, key, label) do
+    case Map.get(data || %{}, key) do
+      count when is_integer(count) -> "#{label}=#{count}"
+      _other -> "#{label}=—"
+    end
+  end
+
+  defp error_summary(%{document_error: error}) when is_binary(error) and error != "", do: "error=#{error}"
+  defp error_summary(_ingested), do: ""
 
   defp value(map, key) when is_map(map), do: Map.get(map, key)
   defp value(_map, _key), do: nil

--- a/lib/agent_jido_web/live/chat_ops_live.ex
+++ b/lib/agent_jido_web/live/chat_ops_live.ex
@@ -465,25 +465,7 @@ defmodule AgentJidoWeb.ChatOpsLive do
   defp fetch_inventory(_provider), do: {:error, :invalid_inventory_provider}
 
   defp fetch_recent_messages(provider, opts) when is_atom(provider) and is_list(opts) do
-    response =
-      cond do
-        function_exported?(provider, :fetch_recent_messages, 1) ->
-          provider.fetch_recent_messages(opts)
-
-        function_exported?(provider, :fetch_recent_messages, 0) ->
-          provider.fetch_recent_messages()
-
-        function_exported?(provider, :fetch, 1) ->
-          provider.fetch(opts)
-
-        function_exported?(provider, :fetch, 0) ->
-          provider.fetch()
-
-        true ->
-          {:error, :invalid_message_provider}
-      end
-
-    case response do
+    case invoke_provider(provider, [{:fetch_recent_messages, opts}, {:fetch, opts}], :invalid_message_provider) do
       {:ok, recent_messages} when is_list(recent_messages) ->
         {:ok, recent_messages}
 
@@ -507,25 +489,11 @@ defmodule AgentJidoWeb.ChatOpsLive do
   defp fetch_recent_messages(_provider, _opts), do: {:error, :invalid_message_provider}
 
   defp fetch_action_timeline(provider, opts) when is_atom(provider) and is_list(opts) do
-    response =
-      cond do
-        function_exported?(provider, :fetch_action_timeline, 1) ->
-          provider.fetch_action_timeline(opts)
-
-        function_exported?(provider, :fetch_action_timeline, 0) ->
-          provider.fetch_action_timeline()
-
-        function_exported?(provider, :fetch, 1) ->
-          provider.fetch(opts)
-
-        function_exported?(provider, :fetch, 0) ->
-          provider.fetch()
-
-        true ->
-          {:error, :invalid_action_timeline_provider}
-      end
-
-    case response do
+    case invoke_provider(
+           provider,
+           [{:fetch_action_timeline, opts}, {:fetch, opts}],
+           :invalid_action_timeline_provider
+         ) do
       {:ok, entries} when is_list(entries) ->
         {:ok, entries}
 
@@ -659,26 +627,15 @@ defmodule AgentJidoWeb.ChatOpsLive do
 
   defp normalize_action_entry(entry) when is_map(entry) do
     %{
-      id: normalize_string(Map.get(entry, :id) || Map.get(entry, "id"), nil),
-      timestamp: normalize_datetime(Map.get(entry, :timestamp) || Map.get(entry, "timestamp")),
-      type: normalize_entry_type(Map.get(entry, :type) || Map.get(entry, "type")),
-      label:
-        normalize_string(
-          Map.get(entry, :label) || Map.get(entry, "label"),
-          "ChatOps event"
-        ),
-      outcome: normalize_outcome(Map.get(entry, :outcome) || Map.get(entry, "outcome")),
-      authz_status: normalize_authz_status(Map.get(entry, :authz_status) || Map.get(entry, "authz_status")),
-      mutation_enabled: normalize_optional_boolean(Map.get(entry, :mutation_enabled, Map.get(entry, "mutation_enabled"))),
-      actor: normalize_action_actor(Map.get(entry, :actor, Map.get(entry, "actor"))),
-      details:
-        normalize_string(
-          Map.get(entry, :details) ||
-            Map.get(entry, "details") ||
-            Map.get(entry, :message) ||
-            Map.get(entry, "message"),
-          nil
-        )
+      id: normalize_string(entry_value(entry, :id), nil),
+      timestamp: normalize_datetime(entry_value(entry, :timestamp)),
+      type: normalize_entry_type(entry_value(entry, :type)),
+      label: normalize_string(entry_value(entry, :label), "ChatOps event"),
+      outcome: normalize_outcome(entry_value(entry, :outcome)),
+      authz_status: normalize_authz_status(entry_value(entry, :authz_status)),
+      mutation_enabled: normalize_optional_boolean(entry_value(entry, :mutation_enabled)),
+      actor: normalize_action_actor(entry_value(entry, :actor)),
+      details: normalize_string(entry_value(entry, :details) || entry_value(entry, :message), nil)
     }
   end
 
@@ -703,6 +660,18 @@ defmodule AgentJidoWeb.ChatOpsLive do
   end
 
   defp normalize_guardrails(_guardrails), do: default_guardrail_state()
+
+  defp invoke_provider(provider, [{fun, opts} | rest], invalid_reason) do
+    cond do
+      function_exported?(provider, fun, 1) -> apply(provider, fun, [opts])
+      function_exported?(provider, fun, 0) -> apply(provider, fun, [])
+      true -> invoke_provider(provider, rest, invalid_reason)
+    end
+  end
+
+  defp invoke_provider(_provider, [], invalid_reason), do: {:error, invalid_reason}
+
+  defp entry_value(entry, key), do: Map.get(entry, key) || Map.get(entry, Atom.to_string(key))
 
   defp normalize_guardrail_counts(counts) when is_map(counts) do
     %{

--- a/lib/agent_jido_web/live/content_assistant_live.ex
+++ b/lib/agent_jido_web/live/content_assistant_live.ex
@@ -573,69 +573,7 @@ defmodule AgentJidoWeb.ContentAssistantLive do
         restored_socket
 
       :miss ->
-        query_log_id = if origin == :user_submit, do: track_query_id(query, socket), else: nil
-        if origin == :user_submit, do: emit_query_issued(query)
-
-        with :ok <- ensure_assistant_task_supervisor(),
-             task <-
-               Task.Supervisor.async_nolink(@assistant_task_supervisor, fn ->
-                 run_assistant(socket.assigns.content_assistant_module, query, assistant_opts, query_log_id)
-               end) do
-          timeout_ref = Process.send_after(self(), {:assistant_timeout, task.ref}, assistant_timeout_ms())
-
-          assign(socket,
-            status: :loading,
-            response: nil,
-            assistant_task_ref: task.ref,
-            assistant_task_pid: task.pid,
-            assistant_timeout_ref: timeout_ref,
-            assistant_started_at: System.monotonic_time(),
-            assistant_query_log_id: query_log_id,
-            assistant_origin: origin,
-            assistant_cache_key: cache_key,
-            last_query_log_id: nil,
-            feedback_value: nil,
-            feedback_note: "",
-            feedback_submitted: false,
-            enhancement_task_ref: nil,
-            enhancement_task_pid: nil,
-            enhancement_timeout_ref: nil,
-            enhancement_status: :idle
-          )
-        else
-          {:error, reason} ->
-            Logger.warning("content assistant task supervisor unavailable; falling back to inline execution: #{inspect(reason)}")
-
-            socket_for_run =
-              assign(socket,
-                assistant_started_at: System.monotonic_time(),
-                assistant_query_log_id: query_log_id,
-                assistant_origin: origin,
-                assistant_cache_key: cache_key,
-                enhancement_task_ref: nil,
-                enhancement_task_pid: nil,
-                enhancement_timeout_ref: nil,
-                enhancement_status: :idle
-              )
-
-            response =
-              run_assistant(
-                socket.assigns.content_assistant_module,
-                query,
-                assistant_opts,
-                query_log_id
-              )
-
-            response = maybe_prepare_progressive_fast_response(socket_for_run, response, turnstile_token)
-
-            socket_for_run
-            |> maybe_cache_response(response)
-            |> maybe_finalize_query_log(response)
-            |> maybe_emit_query_outcome(response)
-            |> maybe_track_restore(response, false)
-            |> apply_response(response)
-            |> maybe_start_progressive_enhancement(response, turnstile_token)
-        end
+        start_assistant_run(socket, query, origin, assistant_opts, cache_key, turnstile_token)
     end
   end
 
@@ -876,21 +814,8 @@ defmodule AgentJidoWeb.ContentAssistantLive do
 
     if should_start_progressive_enhancement?(socket, response, enhancement_opts) do
       with :ok <- ensure_assistant_task_supervisor(),
-           task <-
-             Task.Supervisor.async_nolink(@assistant_task_supervisor, fn ->
-               enhancement_started_at_ms = monotonic_ms()
-               enhancement_response = run_assistant(socket.assigns.content_assistant_module, response.query, enhancement_opts, nil)
-               maybe_wait_for_progressive_dwell(enhancement_started_at_ms)
-               enhancement_response
-             end) do
-        timeout_ref = Process.send_after(self(), {:assistant_enhancement_timeout, task.ref}, assistant_timeout_ms())
-
-        assign(socket,
-          enhancement_task_ref: task.ref,
-          enhancement_task_pid: task.pid,
-          enhancement_timeout_ref: timeout_ref,
-          enhancement_status: :running
-        )
+           task <- start_enhancement_task(socket, response, enhancement_opts) do
+        assign_enhancement_task(socket, task)
       else
         _ -> clear_enhancement_state(socket, :failed)
       end
@@ -933,6 +858,112 @@ defmodule AgentJidoWeb.ContentAssistantLive do
   end
 
   defp should_start_progressive_enhancement?(_socket, _response, _enhancement_opts), do: false
+
+  defp maybe_track_query_id(:user_submit, query, socket), do: track_query_id(query, socket)
+  defp maybe_track_query_id(_origin, _query, _socket), do: nil
+
+  defp maybe_emit_query_issued(:user_submit, query), do: emit_query_issued(query)
+  defp maybe_emit_query_issued(_origin, _query), do: :ok
+
+  defp start_assistant_run(socket, query, origin, assistant_opts, cache_key, turnstile_token) do
+    query_log_id = maybe_track_query_id(origin, query, socket)
+    maybe_emit_query_issued(origin, query)
+
+    with :ok <- ensure_assistant_task_supervisor(),
+         task <-
+           Task.Supervisor.async_nolink(@assistant_task_supervisor, fn ->
+             run_assistant(socket.assigns.content_assistant_module, query, assistant_opts, query_log_id)
+           end) do
+      build_loading_socket(socket, task, query_log_id, origin, cache_key)
+    else
+      {:error, reason} ->
+        fallback_assistant_run(socket, reason, query, assistant_opts, query_log_id, origin, cache_key, turnstile_token)
+    end
+  end
+
+  defp build_loading_socket(socket, task, query_log_id, origin, cache_key) do
+    timeout_ref = Process.send_after(self(), {:assistant_timeout, task.ref}, assistant_timeout_ms())
+
+    assign(socket,
+      status: :loading,
+      response: nil,
+      assistant_task_ref: task.ref,
+      assistant_task_pid: task.pid,
+      assistant_timeout_ref: timeout_ref,
+      assistant_started_at: System.monotonic_time(),
+      assistant_query_log_id: query_log_id,
+      assistant_origin: origin,
+      assistant_cache_key: cache_key,
+      last_query_log_id: nil,
+      feedback_value: nil,
+      feedback_note: "",
+      feedback_submitted: false,
+      enhancement_task_ref: nil,
+      enhancement_task_pid: nil,
+      enhancement_timeout_ref: nil,
+      enhancement_status: :idle
+    )
+  end
+
+  defp fallback_assistant_run(socket, reason, query, assistant_opts, query_log_id, origin, cache_key, turnstile_token) do
+    Logger.warning("content assistant task supervisor unavailable; falling back to inline execution: #{inspect(reason)}")
+
+    socket_for_run =
+      assign(socket,
+        assistant_started_at: System.monotonic_time(),
+        assistant_query_log_id: query_log_id,
+        assistant_origin: origin,
+        assistant_cache_key: cache_key,
+        enhancement_task_ref: nil,
+        enhancement_task_pid: nil,
+        enhancement_timeout_ref: nil,
+        enhancement_status: :idle
+      )
+
+    response =
+      run_assistant(
+        socket.assigns.content_assistant_module,
+        query,
+        assistant_opts,
+        query_log_id
+      )
+      |> prepare_fast_response_for_fallback(socket_for_run, turnstile_token)
+
+    socket_for_run
+    |> maybe_cache_response(response)
+    |> maybe_finalize_query_log(response)
+    |> maybe_emit_query_outcome(response)
+    |> maybe_track_restore(response, false)
+    |> apply_response(response)
+    |> maybe_start_progressive_enhancement(response, turnstile_token)
+  end
+
+  defp prepare_fast_response_for_fallback(response, socket, turnstile_token) do
+    maybe_prepare_progressive_fast_response(socket, response, turnstile_token)
+  end
+
+  defp start_enhancement_task(socket, response, enhancement_opts) do
+    Task.Supervisor.async_nolink(@assistant_task_supervisor, fn ->
+      enhancement_started_at_ms = monotonic_ms()
+
+      enhancement_response =
+        run_assistant(socket.assigns.content_assistant_module, response.query, enhancement_opts, nil)
+
+      maybe_wait_for_progressive_dwell(enhancement_started_at_ms)
+      enhancement_response
+    end)
+  end
+
+  defp assign_enhancement_task(socket, task) do
+    timeout_ref = Process.send_after(self(), {:assistant_enhancement_timeout, task.ref}, assistant_timeout_ms())
+
+    assign(socket,
+      enhancement_task_ref: task.ref,
+      enhancement_task_pid: task.pid,
+      enhancement_timeout_ref: timeout_ref,
+      enhancement_status: :running
+    )
+  end
 
   defp llm_enabled?(opts) when is_list(opts) do
     case Keyword.fetch(opts, :llm) do

--- a/lib/agent_jido_web/live/content_ops_github_live.ex
+++ b/lib/agent_jido_web/live/content_ops_github_live.ex
@@ -382,51 +382,10 @@ defmodule AgentJidoWeb.ContentOpsGithubLive do
     case socket.assigns.merge_task_ref do
       {^ref, number, title} ->
         Process.demonitor(ref, [:flush])
-        socket = assign(socket, :merge_task_ref, nil)
-
-        socket =
-          case result do
-            {200, %{"merged" => true}, _} ->
-              invalidate_cache()
-
-              socket
-              |> put_flash(:info, "✓ PR ##{number} (#{title}) merged successfully!")
-              |> assign(:loading, true)
-              |> fetch_data()
-
-            {status, body, _} ->
-              put_flash(
-                socket,
-                :error,
-                "Failed to merge PR ##{number}: HTTP #{status} — #{inspect(body)}"
-              )
-
-            error ->
-              put_flash(socket, :error, "Failed to merge PR ##{number}: #{inspect(error)}")
-          end
-
-        {:noreply, socket}
+        {:noreply, handle_merge_result(assign(socket, :merge_task_ref, nil), result, number, title)}
 
       _ ->
-        case socket.assigns.solve_task_ref do
-          {^ref, number, _title} ->
-            Process.demonitor(ref, [:flush])
-            socket = assign(socket, :solve_task_ref, nil)
-
-            socket =
-              case result do
-                %{status: :completed} ->
-                  put_flash(socket, :info, "✓ ContentOps completed for issue ##{number}!")
-
-                _ ->
-                  put_flash(socket, :info, "ContentOps run finished for issue ##{number}.")
-              end
-
-            {:noreply, socket}
-
-          _ ->
-            {:noreply, socket}
-        end
+        {:noreply, handle_solve_result(socket, ref, result)}
     end
   end
 
@@ -480,6 +439,43 @@ defmodule AgentJidoWeb.ContentOpsGithubLive do
   def handle_info(_msg, socket), do: {:noreply, socket}
 
   # ── Private helpers ────────────────────────────────────────────────
+
+  defp handle_merge_result(socket, {200, %{"merged" => true}, _}, number, title) do
+    invalidate_cache()
+
+    socket
+    |> put_flash(:info, "✓ PR ##{number} (#{title}) merged successfully!")
+    |> assign(:loading, true)
+    |> fetch_data()
+  end
+
+  defp handle_merge_result(socket, {status, body, _}, number, _title) do
+    put_flash(socket, :error, "Failed to merge PR ##{number}: HTTP #{status} — #{inspect(body)}")
+  end
+
+  defp handle_merge_result(socket, error, number, _title) do
+    put_flash(socket, :error, "Failed to merge PR ##{number}: #{inspect(error)}")
+  end
+
+  defp handle_solve_result(socket, ref, result) do
+    case socket.assigns.solve_task_ref do
+      {^ref, number, _title} ->
+        Process.demonitor(ref, [:flush])
+        socket = assign(socket, :solve_task_ref, nil)
+        solve_flash(socket, result, number)
+
+      _other ->
+        socket
+    end
+  end
+
+  defp solve_flash(socket, %{status: :completed}, number) do
+    put_flash(socket, :info, "✓ ContentOps completed for issue ##{number}!")
+  end
+
+  defp solve_flash(socket, _result, number) do
+    put_flash(socket, :info, "ContentOps run finished for issue ##{number}.")
+  end
 
   defp fetch_data(socket) do
     token = socket.assigns.token

--- a/lib/agent_jido_web/live/content_ops_live.ex
+++ b/lib/agent_jido_web/live/content_ops_live.ex
@@ -454,20 +454,7 @@ defmodule AgentJidoWeb.ContentOpsLive do
     socket =
       case result do
         %{mode: _mode, productions: productions, status: :completed} ->
-          # Try to find the report to get the run_id
-          report = OrchestratorAgent.run_report(result)
-          run_id = if report, do: report.run_id, else: nil
-
-          if run_id do
-            runs =
-              Enum.map(socket.assigns.runs, fn run ->
-                if run.run_id == run_id, do: Map.put(run, :productions, productions), else: run
-              end)
-
-            assign(socket, :runs, runs)
-          else
-            socket
-          end
+          attach_run_productions(socket, result, productions)
 
         _ ->
           socket
@@ -493,6 +480,21 @@ defmodule AgentJidoWeb.ContentOpsLive do
   def handle_info(_msg, socket), do: {:noreply, socket}
 
   # ── Server status helpers ──────────────────────────────────────────
+
+  defp attach_run_productions(socket, result, productions) do
+    case OrchestratorAgent.run_report(result) do
+      %{run_id: run_id} ->
+        runs = Enum.map(socket.assigns.runs, &replace_run_productions(&1, run_id, productions))
+        assign(socket, :runs, runs)
+
+      _other ->
+        socket
+    end
+  end
+
+  defp replace_run_productions(run, run_id, productions) do
+    if run.run_id == run_id, do: Map.put(run, :productions, productions), else: run
+  end
 
   defp refresh_server_status(socket) do
     case Jido.AgentServer.status(@server_name) do

--- a/lib/agent_jido_web/live/jido_ecosystem_package_live.ex
+++ b/lib/agent_jido_web/live/jido_ecosystem_package_live.ex
@@ -329,30 +329,7 @@ defmodule AgentJidoWeb.JidoEcosystemPackageLive do
     source_items = important_source_items(pkg)
 
     source_items
-    |> Enum.reduce({MapSet.new(), []}, fn %{id: id, reason: reason}, {seen, acc} ->
-      if MapSet.member?(seen, id) do
-        {seen, acc}
-      else
-        case Ecosystem.get_public_package(id) do
-          nil ->
-            {MapSet.put(seen, id), acc}
-
-          related ->
-            {label, href} = external_doc_link(related)
-
-            item = %{
-              id: related.id,
-              title: related.title,
-              path: "/ecosystem/#{related.id}",
-              reason: normalize_text(reason),
-              external_label: label,
-              external_href: href
-            }
-
-            {MapSet.put(seen, id), acc ++ [item]}
-        end
-      end
-    end)
+    |> Enum.reduce({MapSet.new(), []}, &reduce_related_package(&1, &2))
     |> elem(1)
   end
 
@@ -614,17 +591,7 @@ defmodule AgentJidoWeb.JidoEcosystemPackageLive do
       case URI.parse(trimmed) do
         %URI{scheme: scheme, host: host, path: path}
         when scheme in ["http", "https"] and host in ["github.com", "www.github.com"] ->
-          path
-          |> to_string()
-          |> String.trim("/")
-          |> String.split("/", trim: true)
-          |> case do
-            [owner, repo | _rest] when owner != "" and repo != "" ->
-              "https://github.com/#{owner}/#{String.trim_trailing(repo, ".git")}/issues"
-
-            _other ->
-              nil
-          end
+          github_issue_url(path)
 
         _other ->
           nil
@@ -635,4 +602,39 @@ defmodule AgentJidoWeb.JidoEcosystemPackageLive do
   defp present?(nil), do: false
   defp present?(""), do: false
   defp present?(_), do: true
+
+  defp reduce_related_package(%{id: id, reason: reason}, {seen, acc}) do
+    if MapSet.member?(seen, id) do
+      {seen, acc}
+    else
+      case Ecosystem.get_public_package(id) do
+        nil ->
+          {MapSet.put(seen, id), acc}
+
+        related ->
+          {label, href} = external_doc_link(related)
+
+          item = %{
+            id: related.id,
+            title: related.title,
+            path: "/ecosystem/#{related.id}",
+            reason: normalize_text(reason),
+            external_label: label,
+            external_href: href
+          }
+
+          {MapSet.put(seen, id), acc ++ [item]}
+      end
+    end
+  end
+
+  defp github_issue_url(path) do
+    case path |> to_string() |> String.trim("/") |> String.split("/", trim: true) do
+      [owner, repo | _rest] when owner != "" and repo != "" ->
+        "https://github.com/#{owner}/#{String.trim_trailing(repo, ".git")}/issues"
+
+      _other ->
+        nil
+    end
+  end
 end

--- a/lib/agent_jido_web/live/page_live.ex
+++ b/lib/agent_jido_web/live/page_live.ex
@@ -365,25 +365,7 @@ defmodule AgentJidoWeb.PageLive do
       {:ok, document} ->
         document
         |> Floki.find("h1, h2, h3")
-        |> Enum.map(fn header ->
-          {tag_name, attrs, _content} = header
-          level = String.to_integer(String.trim_leading(tag_name, "h"))
-
-          id =
-            Enum.find_value(attrs, fn
-              {"id", id} -> id
-              _ -> nil
-            end) || slugify(Floki.text(header))
-
-          title = Floki.text(header)
-
-          %{
-            id: id,
-            title: title,
-            level: level,
-            children: []
-          }
-        end)
+        |> Enum.map(&header_to_toc_item/1)
 
       {:error, _} ->
         []
@@ -659,23 +641,7 @@ defmodule AgentJidoWeb.PageLive do
     session_id = get_in(socket.assigns, [:analytics_identity, :session_id])
 
     if function_exported?(module, :latest_feedback_for_identity, 4) do
-      case module.latest_feedback_for_identity(visitor_id, session_id, path, surface: "docs_page") do
-        %{feedback_value: value, feedback_note: note} ->
-          case normalize_feedback_value(value) do
-            nil ->
-              empty_docs_feedback()
-
-            normalized_value ->
-              %{
-                submitted: true,
-                value: normalized_value,
-                note: normalize_feedback_note(note)
-              }
-          end
-
-        _other ->
-          empty_docs_feedback()
-      end
+      normalize_existing_feedback(module.latest_feedback_for_identity(visitor_id, session_id, path, surface: "docs_page"))
     else
       empty_docs_feedback()
     end
@@ -688,6 +654,38 @@ defmodule AgentJidoWeb.PageLive do
   defp empty_docs_feedback do
     %{submitted: false, value: nil, note: nil}
   end
+
+  defp header_to_toc_item({tag_name, attrs, _content} = header) do
+    %{
+      id: header_id(attrs, header),
+      title: Floki.text(header),
+      level: String.to_integer(String.trim_leading(tag_name, "h")),
+      children: []
+    }
+  end
+
+  defp header_id(attrs, header) do
+    Enum.find_value(attrs, fn
+      {"id", id} -> id
+      _ -> nil
+    end) || slugify(Floki.text(header))
+  end
+
+  defp normalize_existing_feedback(%{feedback_value: value, feedback_note: note}) do
+    case normalize_feedback_value(value) do
+      nil ->
+        empty_docs_feedback()
+
+      normalized_value ->
+        %{
+          submitted: true,
+          value: normalized_value,
+          note: normalize_feedback_note(note)
+        }
+    end
+  end
+
+  defp normalize_existing_feedback(_other), do: empty_docs_feedback()
 
   defp analytics_module do
     Application.get_env(:agent_jido, :analytics_module, Analytics)

--- a/lib/agent_jido_web/markdown_content.ex
+++ b/lib/agent_jido_web/markdown_content.ex
@@ -122,21 +122,10 @@ defmodule AgentJidoWeb.MarkdownContent do
 
   defp resolve_from_ecosystem("/ecosystem/" <> id_path) do
     if valid_single_segment?(id_path) do
-      id = String.trim(id_path)
-
-      case Ecosystem.get_public_package(id) do
-        nil ->
-          :no_match
-
-        package ->
-          case read_source_markdown(map_get(package, :path)) do
-            {:ok, markdown} ->
-              {:ok, markdown}
-
-            _other ->
-              {:fallback, map_get(package, :title) || "Ecosystem Package", package_summary(package)}
-          end
-      end
+      id_path
+      |> String.trim()
+      |> Ecosystem.get_public_package()
+      |> resolve_markdown_target("Ecosystem Package", &package_summary/1, &map_get(&1, :path), &map_get(&1, :title))
     else
       :no_match
     end
@@ -150,21 +139,10 @@ defmodule AgentJidoWeb.MarkdownContent do
 
   defp resolve_from_examples("/examples/" <> slug_path) do
     if valid_single_segment?(slug_path) do
-      slug = String.trim(slug_path)
-
-      case Examples.get_example(slug) do
-        nil ->
-          :no_match
-
-        example ->
-          case read_source_markdown(map_get(example, :source_path)) do
-            {:ok, markdown} ->
-              {:ok, markdown}
-
-            _other ->
-              {:fallback, map_get(example, :title) || "Example", example_summary(example)}
-          end
-      end
+      slug_path
+      |> String.trim()
+      |> Examples.get_example()
+      |> resolve_markdown_target("Example", &example_summary/1, &map_get(&1, :source_path), &map_get(&1, :title))
     else
       :no_match
     end
@@ -187,6 +165,18 @@ defmodule AgentJidoWeb.MarkdownContent do
   end
 
   defp resolve_from_showcase(_path), do: nil
+
+  defp resolve_markdown_target(nil, _default_title, _summary_fun, _path_fun, _title_fun), do: :no_match
+
+  defp resolve_markdown_target(item, default_title, summary_fun, path_fun, title_fun) do
+    case read_source_markdown(path_fun.(item)) do
+      {:ok, markdown} ->
+        {:ok, markdown}
+
+      _other ->
+        {:fallback, title_fun.(item) || default_title, summary_fun.(item)}
+    end
+  end
 
   defp resolve_misc("/") do
     {:fallback, "Agent Jido",

--- a/lib/agent_jido_web/plugs/llm_response.ex
+++ b/lib/agent_jido_web/plugs/llm_response.ex
@@ -20,18 +20,7 @@ defmodule AgentJidoWeb.Plugs.LLMResponse do
       when method in ["GET", "HEAD"] and is_binary(request_path) do
     case markdown_paths(request_path) do
       {canonical_path, markdown_path} ->
-        if MarkdownContent.eligible_public_path?(canonical_path) do
-          canonical_url = MarkdownLinks.absolute_url(canonical_path, conn.query_string)
-          markdown_url = MarkdownLinks.absolute_url(markdown_path, conn.query_string)
-
-          if markdown_route_request?(request_path) or markdown_request?(conn) do
-            maybe_render_markdown(conn, canonical_path, canonical_url, markdown_url)
-          else
-            register_discovery_headers(conn, markdown_url)
-          end
-        else
-          conn
-        end
+        handle_markdown_match(conn, request_path, canonical_path, markdown_path)
 
       :no_match ->
         conn
@@ -39,6 +28,21 @@ defmodule AgentJidoWeb.Plugs.LLMResponse do
   end
 
   def call(conn, _opts), do: conn
+
+  defp handle_markdown_match(conn, request_path, canonical_path, markdown_path) do
+    if MarkdownContent.eligible_public_path?(canonical_path) do
+      canonical_url = MarkdownLinks.absolute_url(canonical_path, conn.query_string)
+      markdown_url = MarkdownLinks.absolute_url(markdown_path, conn.query_string)
+
+      if markdown_route_request?(request_path) or markdown_request?(conn) do
+        maybe_render_markdown(conn, canonical_path, canonical_url, markdown_url)
+      else
+        register_discovery_headers(conn, markdown_url)
+      end
+    else
+      conn
+    end
+  end
 
   defp maybe_render_markdown(conn, canonical_path, canonical_url, markdown_url) do
     case MarkdownContent.resolve(canonical_path, canonical_url) do

--- a/lib/mix/tasks/agentjido.signal.ex
+++ b/lib/mix/tasks/agentjido.signal.ex
@@ -122,15 +122,19 @@ defmodule Mix.Tasks.Agentjido.Signal do
             :ok
 
           {:error, {:already_started, _pid}} ->
-            if Process.whereis(registry_name) do
-              :ok
-            else
-              Mix.raise("AgentJido.Jido started without registry; restart runtime and retry.")
-            end
+            ensure_registry_started!(registry_name)
 
           {:error, reason} ->
             Mix.raise("Failed to start AgentJido.Jido: #{inspect(reason)}")
         end
+    end
+  end
+
+  defp ensure_registry_started!(registry_name) do
+    if Process.whereis(registry_name) do
+      :ok
+    else
+      Mix.raise("AgentJido.Jido started without registry; restart runtime and retry.")
     end
   end
 

--- a/lib/mix/tasks/arcana.health.ex
+++ b/lib/mix/tasks/arcana.health.ex
@@ -102,75 +102,61 @@ defmodule Mix.Tasks.Arcana.Health do
       |> maybe_add(not is_nil(dirty_error), "Could not count dirty communities: #{dirty_error}")
       |> maybe_add(not is_nil(summarized_error), "Could not count summarized communities: #{summarized_error}")
 
-    print_report(
-      embedder,
-      embedding_info,
-      db_dims,
-      graph_enabled,
-      graph_extractor,
-      graph_entity_extractor,
-      llm,
-      docs_count,
-      chunks_count,
-      entities_count,
-      rels_count,
-      communities_count,
-      dirty_count,
-      summarized_count,
-      warnings,
-      issues
-    )
+    print_report(%{
+      embedder: embedder,
+      embedding_info: embedding_info,
+      db_dims: db_dims,
+      graph_enabled: graph_enabled,
+      graph_extractor: graph_extractor,
+      graph_entity_extractor: graph_entity_extractor,
+      llm: llm,
+      docs_count: docs_count,
+      chunks_count: chunks_count,
+      entities_count: entities_count,
+      rels_count: rels_count,
+      communities_count: communities_count,
+      dirty_count: dirty_count,
+      summarized_count: summarized_count,
+      warnings: warnings,
+      issues: issues
+    })
 
     if issues != [] or (strict and warnings != []) do
       Mix.raise("Arcana health check failed (issues: #{length(issues)}, warnings: #{length(warnings)})")
     end
   end
 
-  defp print_report(
-         embedder,
-         embedding_info,
-         db_dims,
-         graph_enabled,
-         graph_extractor,
-         graph_entity_extractor,
-         llm,
-         docs_count,
-         chunks_count,
-         entities_count,
-         rels_count,
-         communities_count,
-         dirty_count,
-         summarized_count,
-         warnings,
-         issues
-       ) do
+  defp print_report(report) do
     shell = Mix.shell()
 
     shell.info("Arcana Health")
-    shell.info("embedder_config: #{inspect(embedder)}")
-    shell.info("embedder_info: #{inspect(embedding_info)}")
-    shell.info("db_embedding_dimensions: #{inspect(db_dims)}")
-    shell.info("graph_enabled: #{inspect(graph_enabled)}")
-    shell.info("graph_extractor: #{inspect(graph_extractor)}")
-    shell.info("graph_entity_extractor: #{inspect(graph_entity_extractor)}")
-    shell.info("llm_configured: #{inspect(not is_nil(llm))}")
-    shell.info("documents: #{format_count(docs_count)}")
-    shell.info("chunks: #{format_count(chunks_count)}")
-    shell.info("graph_entities: #{format_count(entities_count)}")
-    shell.info("graph_relationships: #{format_count(rels_count)}")
-    shell.info("graph_communities: #{format_count(communities_count)}")
-    shell.info("graph_communities_dirty: #{format_count(dirty_count)}")
-    shell.info("graph_communities_summarized: #{format_count(summarized_count)}")
-
-    Enum.each(warnings, &shell.error("WARNING: " <> &1))
-    Enum.each(issues, &shell.error("ISSUE: " <> &1))
-
-    if issues == [] and warnings == [] do
-      shell.info("status: healthy")
-    else
-      shell.info("status: unhealthy")
-    end
+    Enum.each(report_lines(report), &shell.info/1)
+    Enum.each(report.warnings, &shell.error("WARNING: " <> &1))
+    Enum.each(report.issues, &shell.error("ISSUE: " <> &1))
+    shell.info("status: #{report_status(report)}")
   end
+
+  defp report_lines(report) do
+    [
+      "embedder_config: #{inspect(report.embedder)}",
+      "embedder_info: #{inspect(report.embedding_info)}",
+      "db_embedding_dimensions: #{inspect(report.db_dims)}",
+      "graph_enabled: #{inspect(report.graph_enabled)}",
+      "graph_extractor: #{inspect(report.graph_extractor)}",
+      "graph_entity_extractor: #{inspect(report.graph_entity_extractor)}",
+      "llm_configured: #{inspect(not is_nil(report.llm))}",
+      "documents: #{format_count(report.docs_count)}",
+      "chunks: #{format_count(report.chunks_count)}",
+      "graph_entities: #{format_count(report.entities_count)}",
+      "graph_relationships: #{format_count(report.rels_count)}",
+      "graph_communities: #{format_count(report.communities_count)}",
+      "graph_communities_dirty: #{format_count(report.dirty_count)}",
+      "graph_communities_summarized: #{format_count(report.summarized_count)}"
+    ]
+  end
+
+  defp report_status(%{issues: [], warnings: []}), do: "healthy"
+  defp report_status(_report), do: "unhealthy"
 
   defp local_embedder?(embedder) do
     match?(:local, embedder) or

--- a/lib/mix/tasks/content.plan.generate.ex
+++ b/lib/mix/tasks/content.plan.generate.ex
@@ -108,14 +108,7 @@ defmodule Mix.Tasks.Content.Plan.Generate do
         |> Enum.map(&{to_string(&1.status), &1.status})
         |> Map.new()
 
-      Enum.map(status_values, fn value ->
-        key = String.trim(value)
-
-        case Map.fetch(known_statuses, key) do
-          {:ok, atom_status} -> atom_status
-          :error -> Mix.raise("Unknown --status value #{inspect(value)}")
-        end
-      end)
+      Enum.map(status_values, &parse_status_value(&1, known_statuses))
     end
   end
 
@@ -190,22 +183,44 @@ defmodule Mix.Tasks.Content.Plan.Generate do
 
   defp print_summary(report) do
     stats = report.stats || %{}
-
-    Mix.shell().info("Run ID: #{report.run_id}")
-    Mix.shell().info("Report: #{report.report_path}")
-    Mix.shell().info("Selected: #{stats.selected || 0}")
-    Mix.shell().info("Written: #{stats.written || 0}")
-    Mix.shell().info("Dry-run candidates: #{stats.dry_run_candidates || 0}")
-    Mix.shell().info("No-op skipped: #{stats.skipped_noop || 0}")
-    Mix.shell().info("Non-file skipped: #{stats.skipped_non_file_target || 0}")
-    Mix.shell().info("Audit failed: #{stats.audit_failed || 0}")
-    Mix.shell().info("Generation failed: #{stats.generation_failed || 0}")
-    Mix.shell().info("Parse failed: #{stats.parse_failed || 0}")
-    Mix.shell().info("Churn blocked: #{stats.churn_blocked || 0}")
-    Mix.shell().info("Verification failed: #{stats.verification_failed || 0}")
+    Enum.each(summary_lines(report, stats), &Mix.shell().info/1)
 
     if Map.get(report.options || %{}, :verify, false) do
       print_verify_summary(report)
+    end
+  end
+
+  defp summary_lines(report, stats) do
+    summary_pairs(report, stats)
+    |> Enum.map(&format_summary_line/1)
+  end
+
+  defp summary_pairs(report, stats) do
+    stat_pairs = [
+      {"Selected", :selected},
+      {"Written", :written},
+      {"Dry-run candidates", :dry_run_candidates},
+      {"No-op skipped", :skipped_noop},
+      {"Non-file skipped", :skipped_non_file_target},
+      {"Audit failed", :audit_failed},
+      {"Generation failed", :generation_failed},
+      {"Parse failed", :parse_failed},
+      {"Churn blocked", :churn_blocked},
+      {"Verification failed", :verification_failed}
+    ]
+
+    [{"Run ID", report.run_id}, {"Report", report.report_path}] ++
+      Enum.map(stat_pairs, fn {label, key} -> {label, Map.get(stats, key, 0)} end)
+  end
+
+  defp format_summary_line({label, value}), do: "#{label}: #{value}"
+
+  defp parse_status_value(value, known_statuses) do
+    key = String.trim(value)
+
+    case Map.fetch(known_statuses, key) do
+      {:ok, atom_status} -> atom_status
+      :error -> Mix.raise("Unknown --status value #{inspect(value)}")
     end
   end
 

--- a/test/agent_jido_web/live/admin_content_generator_live_test.exs
+++ b/test/agent_jido_web/live/admin_content_generator_live_test.exs
@@ -10,35 +10,71 @@ defmodule AgentJidoWeb.AdminContentGeneratorLiveTest do
 
   defmodule ContentGenRunStub do
     def run(opts) do
-      if is_pid(Application.get_env(:agent_jido, :content_gen_test_pid)) do
-        send(Application.get_env(:agent_jido, :content_gen_test_pid), {:content_gen_run_opts, opts})
-      end
+      notify_test_pid(opts)
 
+      entry_id = opts.entry || "docs/test-entry"
+      route = route_for(entry_id)
+
+      %{
+        run_id: run_id,
+        run_dir: run_dir,
+        report_path: report_path,
+        candidate_path: candidate_path
+      } = run_paths(entry_id)
+
+      :ok = write_candidate(candidate_path)
+
+      stats = stub_stats(opts)
+      report = stub_report(opts, run_id, run_dir, report_path, entry_id, route, candidate_path, stats)
+
+      :ok = write_report(report_path, report)
+
+      {:ok, stub_result(run_id, report, stats)}
+    end
+
+    defp notify_test_pid(opts) do
+      test_pid = Application.get_env(:agent_jido, :content_gen_test_pid)
+
+      if is_pid(test_pid) do
+        send(test_pid, {:content_gen_run_opts, opts})
+      end
+    end
+
+    defp run_paths(entry_id) do
       runs_root = Application.fetch_env!(:agent_jido, :content_gen_test_runs_root)
       run_id = "run_test_ui_#{System.unique_integer([:positive])}"
       run_dir = Path.join(runs_root, run_id)
       report_path = Path.join(run_dir, "report.json")
+      candidate_path = Path.join([run_dir, "candidates", candidate_filename(entry_id)])
 
-      entry_id = opts.entry || "docs/test-entry"
-      route = "/" <> String.trim_leading(String.replace(entry_id, "docs/", "docs/"), "/")
-      candidate_filename = String.replace(entry_id, "/", "__") <> ".livemd"
-      candidate_path = Path.join([run_dir, "candidates", candidate_filename])
+      %{
+        run_id: run_id,
+        run_dir: run_dir,
+        report_path: report_path,
+        candidate_path: candidate_path
+      }
+    end
 
+    defp candidate_filename(entry_id), do: String.replace(entry_id, "/", "__") <> ".livemd"
+    defp route_for(entry_id), do: "/" <> String.trim_leading(String.replace(entry_id, "docs/", "docs/"), "/")
+
+    defp write_candidate(candidate_path) do
       :ok = File.mkdir_p(Path.dirname(candidate_path))
 
-      :ok =
-        File.write(
-          candidate_path,
-          """
-          # Candidate
+      File.write(
+        candidate_path,
+        """
+        # Candidate
 
-          ```elixir
-          IO.puts(:ok)
-          ```
-          """
-        )
+        ```elixir
+        IO.puts(:ok)
+        ```
+        """
+      )
+    end
 
-      stats = %{
+    defp stub_stats(opts) do
+      %{
         selected: 1,
         written: if(opts.apply, do: 1, else: 0),
         dry_run_candidates: if(opts.apply, do: 0, else: 1),
@@ -52,81 +88,92 @@ defmodule AgentJidoWeb.AdminContentGeneratorLiveTest do
         churn_blocked: 0,
         verification_failed: 0
       }
+    end
 
-      verification_status = if(opts.verify, do: "passed", else: "skipped")
-
-      report = %{
+    defp stub_report(opts, run_id, run_dir, report_path, entry_id, route, candidate_path, stats) do
+      %{
         run_id: run_id,
         generated_at: DateTime.utc_now(),
         report_path: report_path,
         run_dir: run_dir,
-        options: %{
-          apply: opts.apply,
-          entry: opts.entry,
-          max: opts.max,
-          statuses: Enum.map(opts.statuses || [], &Atom.to_string/1),
-          sections: opts.sections || [],
-          backend: Atom.to_string(opts.backend || :auto),
-          update_mode: Atom.to_string(opts.update_mode || :improve),
-          source_root: opts.source_root,
-          report: opts.report,
-          fail_on_audit: opts.fail_on_audit,
-          verify: opts.verify,
-          docs_format: Atom.to_string(opts.docs_format || :tag)
-        },
+        options: stub_options(opts),
         stats: stats,
-        entries: [
-          %{
-            id: entry_id,
-            title: "Stub Entry",
-            section: "docs",
-            route: route,
-            status: if(opts.apply, do: "written", else: "dry_run_candidate"),
-            candidate_path: candidate_path,
-            target_path: "priv/pages/docs/stub-entry.livemd",
-            read_path: "priv/pages/docs/stub-entry.livemd",
-            diff: %{
-              changed: true,
-              old_bytes: 0,
-              new_bytes: 42,
-              delta_bytes: 42,
-              old_lines: 0,
-              new_lines: 4,
-              delta_lines: 4
-            },
-            audit: %{errors: [], warnings: [], summary: %{}, score: 1.0},
-            verification: %{
-              status: verification_status,
-              checks: ["audit_only", "route_render", "livebook_test"],
-              check_results: %{
-                audit_only: "passed",
-                route_render: "passed",
-                livebook_test: verification_status
-              },
-              livebook_test_file: nil,
-              command_output_excerpt: nil
-            }
-          }
-        ],
+        entries: [stub_entry(opts, entry_id, route, candidate_path)],
         change_requests: []
       }
+    end
 
+    defp stub_options(opts) do
+      %{
+        apply: opts.apply,
+        entry: opts.entry,
+        max: opts.max,
+        statuses: Enum.map(opts.statuses || [], &Atom.to_string/1),
+        sections: opts.sections || [],
+        backend: Atom.to_string(opts.backend || :auto),
+        update_mode: Atom.to_string(opts.update_mode || :improve),
+        source_root: opts.source_root,
+        report: opts.report,
+        fail_on_audit: opts.fail_on_audit,
+        verify: opts.verify,
+        docs_format: Atom.to_string(opts.docs_format || :tag)
+      }
+    end
+
+    defp stub_entry(opts, entry_id, route, candidate_path) do
+      verification_status = if(opts.verify, do: "passed", else: "skipped")
+
+      %{
+        id: entry_id,
+        title: "Stub Entry",
+        section: "docs",
+        route: route,
+        status: if(opts.apply, do: "written", else: "dry_run_candidate"),
+        candidate_path: candidate_path,
+        target_path: "priv/pages/docs/stub-entry.livemd",
+        read_path: "priv/pages/docs/stub-entry.livemd",
+        diff: %{
+          changed: true,
+          old_bytes: 0,
+          new_bytes: 42,
+          delta_bytes: 42,
+          old_lines: 0,
+          new_lines: 4,
+          delta_lines: 4
+        },
+        audit: %{errors: [], warnings: [], summary: %{}, score: 1.0},
+        verification: %{
+          status: verification_status,
+          checks: ["audit_only", "route_render", "livebook_test"],
+          check_results: %{
+            audit_only: "passed",
+            route_render: "passed",
+            livebook_test: verification_status
+          },
+          livebook_test_file: nil,
+          command_output_excerpt: nil
+        }
+      }
+    end
+
+    defp write_report(report_path, report) do
       :ok = File.mkdir_p(Path.dirname(report_path))
-      :ok = File.write(report_path, Jason.encode!(report))
+      File.write(report_path, Jason.encode!(report))
+    end
 
-      {:ok,
-       %{
-         run_id: run_id,
-         generated_at: report.generated_at,
-         report_path: report_path,
-         stats: %{
-           selected: 1,
-           written: stats.written,
-           dry_run_candidates: stats.dry_run_candidates,
-           audit_failed: 0,
-           verification_failed: 0
-         }
-       }}
+    defp stub_result(run_id, report, stats) do
+      %{
+        run_id: run_id,
+        generated_at: report.generated_at,
+        report_path: report.report_path,
+        stats: %{
+          selected: 1,
+          written: stats.written,
+          dry_run_candidates: stats.dry_run_candidates,
+          audit_failed: 0,
+          verification_failed: 0
+        }
+      }
     end
   end
 

--- a/test/agent_jido_web/live/admin_content_ingestion_live_test.exs
+++ b/test/agent_jido_web/live/admin_content_ingestion_live_test.exs
@@ -15,11 +15,7 @@ defmodule AgentJidoWeb.AdminContentIngestionLiveTest do
         raise "targeted ingest must set reconcile_stale: false"
       end
 
-      total_sources =
-        case selected_sources do
-          [] -> 12
-          list -> length(list)
-        end
+      total_sources = if selected_sources == [], do: 12, else: length(selected_sources)
 
       %{
         mode: if(dry_run?, do: :dry_run, else: :apply),


### PR DESCRIPTION
## Summary\n- implement the Phase 4 hotspot reductions from the Credo remediation plan\n- flatten the remaining nested-body and complexity hotspots across content generation, LiveViews, OG image rendering, and supporting tests\n- keep the enforced quality gates green after the refactor batch\n\n## Verification\n- ASDF_ELIXIR_VERSION=1.18.4-otp-27 ASDF_ERLANG_VERSION=27.3 CONTENTOPS_CHAT_ENABLED=false mix compile --warnings-as-errors\n- ASDF_ELIXIR_VERSION=1.18.4-otp-27 ASDF_ERLANG_VERSION=27.3 CONTENTOPS_CHAT_ENABLED=false mix credo --strict\n- ASDF_ELIXIR_VERSION=1.18.4-otp-27 ASDF_ERLANG_VERSION=27.3 CONTENTOPS_CHAT_ENABLED=false mix test\n- ASDF_ELIXIR_VERSION=1.18.4-otp-27 ASDF_ERLANG_VERSION=27.3 CONTENTOPS_CHAT_ENABLED=false mix dialyzer