### PR TITLE
Credo Phase 5: promote strict checks to the quality gate

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,7 @@ mix format
 mix test
 ```
 
-`mix credo` and `mix quality` are encouraged for larger changes.
+`mix credo --strict` and `mix quality` are encouraged for larger changes. The managed `pre_push` hook now enforces `mix credo --strict`, `mix test`, and `mix dialyzer` before a branch is pushed.
 
 ## Pull Request Guidelines
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ mix credo
 mix quality
 ```
 
+`mix quality` now runs the strict Credo baseline, warnings-as-errors compile, and Dialyzer. The managed `pre_push` hook also runs `mix credo --strict`, `mix test`, and `mix dialyzer`.
+
 ## Content Layout
 
 - `priv/content_plan/**` contains content briefs and planning docs.

--- a/config/config.exs
+++ b/config/config.exs
@@ -184,6 +184,7 @@ if config_env() == :dev do
       ],
       pre_push: [
         tasks: [
+          {:cmd, "mix credo --strict"},
           {:mix_task, :test},
           {:mix_task, :dialyzer}
         ]

--- a/mix.exs
+++ b/mix.exs
@@ -149,7 +149,7 @@ defmodule AgentJido.MixProject do
       quality: [
         "format --check-formatted",
         "compile --warnings-as-errors",
-        "credo --min-priority higher",
+        "credo --strict",
         "dialyzer"
       ]
     ]


### PR DESCRIPTION
## Summary\n- promote  into the supported  path\n- add  to the managed  hook before test and Dialyzer\n- update contributor docs to reflect the new enforced quality path\n\n## Verification\n- ASDF_ELIXIR_VERSION=1.18.4-otp-27 ASDF_ERLANG_VERSION=27.3 CONTENTOPS_CHAT_ENABLED=false mix git_hooks.install\n- ASDF_ELIXIR_VERSION=1.18.4-otp-27 ASDF_ERLANG_VERSION=27.3 CONTENTOPS_CHAT_ENABLED=false mix quality\n- ASDF_ELIXIR_VERSION=1.18.4-otp-27 ASDF_ERLANG_VERSION=27.3 CONTENTOPS_CHAT_ENABLED=false git push -u origin codex/credo-phase-05-quality-gate-promotion