### PR TITLE
test(docs): lock plugins runtime startup example

### DIFF
--- a/test/agent_jido/docs/plugins_and_composable_agents_source_test.exs
+++ b/test/agent_jido/docs/plugins_and_composable_agents_source_test.exs
@@ -1,0 +1,13 @@
+defmodule AgentJido.Docs.PluginsAndComposableAgentsSourceTest do
+  use ExUnit.Case, async: true
+
+  @source_path Path.expand("../../../priv/pages/docs/learn/plugins-and-composable-agents.livemd", __DIR__)
+
+  test "signal routing section uses the runtime instance name" do
+    source = File.read!(@source_path)
+
+    assert source =~ "Jido.start_agent(runtime_name, MyApp.NotesAgent, id: \"notes-demo\")"
+    refute source =~ "Jido.start_agent(jido, MyApp.NotesAgent, id: \"notes-demo\")"
+    assert source =~ "expects the runtime instance name, not that pid"
+  end
+end


### PR DESCRIPTION
## Summary
- add regression coverage for the plugins-and-composable-agents signal routing snippet
- assert the page uses the runtime instance name with Jido.start_agent/3
- guard against the old pid-based example form returning to the docs

Closes #71

## Verification
- ASDF_ELIXIR_VERSION=1.18.4-otp-27 ASDF_ERLANG_VERSION=27.3 CONTENTOPS_CHAT_ENABLED=false mix test test/agent_jido/docs/plugins_and_composable_agents_source_test.exs
- ASDF_ELIXIR_VERSION=1.18.4-otp-27 ASDF_ERLANG_VERSION=27.3 CONTENTOPS_CHAT_ENABLED=false git push -u origin codex/fix-issue-71-plugin-runtime-regression