### PR TITLE
feat(examples): replace Runic delegating demo

### DIFF
--- a/lib/agent_jido/demos/runic_delegating_orchestrator/orchestrator_agent.ex
+++ b/lib/agent_jido/demos/runic_delegating_orchestrator/orchestrator_agent.ex
@@ -1,0 +1,52 @@
+defmodule AgentJido.Demos.RunicDelegatingOrchestrator.OrchestratorAgent do
+  @moduledoc """
+  Deterministic Runic orchestrator that delegates drafting and editing nodes.
+  """
+
+  @child_modules %{
+    drafter: Jido.Runic.ChildWorker,
+    editor: Jido.Runic.ChildWorker
+  }
+
+  use Jido.Agent,
+    name: "runic_delegating_orchestrator",
+    description: "Runs deterministic local and delegated Runic stages with child-worker handoffs",
+    strategy: {Jido.Runic.Strategy, workflow_fn: &__MODULE__.build_workflow/0, child_modules: @child_modules},
+    schema: []
+
+  alias AgentJido.Demos.RunicResearchStudio.Actions.{
+    BuildOutline,
+    DraftArticle,
+    EditAndAssemble,
+    PlanQueries,
+    SimulateSearch
+  }
+
+  alias Jido.Runic.ActionNode
+  alias Runic.Workflow
+
+  @doc false
+  @spec plugin_specs() :: [Jido.Plugin.Spec.t()]
+  def plugin_specs, do: []
+
+  @doc "Returns the deterministic child-module mapping used by the delegating example."
+  @spec child_modules() :: %{drafter: module(), editor: module()}
+  def child_modules, do: @child_modules
+
+  @doc "Builds the five-stage delegating workflow DAG."
+  @spec build_workflow() :: Runic.Workflow.t()
+  def build_workflow do
+    draft_node =
+      ActionNode.new(DraftArticle, %{}, name: :draft_article, executor: {:child, :drafter})
+
+    edit_node =
+      ActionNode.new(EditAndAssemble, %{}, name: :edit_and_assemble, executor: {:child, :editor})
+
+    Workflow.new(name: :delegating_pipeline)
+    |> Workflow.add(PlanQueries)
+    |> Workflow.add(SimulateSearch, to: :plan_queries)
+    |> Workflow.add(BuildOutline, to: :simulate_search)
+    |> Workflow.add(draft_node, to: :build_outline)
+    |> Workflow.add(edit_node, to: :draft_article)
+  end
+end

--- a/lib/agent_jido/demos/runic_delegating_orchestrator/runtime_demo.ex
+++ b/lib/agent_jido/demos/runic_delegating_orchestrator/runtime_demo.ex
@@ -1,0 +1,313 @@
+defmodule AgentJido.Demos.RunicDelegatingOrchestrator.RuntimeDemo do
+  @moduledoc """
+  Deterministic wrapper around the real Runic delegating orchestrator workflow.
+  """
+
+  alias AgentJido.Demos.RunicDelegatingOrchestrator.OrchestratorAgent
+  alias AgentJido.Demos.RunicResearchStudio.Fixtures
+  alias Jido.Agent.Directive.Emit
+  alias Jido.Agent.Strategy.State, as: StratState
+  alias Jido.Runic.Directive.ExecuteRunnable
+  alias Jido.Runic.Introspection
+  alias Runic.Workflow
+  alias Runic.Workflow.Invokable
+
+  @pipeline_order [:plan_queries, :simulate_search, :build_outline, :draft_article, :edit_and_assemble]
+
+  defstruct selected_topic_id: Fixtures.default_topic_id(),
+            selected_topic: nil,
+            agent: nil,
+            graph: %{nodes: [], edges: []},
+            executions: [],
+            handoffs: [],
+            log: [],
+            status: :idle,
+            done?: false,
+            article_markdown: "",
+            takeaway: ""
+
+  @type execution_entry :: %{
+          required(:index) => non_neg_integer(),
+          required(:target) => :local | {:child, atom()},
+          required(:node) => atom(),
+          required(:action) => module() | nil,
+          required(:status) => atom(),
+          required(:input) => map(),
+          required(:output) => map() | nil,
+          required(:error) => term()
+        }
+
+  @type handoff_entry :: %{
+          required(:index) => non_neg_integer(),
+          required(:tag) => atom(),
+          required(:node) => atom(),
+          required(:runnable_id) => term(),
+          required(:state) => atom(),
+          required(:child_module) => module()
+        }
+
+  @type t :: %__MODULE__{
+          selected_topic_id: String.t(),
+          selected_topic: map(),
+          agent: Jido.Agent.t(),
+          graph: map(),
+          executions: [execution_entry()],
+          handoffs: [handoff_entry()],
+          log: [map()],
+          status: atom(),
+          done?: boolean(),
+          article_markdown: String.t(),
+          takeaway: String.t()
+        }
+
+  @doc "Returns the deterministic topic catalog used by the delegating example."
+  @spec topics() :: [map()]
+  def topics, do: Fixtures.catalog()
+
+  @doc "Returns the fixed workflow ordering for rendering the delegating graph."
+  @spec pipeline_order() :: [atom()]
+  def pipeline_order, do: @pipeline_order
+
+  @doc "Builds a fresh demo state for the selected topic."
+  @spec new(String.t() | nil) :: t()
+  def new(topic_id \\ nil) do
+    selected_topic = Fixtures.fetch!(topic_id || Fixtures.default_topic_id())
+    agent = OrchestratorAgent.new()
+
+    %__MODULE__{
+      selected_topic_id: selected_topic.id,
+      selected_topic: selected_topic,
+      agent: agent,
+      graph: graph_for(agent)
+    }
+    |> sync_status()
+  end
+
+  @doc "Resets the delegating demo while optionally changing topic."
+  @spec reset(t(), keyword()) :: t()
+  def reset(%__MODULE__{} = demo, opts \\ []) do
+    topic_id = Keyword.get(opts, :topic_id, demo.selected_topic_id)
+    new(topic_id)
+  end
+
+  @doc "Changes the selected topic by rebuilding the demo state."
+  @spec select_topic(t(), String.t()) :: t()
+  def select_topic(%__MODULE__{} = demo, topic_id) do
+    reset(demo, topic_id: topic_id)
+  end
+
+  @doc "Runs the full deterministic delegating workflow."
+  @spec run(t()) :: t()
+  def run(%__MODULE__{} = demo) do
+    demo =
+      demo
+      |> reset()
+      |> append_log("Feed", "Fed the selected topic into the delegating Runic workflow.")
+
+    {agent, directives} =
+      strategy_cmd(demo.agent, :runic_feed_signal, %{data: %{topic: demo.selected_topic.title}})
+
+    demo =
+      demo
+      |> Map.put(:agent, agent)
+      |> sync_status()
+      |> run_directives(directives)
+
+    productions = productions_for(demo.agent)
+
+    demo
+    |> Map.put(:graph, graph_for(demo.agent))
+    |> Map.put(:article_markdown, extract_article_markdown(productions))
+    |> Map.put(:takeaway, extract_takeaway(productions))
+    |> append_log("Complete", "Finished the delegating pipeline with local and child-worker stages.")
+    |> sync_status()
+  end
+
+  @doc "Returns the completed local node names from the current execution history."
+  @spec completed_local_nodes(t()) :: [atom()]
+  def completed_local_nodes(%__MODULE__{} = demo) do
+    demo.executions
+    |> Enum.filter(&(&1.target == :local and &1.status == :completed))
+    |> Enum.map(& &1.node)
+  end
+
+  @doc "Returns the completed delegated child tags from the current handoff history."
+  @spec completed_child_tags(t()) :: [atom()]
+  def completed_child_tags(%__MODULE__{} = demo) do
+    demo.handoffs
+    |> Enum.filter(&(&1.state == :completed))
+    |> Enum.map(& &1.tag)
+  end
+
+  defp run_directives(%__MODULE__{} = demo, directives) when directives in [nil, []], do: sync_status(demo)
+
+  defp run_directives(%__MODULE__{} = demo, directives) when is_list(directives) do
+    Enum.reduce(directives, demo, fn
+      %ExecuteRunnable{target: :local} = directive, acc ->
+        executed = Invokable.execute(directive.runnable.node, directive.runnable)
+        {agent, next_directives} = strategy_cmd(acc.agent, :runic_apply_result, %{runnable: executed})
+
+        acc
+        |> Map.put(:agent, agent)
+        |> record_execution(executed, :local)
+        |> sync_status()
+        |> run_directives(next_directives)
+
+      %ExecuteRunnable{target: {:child, tag}} = directive, acc ->
+        handle_child_execution(acc, directive, tag)
+
+      %Emit{} = directive, acc ->
+        signal_type = Map.get(directive.signal, :type, "runic.workflow.production")
+        append_log(acc, "Emit", "Emitted #{signal_type}.")
+
+      _other, acc ->
+        acc
+    end)
+  end
+
+  defp handle_child_execution(%__MODULE__{} = demo, %ExecuteRunnable{} = directive, tag) do
+    executor = Map.fetch!(directive.runnable.node, :executor)
+    child_module = Map.fetch!(OrchestratorAgent.child_modules(), tag)
+
+    {agent, _spawn_directives} =
+      strategy_cmd(demo.agent, :runic_child_dispatch, %{
+        tag: tag,
+        runnable_id: directive.runnable_id,
+        runnable: directive.runnable,
+        executor: executor
+      })
+
+    demo =
+      demo
+      |> Map.put(:agent, agent)
+      |> record_handoff(tag, directive, :spawn_requested, child_module)
+      |> append_log("Delegate", "Assigned #{directive.runnable.node.name} to child #{tag}.")
+
+    {agent, _emit_directives} =
+      strategy_cmd(demo.agent, :runic_child_started, %{
+        tag: tag,
+        pid: self(),
+        parent_id: demo.agent.id,
+        child_id: "#{tag}-child",
+        child_module: child_module,
+        meta: %{demo: true}
+      })
+
+    demo =
+      demo
+      |> Map.put(:agent, agent)
+      |> record_handoff(tag, directive, :child_started, child_module)
+      |> append_log("Child ready", "Child #{tag} accepted #{directive.runnable.node.name}.")
+
+    executed = Invokable.execute(directive.runnable.node, directive.runnable)
+    {agent, next_directives} = strategy_cmd(demo.agent, :runic_apply_result, %{runnable: executed})
+
+    demo
+    |> Map.put(:agent, agent)
+    |> record_execution(executed, {:child, tag})
+    |> record_handoff(tag, directive, :completed, child_module)
+    |> append_log("Child complete", "Child #{tag} completed #{directive.runnable.node.name}.")
+    |> sync_status()
+    |> run_directives(next_directives)
+  end
+
+  defp strategy_cmd(agent, action, params) do
+    OrchestratorAgent.cmd(agent, {action, params})
+  end
+
+  defp graph_for(agent) do
+    strat = StratState.get(agent, %{})
+    workflow = Map.get(strat, :workflow, OrchestratorAgent.build_workflow())
+    Introspection.annotated_graph(workflow, strat)
+  end
+
+  defp productions_for(agent) do
+    agent
+    |> current_workflow()
+    |> Workflow.raw_productions()
+  end
+
+  defp current_workflow(agent) do
+    StratState.get(agent, %{})
+    |> Map.get(:workflow, OrchestratorAgent.build_workflow())
+  end
+
+  defp sync_status(%__MODULE__{} = demo) do
+    status = StratState.get(demo.agent, %{}) |> Map.get(:status, :idle)
+    %{demo | status: status, done?: status in [:success, :failure]}
+  end
+
+  defp record_execution(%__MODULE__{} = demo, runnable, target) do
+    entry = %{
+      index: length(demo.executions),
+      target: target,
+      node: runnable.node.name,
+      action: action_module_for(runnable.node),
+      status: runnable.status,
+      input: runnable.input_fact.value,
+      output: if(runnable.status == :completed, do: runnable.result.value, else: nil),
+      error: if(runnable.status == :failed, do: runnable.error, else: nil)
+    }
+
+    demo
+    |> Map.update!(:executions, &(&1 ++ [entry]))
+    |> append_log(log_label(entry), log_detail(entry))
+  end
+
+  defp record_handoff(%__MODULE__{} = demo, tag, %ExecuteRunnable{} = directive, state, child_module) do
+    entry = %{
+      index: length(demo.handoffs),
+      tag: tag,
+      node: directive.runnable.node.name,
+      runnable_id: directive.runnable_id,
+      state: state,
+      child_module: child_module
+    }
+
+    Map.update!(demo, :handoffs, &(&1 ++ [entry]))
+  end
+
+  defp extract_article_markdown(productions) do
+    Enum.find_value(productions, "", fn
+      %{article_markdown: article_markdown} when is_binary(article_markdown) -> article_markdown
+      _ -> nil
+    end)
+  end
+
+  defp extract_takeaway(productions) do
+    Enum.find_value(productions, "", fn
+      %{takeaway: takeaway} when is_binary(takeaway) -> takeaway
+      _ -> nil
+    end)
+  end
+
+  defp log_label(%{target: :local, node: node}), do: "local.#{node}"
+  defp log_label(%{target: {:child, tag}, node: node}), do: "child.#{tag}.#{node}"
+
+  defp log_detail(%{status: :completed, output: output}) do
+    "Completed with keys #{output_keys(output)}."
+  end
+
+  defp log_detail(%{status: :failed, error: error}) do
+    "Failed with #{inspect(error)}."
+  end
+
+  defp log_detail(entry) do
+    "Finished with status #{entry.status}."
+  end
+
+  defp output_keys(output) when is_map(output) do
+    output
+    |> Map.keys()
+    |> Enum.map_join(", ", &to_string/1)
+  end
+
+  defp output_keys(_output), do: "none"
+
+  defp append_log(%__MODULE__{} = demo, label, detail) do
+    entry = %{label: label, detail: detail}
+    Map.update!(demo, :log, &([entry | &1] |> Enum.take(24)))
+  end
+
+  defp action_module_for(node), do: Map.get(node, :action_mod)
+end

--- a/lib/agent_jido_web/examples/runic_delegating_orchestrator_live.ex
+++ b/lib/agent_jido_web/examples/runic_delegating_orchestrator_live.ex
@@ -1,0 +1,254 @@
+defmodule AgentJidoWeb.Examples.RunicDelegatingOrchestratorLive do
+  @moduledoc """
+  Interactive demo for deterministic Runic delegation workflows.
+  """
+
+  use AgentJidoWeb, :live_view
+
+  alias AgentJido.Demos.RunicDelegatingOrchestrator.RuntimeDemo
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {:ok, assign(socket, :demo, RuntimeDemo.new())}
+  end
+
+  @impl true
+  def render(assigns) do
+    ordered_nodes = ordered_nodes(assigns.demo.graph)
+    assigns = assign(assigns, :ordered_nodes, ordered_nodes)
+
+    ~H"""
+    <div id="runic-delegating-orchestrator-demo" class="rounded-lg border border-border bg-card p-6 space-y-6">
+      <div class="flex items-center justify-between gap-4">
+        <div>
+          <div class="text-sm font-semibold text-foreground">Runic Delegating Orchestrator</div>
+          <div class="text-[11px] text-muted-foreground">
+            Real deterministic parent and child-worker handoffs for delegated drafting and editing stages
+          </div>
+        </div>
+        <div class="text-[10px] font-mono text-muted-foreground bg-elevated px-2 py-1 rounded border border-border">
+          status: {@demo.status}
+        </div>
+      </div>
+
+      <div class="grid gap-3 sm:grid-cols-4">
+        <div class="rounded-md border border-border bg-elevated p-3 text-center">
+          <div class="text-[10px] uppercase tracking-wider text-muted-foreground">Local Nodes</div>
+          <div id="runic-delegating-local-count" class="text-sm font-semibold text-foreground mt-2">
+            {length(RuntimeDemo.completed_local_nodes(@demo))}
+          </div>
+        </div>
+        <div class="rounded-md border border-border bg-elevated p-3 text-center">
+          <div class="text-[10px] uppercase tracking-wider text-muted-foreground">Delegated Nodes</div>
+          <div id="runic-delegating-delegated-count" class="text-sm font-semibold text-foreground mt-2">
+            {length(RuntimeDemo.completed_child_tags(@demo))}
+          </div>
+        </div>
+        <div class="rounded-md border border-border bg-elevated p-3 text-center">
+          <div class="text-[10px] uppercase tracking-wider text-muted-foreground">Handoff Events</div>
+          <div id="runic-delegating-handoff-count" class="text-sm font-semibold text-foreground mt-2">
+            {length(@demo.handoffs)}
+          </div>
+        </div>
+        <div class="rounded-md border border-border bg-elevated p-3 text-center">
+          <div class="text-[10px] uppercase tracking-wider text-muted-foreground">Executed Nodes</div>
+          <div id="runic-delegating-execution-count" class="text-sm font-semibold text-foreground mt-2">
+            {length(@demo.executions)}
+          </div>
+        </div>
+      </div>
+
+      <div class="space-y-3">
+        <div class="text-[10px] uppercase tracking-wider text-muted-foreground">Topic presets</div>
+        <div class="flex gap-2 flex-wrap">
+          <%= for topic <- RuntimeDemo.topics() do %>
+            <button
+              phx-click="select_topic"
+              phx-value-topic={topic.id}
+              class={"px-3 py-2 rounded-md border text-xs transition-colors #{topic_button_class(@demo.selected_topic_id == topic.id)}"}
+            >
+              {topic.title}
+            </button>
+          <% end %>
+        </div>
+      </div>
+
+      <div class="rounded-md border border-border bg-elevated p-4">
+        <div class="text-[10px] uppercase tracking-wider text-muted-foreground mb-2">Selected Topic</div>
+        <div id="runic-delegating-topic" class="text-sm font-semibold text-foreground">{@demo.selected_topic.title}</div>
+        <div class="text-[11px] text-muted-foreground mt-2">
+          Delegated nodes: `draft_article -> child:drafter`, `edit_and_assemble -> child:editor`
+        </div>
+      </div>
+
+      <div class="flex gap-3 flex-wrap">
+        <button
+          id="runic-delegating-run-btn"
+          phx-click="run_workflow"
+          class="px-4 py-2 rounded-md bg-primary/10 border border-primary/30 text-primary hover:bg-primary/20 transition-colors text-sm font-semibold"
+        >
+          Run Delegating Workflow
+        </button>
+        <button
+          id="runic-delegating-reset-btn"
+          phx-click="reset_demo"
+          class="px-3 py-2 rounded-md bg-elevated border border-border text-muted-foreground hover:text-foreground hover:border-primary/40 transition-colors text-xs"
+        >
+          Reset
+        </button>
+      </div>
+
+      <div class="grid gap-4 xl:grid-cols-[0.95fr_1.05fr]">
+        <div class="space-y-4">
+          <div class="rounded-md border border-border bg-elevated p-4">
+            <div class="flex items-center justify-between mb-2">
+              <div class="text-[10px] uppercase tracking-wider text-muted-foreground">Workflow Graph</div>
+              <div class="text-[10px] text-muted-foreground">{length(@ordered_nodes)} node(s)</div>
+            </div>
+
+            <div id="runic-delegating-graph" class="space-y-2">
+              <%= for node <- @ordered_nodes do %>
+                <div class="rounded-md border border-border bg-background/70 p-3">
+                  <div class="flex items-center justify-between gap-3">
+                    <div>
+                      <div class="text-xs font-semibold text-foreground">{node.name}</div>
+                      <div class="text-[11px] text-muted-foreground mt-1">{inspect(node.action_mod)}</div>
+                      <div class="text-[10px] text-muted-foreground mt-1">{executor_label(node)}</div>
+                    </div>
+                    <div class={"text-[10px] uppercase tracking-wider #{node_status_class(node.status)}"}>
+                      {node.status}
+                    </div>
+                  </div>
+                </div>
+              <% end %>
+            </div>
+          </div>
+
+          <div class="rounded-md border border-border bg-elevated p-4">
+            <div class="flex items-center justify-between mb-2">
+              <div class="text-[10px] uppercase tracking-wider text-muted-foreground">Child Handoffs</div>
+              <div class="text-[10px] text-muted-foreground">{length(@demo.handoffs)} event(s)</div>
+            </div>
+
+            <div :if={@demo.handoffs == []} class="text-xs text-muted-foreground">
+              Run the workflow to inspect child assignment, child start, and child completion events.
+            </div>
+
+            <div :if={@demo.handoffs != []} id="runic-delegating-handoffs" class="space-y-2 max-h-[24rem] overflow-y-auto">
+              <%= for entry <- @demo.handoffs do %>
+                <div class="rounded-md border border-border bg-background/70 px-3 py-2">
+                  <div class="text-[11px] font-semibold text-foreground">{entry.node} -> {entry.tag}</div>
+                  <div class="text-[11px] text-muted-foreground">
+                    {entry.state} via {inspect(entry.child_module)}
+                  </div>
+                </div>
+              <% end %>
+            </div>
+          </div>
+        </div>
+
+        <div class="space-y-4">
+          <div class="rounded-md border border-border bg-elevated p-4">
+            <div class="text-[10px] uppercase tracking-wider text-muted-foreground mb-2">Article Output</div>
+            <pre id="runic-delegating-article" class="text-[11px] text-foreground whitespace-pre-wrap font-mono"><%= if @demo.article_markdown == "", do: "Run the workflow to inspect the delegated article artifact.", else: @demo.article_markdown %></pre>
+          </div>
+
+          <div class="rounded-md border border-border bg-elevated p-4">
+            <div class="text-[10px] uppercase tracking-wider text-muted-foreground mb-2">Takeaway</div>
+            <div id="runic-delegating-takeaway" class="text-[11px] text-foreground whitespace-pre-wrap">
+              {if @demo.takeaway == "", do: "The editorial takeaway appears after the delegated workflow completes.", else: @demo.takeaway}
+            </div>
+          </div>
+
+          <div class="rounded-md border border-border bg-elevated p-4">
+            <div class="flex items-center justify-between mb-2">
+              <div class="text-[10px] uppercase tracking-wider text-muted-foreground">Execution Log</div>
+              <div class="text-[10px] text-muted-foreground">{length(@demo.executions)} entry(s)</div>
+            </div>
+
+            <div :if={@demo.executions == []} class="text-xs text-muted-foreground">
+              Each local or delegated runnable records its input and output here.
+            </div>
+
+            <div :if={@demo.executions != []} id="runic-delegating-log" class="space-y-3 max-h-[28rem] overflow-y-auto">
+              <%= for entry <- @demo.executions do %>
+                <div class="rounded-md border border-border bg-background/70 p-3 space-y-2">
+                  <div class="flex items-center justify-between gap-3">
+                    <div>
+                      <div class="text-xs font-semibold text-foreground">{entry.node}</div>
+                      <div class="text-[10px] uppercase tracking-wider text-muted-foreground mt-1">{target_label(entry.target)}</div>
+                    </div>
+                    <div class="text-[10px] uppercase tracking-wider text-muted-foreground">{entry.status}</div>
+                  </div>
+                  <div class="grid gap-2 lg:grid-cols-2">
+                    <div>
+                      <div class="text-[10px] uppercase tracking-wider text-muted-foreground mb-1">Input</div>
+                      <pre class="text-[11px] text-foreground whitespace-pre-wrap font-mono"><%= inspect(entry.input, pretty: true, width: 70) %></pre>
+                    </div>
+                    <div>
+                      <div class="text-[10px] uppercase tracking-wider text-muted-foreground mb-1">Output</div>
+                      <pre class="text-[11px] text-foreground whitespace-pre-wrap font-mono"><%= inspect(entry.output, pretty: true, width: 70) %></pre>
+                    </div>
+                  </div>
+                </div>
+              <% end %>
+            </div>
+          </div>
+
+          <div class="rounded-md border border-border bg-elevated p-4">
+            <div class="flex items-center justify-between mb-2">
+              <div class="text-[10px] uppercase tracking-wider text-muted-foreground">Activity</div>
+              <div class="text-[10px] text-muted-foreground">{length(@demo.log)} note(s)</div>
+            </div>
+            <div class="space-y-2 max-h-[18rem] overflow-y-auto">
+              <%= for entry <- @demo.log do %>
+                <div class="rounded-md border border-border bg-background/70 px-3 py-2">
+                  <div class="text-[11px] font-semibold text-foreground">{entry.label}</div>
+                  <div class="text-[11px] text-muted-foreground">{entry.detail}</div>
+                </div>
+              <% end %>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  @impl true
+  def handle_event("select_topic", %{"topic" => topic_id}, socket) do
+    {:noreply, assign(socket, :demo, RuntimeDemo.select_topic(socket.assigns.demo, topic_id))}
+  end
+
+  def handle_event("run_workflow", _params, socket) do
+    {:noreply, assign(socket, :demo, RuntimeDemo.run(socket.assigns.demo))}
+  end
+
+  def handle_event("reset_demo", _params, socket) do
+    {:noreply, assign(socket, :demo, RuntimeDemo.reset(socket.assigns.demo))}
+  end
+
+  defp ordered_nodes(graph) do
+    order_index = RuntimeDemo.pipeline_order() |> Enum.with_index() |> Map.new()
+
+    graph.nodes
+    |> Enum.sort_by(fn node -> Map.get(order_index, node.name, 999) end)
+  end
+
+  defp executor_label(%{executor: {:child, tag}}), do: "executor: child #{tag}"
+  defp executor_label(%{executor: {:child, tag, _spec}}), do: "executor: child #{tag}"
+  defp executor_label(_node), do: "executor: local"
+
+  defp target_label(:local), do: "local"
+  defp target_label({:child, tag}), do: "child #{tag}"
+
+  defp topic_button_class(true), do: "border-primary/40 bg-primary/10 text-primary"
+  defp topic_button_class(false), do: "border-border bg-elevated text-muted-foreground hover:text-foreground hover:border-primary/30"
+
+  defp node_status_class(:completed), do: "text-emerald-300"
+  defp node_status_class(:pending), do: "text-amber-300"
+  defp node_status_class(:failed), do: "text-red-300"
+  defp node_status_class(:idle), do: "text-muted-foreground"
+  defp node_status_class(:waiting), do: "text-accent-cyan"
+  defp node_status_class(_other), do: "text-muted-foreground"
+end

--- a/lib/agent_jido_web/examples/simulated_showcase_live.ex
+++ b/lib/agent_jido_web/examples/simulated_showcase_live.ex
@@ -242,26 +242,6 @@ defmodule AgentJidoWeb.Examples.SimulatedShowcaseLive do
     }
   end
 
-  defp scenario_for("runic-delegating-orchestrator") do
-    %{
-      title: "Runic Delegating Orchestrator",
-      steps: [
-        %{label: "Local nodes", detail: "Ran PlanQueries, SimulateSearch, and BuildOutline locally"},
-        %{label: "Delegate draft", detail: "Dispatched DraftArticle runnable to child:drafter"},
-        %{label: "Apply child result", detail: "Parent applied runnable completion to workflow"},
-        %{label: "Delegate edit", detail: "Dispatched EditAndAssemble runnable to child:editor"},
-        %{label: "Finalize", detail: "Parent merged child outputs and emitted final article"}
-      ],
-      result: """
-      {
-        "model": "simulated:runic-orchestrator",
-        "delegated_nodes": ["draft_article", "edit_and_assemble"],
-        "status": "completed"
-      }
-      """
-    }
-  end
-
   defp scenario_for("jido-ai-weather-multi-turn-context") do
     %{
       title: "Jido.AI Weather Multi-Turn Context",

--- a/priv/examples/runic-delegating-orchestrator.md
+++ b/priv/examples/runic-delegating-orchestrator.md
@@ -1,7 +1,7 @@
 %{
   title: "Runic Delegating Orchestrator",
-  description: "Parent workflow that delegates selected nodes to child agents for execution.",
-  tags: ["primary", "showcase", "simulated", "ai", "l2", "coordination", "runic", "multi-agent"],
+  description: "Parent Runic workflow that executes early stages locally and delegates drafting/editing stages through the real child-worker handoff strategy path.",
+  tags: ["primary", "showcase", "ai", "l2", "coordination", "runic", "multi-agent"],
   category: :ai,
   emoji: "🛰",
   related_resources: [
@@ -27,10 +27,14 @@
     }
   ],
   source_files: [
-    "lib/agent_jido_web/examples/simulated_showcase_live.ex"
+    "lib/agent_jido/demos/runic_research_studio/fixtures.ex",
+    "lib/agent_jido/demos/runic_research_studio/actions.ex",
+    "lib/agent_jido/demos/runic_delegating_orchestrator/orchestrator_agent.ex",
+    "lib/agent_jido/demos/runic_delegating_orchestrator/runtime_demo.ex",
+    "lib/agent_jido_web/examples/runic_delegating_orchestrator_live.ex"
   ],
-  live_view_module: "AgentJidoWeb.Examples.SimulatedShowcaseLive",
-  difficulty: :advanced,
+  live_view_module: "AgentJidoWeb.Examples.RunicDelegatingOrchestratorLive",
+  difficulty: :intermediate,
   status: :live,
   scenario_cluster: :coordination,
   wave: :l2,
@@ -38,7 +42,7 @@
   content_intent: :tutorial,
   capability_theme: :coordination_orchestration,
   evidence_surface: :runnable_example,
-  demo_mode: :simulated,
+  demo_mode: :real,
   sort_order: 18
 }
 ---
@@ -47,7 +51,7 @@
 
 - How to mix local node execution with delegated child-agent nodes
 - How `executor: {:child, tag}` affects workflow dispatch behavior
-- How to surface parent/child handoff traces in a deterministic demo UI
+- How to surface parent/child handoff traces in a deterministic demo UI without starting external services
 
 ## Delegated stages
 
@@ -55,4 +59,4 @@
 
 ## Demo note
 
-This page simulates child-agent handoffs and runnable completion signals using fixtures, not live child processes.
+This page runs the real Runic delegation strategy path locally. The child-worker outputs are deterministic fixtures, but the handoff states, delegated runnable execution, and final article artifact come from the actual workflow and strategy commands.

--- a/test/agent_jido/demos/runic_delegating_orchestrator/runtime_demo_test.exs
+++ b/test/agent_jido/demos/runic_delegating_orchestrator/runtime_demo_test.exs
@@ -1,0 +1,30 @@
+defmodule AgentJido.Demos.RunicDelegatingOrchestrator.RuntimeDemoTest do
+  use ExUnit.Case, async: true
+
+  alias AgentJido.Demos.RunicDelegatingOrchestrator.RuntimeDemo
+
+  test "run completes the delegating pipeline with local and child-worker stages" do
+    demo =
+      RuntimeDemo.new("elixir-concurrency")
+      |> RuntimeDemo.run()
+
+    assert demo.status == :success
+    assert RuntimeDemo.completed_local_nodes(demo) == [:plan_queries, :simulate_search, :build_outline]
+    assert RuntimeDemo.completed_child_tags(demo) == [:drafter, :editor]
+    assert Enum.map(demo.graph.nodes, & &1.status) == [:completed, :completed, :completed, :completed, :completed]
+    assert demo.article_markdown =~ "## Research Sources"
+    assert demo.takeaway =~ "Concurrency pays off"
+  end
+
+  test "handoff history records spawn, child start, and completion for each delegated node" do
+    demo =
+      RuntimeDemo.new("fly-bluegreen")
+      |> RuntimeDemo.run()
+
+    assert Enum.count(demo.handoffs, &(&1.state == :spawn_requested)) == 2
+    assert Enum.count(demo.handoffs, &(&1.state == :child_started)) == 2
+    assert Enum.count(demo.handoffs, &(&1.state == :completed)) == 2
+    assert Enum.any?(demo.handoffs, &(&1.tag == :drafter and &1.node == :draft_article))
+    assert Enum.any?(demo.handoffs, &(&1.tag == :editor and &1.node == :edit_and_assemble))
+  end
+end

--- a/test/agent_jido/examples_test.exs
+++ b/test/agent_jido/examples_test.exs
@@ -16,7 +16,7 @@ defmodule AgentJido.ExamplesTest do
     {"runic-ai-research-studio-step-mode", "AgentJidoWeb.Examples.RunicResearchStudioStepModeLive"},
     {"runic-adaptive-researcher", "AgentJidoWeb.Examples.RunicAdaptiveResearcherLive"},
     {"runic-structured-llm-branching", "AgentJidoWeb.Examples.RunicStructuredBranchingLive"},
-    {"runic-delegating-orchestrator", "AgentJidoWeb.Examples.SimulatedShowcaseLive"},
+    {"runic-delegating-orchestrator", "AgentJidoWeb.Examples.RunicDelegatingOrchestratorLive"},
     {"jido-ai-actions-runtime-demos", "AgentJidoWeb.Examples.ActionsRuntimeDemoLive"},
     {"jido-ai-browser-web-workflow", "AgentJidoWeb.Examples.BrowserDocsScoutAgentLive"},
     {"jido-ai-weather-multi-turn-context", "AgentJidoWeb.Examples.SimulatedShowcaseLive"},

--- a/test/agent_jido_web/live/jido_example_live_test.exs
+++ b/test/agent_jido_web/live/jido_example_live_test.exs
@@ -8,7 +8,6 @@ defmodule AgentJidoWeb.JidoExampleLiveTest do
 
   @endpoint AgentJidoWeb.Endpoint
   @new_simulated_showcase_examples [
-    {"runic-delegating-orchestrator", "Runic Delegating Orchestrator"},
     {"jido-ai-weather-multi-turn-context", "Jido.AI Weather Multi-Turn Context"},
     {"jido-ai-weather-reasoning-strategy-suite", "Jido.AI Weather Reasoning Strategy Suite"},
     {"jido-ai-operational-agents-pack", "Jido.AI Operational Agents Pack"}
@@ -415,6 +414,65 @@ defmodule AgentJidoWeb.JidoExampleLiveTest do
                "lib/agent_jido/demos/runic_adaptive_researcher/orchestrator_agent.ex",
                "lib/agent_jido/demos/runic_adaptive_researcher/runtime_demo.ex",
                "lib/agent_jido_web/examples/runic_adaptive_researcher_live.ex"
+             ]
+
+      assert Enum.map(example.sources, & &1.path) == example.source_files
+    end
+  end
+
+  describe "/examples/runic-delegating-orchestrator" do
+    test "renders explanation tab with real delegation guidance", %{conn: conn} do
+      {:ok, _view, html} = live(conn, "/examples/runic-delegating-orchestrator?tab=explanation")
+
+      assert html =~ "Runic Delegating Orchestrator"
+      assert html =~ "executor: {:child, tag}"
+      assert html =~ "child-worker handoff strategy path"
+      assert html =~ "real Runic delegation strategy path locally"
+    end
+
+    test "renders source tab for the dedicated delegating example", %{conn: conn} do
+      {:ok, _view, html} = live(conn, "/examples/runic-delegating-orchestrator?tab=source")
+
+      assert html =~ "fixtures.ex"
+      assert html =~ "actions.ex"
+      assert html =~ "orchestrator_agent.ex"
+      assert html =~ "runtime_demo.ex"
+      assert html =~ "runic_delegating_orchestrator_live.ex"
+      refute html =~ "simulated_showcase_live.ex"
+    end
+
+    test "demo tab runs the deterministic delegating workflow", %{conn: conn} do
+      {:ok, view, html} = live(conn, "/examples/runic-delegating-orchestrator?tab=demo")
+
+      assert html =~ "Runic Delegating Orchestrator"
+      refute html =~ "Simulated demo"
+
+      demo_view = find_live_child(view, "demo-runic-delegating-orchestrator")
+
+      html =
+        demo_view
+        |> element("#runic-delegating-orchestrator-demo button[phx-click='run_workflow']")
+        |> render_click()
+
+      assert has_element?(demo_view, "#runic-delegating-local-count", "3")
+      assert has_element?(demo_view, "#runic-delegating-delegated-count", "2")
+      assert html =~ "child:drafter"
+      assert html =~ "child:editor"
+      assert html =~ "## Research Sources"
+    end
+
+    test "example registry metadata resolves new delegating source files", %{conn: _conn} do
+      example = Examples.get_example!("runic-delegating-orchestrator")
+
+      assert example.title == "Runic Delegating Orchestrator"
+      assert example.live_view_module == "AgentJidoWeb.Examples.RunicDelegatingOrchestratorLive"
+
+      assert example.source_files == [
+               "lib/agent_jido/demos/runic_research_studio/fixtures.ex",
+               "lib/agent_jido/demos/runic_research_studio/actions.ex",
+               "lib/agent_jido/demos/runic_delegating_orchestrator/orchestrator_agent.ex",
+               "lib/agent_jido/demos/runic_delegating_orchestrator/runtime_demo.ex",
+               "lib/agent_jido_web/examples/runic_delegating_orchestrator_live.ex"
              ]
 
       assert Enum.map(example.sources, & &1.path) == example.source_files


### PR DESCRIPTION
## Summary
- replace the simulated Runic delegating orchestrator page with a deterministic real delegation workflow
- wire the slug to a dedicated LiveView and truthful source files
- add runtime and LiveView regression coverage for local stages, child handoffs, and delegated completion

## Testing
- ASDF_ELIXIR_VERSION=1.18.4-otp-27 ASDF_ERLANG_VERSION=27.3 CONTENTOPS_CHAT_ENABLED=false mix test
- ASDF_ELIXIR_VERSION=1.18.4-otp-27 ASDF_ERLANG_VERSION=27.3 CONTENTOPS_CHAT_ENABLED=false mix credo --strict
- managed pre_push hook (`mix credo --strict`, `mix test`, `mix dialyzer`)

Closes #65