### PR TITLE
feat(examples): replace weather multi-turn demo

### DIFF
--- a/lib/agent_jido/demos/weather_multi_turn_context/fixtures.ex
+++ b/lib/agent_jido/demos/weather_multi_turn_context/fixtures.ex
@@ -1,0 +1,103 @@
+defmodule AgentJido.Demos.WeatherMultiTurnContext.Fixtures do
+  @moduledoc """
+  Deterministic city and turn fixtures for the local weather multi-turn demo.
+  """
+
+  @cities [
+    %{
+      id: "seattle",
+      city: "Seattle",
+      period: "Tomorrow Morning",
+      condition: "light rain",
+      temperature: "58F",
+      umbrella: "Yes, bring an umbrella because Seattle is expected to stay damp through Tomorrow Morning.",
+      outdoor_activity: "walk the waterfront with a rain shell",
+      indoor_activity: "visit the aquarium",
+      backup_recommendation: "If the rain picks up, switch to an indoor coffee break downtown."
+    },
+    %{
+      id: "denver",
+      city: "Denver",
+      period: "Tomorrow Afternoon",
+      condition: "sunny with gusty wind",
+      temperature: "71F",
+      umbrella: "No umbrella is needed in Denver, but a light jacket helps with the gusty wind.",
+      outdoor_activity: "take a trail walk at Red Rocks",
+      indoor_activity: "stop by the art museum",
+      backup_recommendation: "If the wind feels sharp, swap the trail for an indoor museum visit."
+    }
+  ]
+
+  @turns [
+    %{
+      id: :forecast,
+      title: "Forecast Anchor",
+      prompt_template: "I'm in %{city}. Give tomorrow's weather in one short paragraph and explicitly mention %{city}.",
+      requires_city_in_prompt?: true
+    },
+    %{
+      id: :umbrella,
+      title: "Umbrella Follow-Up",
+      prompt_template: "Should I bring an umbrella?",
+      requires_city_in_prompt?: false
+    },
+    %{
+      id: :activities,
+      title: "Activities Follow-Up",
+      prompt_template: "Suggest one outdoor and one indoor activity.",
+      requires_city_in_prompt?: false
+    }
+  ]
+
+  @doc "Returns the city presets used by the weather demo."
+  @spec cities() :: [map()]
+  def cities, do: @cities
+
+  @doc "Returns the deterministic turn sequence for the demo."
+  @spec turns() :: [map()]
+  def turns, do: @turns
+
+  @doc "Returns the default city id."
+  @spec default_city_id() :: String.t()
+  def default_city_id, do: "seattle"
+
+  @doc "Fetches a city fixture by stable id."
+  @spec city!(String.t()) :: map()
+  def city!(id) when is_binary(id) do
+    Enum.find(@cities, &(&1.id == id)) ||
+      raise ArgumentError, "unknown weather demo city id: #{inspect(id)}"
+  end
+
+  @doc "Fetches a city fixture by city name."
+  @spec city_by_name!(String.t()) :: map()
+  def city_by_name!(city_name) when is_binary(city_name) do
+    normalized = normalize(city_name)
+
+    Enum.find(@cities, fn city ->
+      normalize(city.city) == normalized
+    end) ||
+      raise ArgumentError, "unknown weather demo city: #{inspect(city_name)}"
+  end
+
+  @doc "Fetches a turn fixture by id."
+  @spec turn!(atom()) :: map()
+  def turn!(id) when is_atom(id) do
+    Enum.find(@turns, &(&1.id == id)) ||
+      raise ArgumentError, "unknown weather demo turn id: #{inspect(id)}"
+  end
+
+  @doc "Renders the prompt text for a turn and city."
+  @spec prompt(atom(), map()) :: String.t()
+  def prompt(turn_id, city_fixture) do
+    turn = turn!(turn_id)
+
+    if turn.requires_city_in_prompt? do
+      turn.prompt_template
+      |> String.replace("%{city}", city_fixture.city)
+    else
+      turn.prompt_template
+    end
+  end
+
+  defp normalize(value), do: value |> String.downcase() |> String.trim()
+end

--- a/lib/agent_jido/demos/weather_multi_turn_context/forecast_action.ex
+++ b/lib/agent_jido/demos/weather_multi_turn_context/forecast_action.ex
@@ -1,0 +1,47 @@
+defmodule AgentJido.Demos.WeatherMultiTurnContext.ForecastAction do
+  @moduledoc """
+  Deterministic local weather tool used by the multi-turn context demo.
+  """
+
+  use Jido.Action,
+    name: "weather_multi_turn_context_forecast",
+    description: "Returns deterministic forecast context for a local weather assistant demo",
+    schema: [
+      city: [type: :string, required: true],
+      turn: [type: {:in, [:forecast, :umbrella, :activities]}, required: true],
+      attempt: [type: :integer, default: 1]
+    ]
+
+  alias AgentJido.Demos.WeatherMultiTurnContext.Fixtures
+
+  @impl true
+  def run(%{city: city, turn: :umbrella, attempt: 1}, _context) do
+    city_fixture = Fixtures.city_by_name!(city)
+
+    {:error,
+     %{
+       type: :busy,
+       city: city_fixture.city,
+       retry_after_ms: 300,
+       detail: "Deterministic busy response on the first umbrella lookup."
+     }}
+  end
+
+  def run(%{city: city, turn: turn, attempt: attempt}, _context) when turn in [:forecast, :umbrella, :activities] do
+    city_fixture = Fixtures.city_by_name!(city)
+
+    {:ok,
+     %{
+       city: city_fixture.city,
+       period: city_fixture.period,
+       condition: city_fixture.condition,
+       temperature: city_fixture.temperature,
+       umbrella: city_fixture.umbrella,
+       outdoor_activity: city_fixture.outdoor_activity,
+       indoor_activity: city_fixture.indoor_activity,
+       backup_recommendation: city_fixture.backup_recommendation,
+       turn: turn,
+       attempt: attempt
+     }}
+  end
+end

--- a/lib/agent_jido/demos/weather_multi_turn_context/runtime_demo.ex
+++ b/lib/agent_jido/demos/weather_multi_turn_context/runtime_demo.ex
@@ -1,0 +1,85 @@
+defmodule AgentJido.Demos.WeatherMultiTurnContext.RuntimeDemo do
+  @moduledoc """
+  Deterministic runtime wrapper for the local weather multi-turn context demo.
+  """
+
+  alias AgentJido.Demos.WeatherMultiTurnContext.{Fixtures, WeatherAssistant}
+
+  defstruct assistant: nil, log: []
+
+  @type log_entry :: %{
+          required(:label) => String.t(),
+          required(:detail) => String.t()
+        }
+
+  @type t :: %__MODULE__{
+          assistant: WeatherAssistant.t(),
+          log: [log_entry()]
+        }
+
+  @doc "Returns the city presets used by the demo."
+  @spec cities() :: [map()]
+  def cities, do: Fixtures.cities()
+
+  @doc "Returns the deterministic turn fixtures used by the demo."
+  @spec turns() :: [map()]
+  def turns, do: Fixtures.turns()
+
+  @doc "Builds a new runtime demo state."
+  @spec new(String.t() | nil) :: t()
+  def new(city_id \\ nil) do
+    %__MODULE__{assistant: WeatherAssistant.new(city_id)}
+  end
+
+  @doc "Resets the demo while optionally changing the selected city."
+  @spec reset(t(), keyword()) :: t()
+  def reset(%__MODULE__{} = demo, opts \\ []) do
+    city_id = Keyword.get(opts, :city_id, demo.assistant.selected_city_id)
+    new(city_id)
+  end
+
+  @doc "Changes the selected city by resetting the demo state."
+  @spec select_city(t(), String.t()) :: t()
+  def select_city(%__MODULE__{} = demo, city_id) do
+    demo
+    |> reset(city_id: city_id)
+    |> append_log("City", "Selected #{demo_city_name(city_id)} for the next conversation run.")
+  end
+
+  @doc "Runs one turn of the deterministic weather conversation."
+  @spec run_turn(t(), atom()) :: t()
+  def run_turn(%__MODULE__{} = demo, turn_id) do
+    before_retry_count = length(demo.assistant.retry_events)
+    assistant = WeatherAssistant.run_turn(demo.assistant, turn_id)
+    turn = List.last(assistant.turns)
+    after_retry_count = length(assistant.retry_events)
+
+    demo =
+      demo
+      |> Map.put(:assistant, assistant)
+      |> append_log(turn.title, "Answered turn #{turn.id} for #{turn.city} in #{turn.attempts} attempt(s).")
+
+    if after_retry_count > before_retry_count do
+      retry = List.last(assistant.retry_events)
+      append_log(demo, "Retry", "Backed off #{retry.backoff_ms}ms before retrying #{retry.turn} for #{retry.city}.")
+    else
+      demo
+    end
+  end
+
+  @doc "Runs the full deterministic three-turn conversation."
+  @spec run_all(t()) :: t()
+  def run_all(%__MODULE__{} = demo) do
+    demo
+    |> run_turn(:forecast)
+    |> run_turn(:umbrella)
+    |> run_turn(:activities)
+  end
+
+  defp append_log(%__MODULE__{} = demo, label, detail) do
+    entry = %{label: label, detail: detail}
+    %{demo | log: [entry | demo.log] |> Enum.take(30)}
+  end
+
+  defp demo_city_name(city_id), do: Fixtures.city!(city_id).city
+end

--- a/lib/agent_jido/demos/weather_multi_turn_context/weather_assistant.ex
+++ b/lib/agent_jido/demos/weather_multi_turn_context/weather_assistant.ex
@@ -1,0 +1,162 @@
+defmodule AgentJido.Demos.WeatherMultiTurnContext.WeatherAssistant do
+  @moduledoc """
+  Deterministic assistant logic for the local weather multi-turn context demo.
+  """
+
+  alias AgentJido.Demos.WeatherMultiTurnContext.{Fixtures, ForecastAction}
+
+  defstruct selected_city_id: Fixtures.default_city_id(),
+            selected_city: nil,
+            current_city: nil,
+            turns: [],
+            retry_events: [],
+            tool_calls: [],
+            completed_turn_ids: []
+
+  @type turn_entry :: %{
+          required(:id) => atom(),
+          required(:title) => String.t(),
+          required(:prompt) => String.t(),
+          required(:response) => String.t(),
+          required(:city) => String.t(),
+          required(:attempts) => pos_integer()
+        }
+
+  @type retry_entry :: %{
+          required(:turn) => atom(),
+          required(:city) => String.t(),
+          required(:attempt) => pos_integer(),
+          required(:backoff_ms) => pos_integer(),
+          required(:detail) => String.t()
+        }
+
+  @type tool_call_entry :: %{
+          required(:turn) => atom(),
+          required(:city) => String.t(),
+          required(:attempt) => pos_integer(),
+          required(:status) => :ok | :error,
+          required(:payload) => map()
+        }
+
+  @type t :: %__MODULE__{
+          selected_city_id: String.t(),
+          selected_city: map(),
+          current_city: String.t() | nil,
+          turns: [turn_entry()],
+          retry_events: [retry_entry()],
+          tool_calls: [tool_call_entry()],
+          completed_turn_ids: [atom()]
+        }
+
+  @doc "Builds a new deterministic assistant state."
+  @spec new(String.t() | nil) :: t()
+  def new(city_id \\ nil) do
+    selected_city = Fixtures.city!(city_id || Fixtures.default_city_id())
+
+    %__MODULE__{
+      selected_city_id: selected_city.id,
+      selected_city: selected_city
+    }
+  end
+
+  @doc "Resets the assistant while optionally changing the selected city."
+  @spec reset(t(), keyword()) :: t()
+  def reset(%__MODULE__{} = assistant, opts \\ []) do
+    city_id = Keyword.get(opts, :city_id, assistant.selected_city_id)
+    new(city_id)
+  end
+
+  @doc "Changes the selected city by resetting the assistant state."
+  @spec select_city(t(), String.t()) :: t()
+  def select_city(%__MODULE__{} = assistant, city_id) do
+    reset(assistant, city_id: city_id)
+  end
+
+  @doc "Runs one deterministic turn while preserving city context and retry behavior."
+  @spec run_turn(t(), atom()) :: t()
+  def run_turn(%__MODULE__{} = assistant, turn_id) when turn_id in [:forecast, :umbrella, :activities] do
+    city_fixture = resolve_city(assistant, turn_id)
+    prompt = Fixtures.prompt(turn_id, city_fixture)
+
+    {assistant, payload, attempts} = lookup_with_retry(assistant, turn_id, city_fixture.city)
+    response = compose_response(turn_id, payload)
+    turn = Fixtures.turn!(turn_id)
+
+    %{
+      assistant
+      | current_city: city_fixture.city,
+        turns:
+          assistant.turns ++
+            [
+              %{
+                id: turn_id,
+                title: turn.title,
+                prompt: prompt,
+                response: response,
+                city: city_fixture.city,
+                attempts: attempts
+              }
+            ],
+        completed_turn_ids: Enum.uniq(assistant.completed_turn_ids ++ [turn_id])
+    }
+  end
+
+  @doc "Runs the full deterministic three-turn weather conversation."
+  @spec run_all(t()) :: t()
+  def run_all(%__MODULE__{} = assistant) do
+    assistant
+    |> run_turn(:forecast)
+    |> run_turn(:umbrella)
+    |> run_turn(:activities)
+  end
+
+  defp resolve_city(%__MODULE__{current_city: current_city}, turn_id) when is_binary(current_city) and turn_id in [:umbrella, :activities] do
+    Fixtures.city_by_name!(current_city)
+  end
+
+  defp resolve_city(%__MODULE__{selected_city: selected_city}, _turn_id), do: selected_city
+
+  defp lookup_with_retry(%__MODULE__{} = assistant, turn_id, city) do
+    case tool_call(turn_id, city, 1) do
+      {:ok, payload} ->
+        {record_tool_call(assistant, turn_id, city, 1, :ok, payload), payload, 1}
+
+      {:error, %{type: :busy, retry_after_ms: retry_after_ms} = reason} ->
+        assistant =
+          assistant
+          |> record_tool_call(turn_id, city, 1, :error, reason)
+          |> record_retry(turn_id, city, 1, retry_after_ms, reason.detail)
+
+        {:ok, payload} = tool_call(turn_id, city, 2)
+        {record_tool_call(assistant, turn_id, city, 2, :ok, payload), payload, 2}
+    end
+  end
+
+  defp tool_call(turn_id, city, attempt) do
+    ForecastAction.run(%{city: city, turn: turn_id, attempt: attempt}, %{})
+  end
+
+  defp record_tool_call(%__MODULE__{} = assistant, turn, city, attempt, status, payload) do
+    entry = %{turn: turn, city: city, attempt: attempt, status: status, payload: payload}
+    %{assistant | tool_calls: assistant.tool_calls ++ [entry]}
+  end
+
+  defp record_retry(%__MODULE__{} = assistant, turn, city, attempt, backoff_ms, detail) do
+    entry = %{turn: turn, city: city, attempt: attempt, backoff_ms: backoff_ms, detail: detail}
+    %{assistant | retry_events: assistant.retry_events ++ [entry]}
+  end
+
+  defp compose_response(:forecast, payload) do
+    "#{payload.city} is expecting #{payload.condition} #{String.downcase(payload.period)} with temperatures around #{payload.temperature}. " <>
+      "Plan for a practical option and keep a backup ready if conditions shift."
+  end
+
+  defp compose_response(:umbrella, payload) do
+    "#{payload.umbrella} Backup recommendation: #{payload.backup_recommendation}"
+  end
+
+  defp compose_response(:activities, payload) do
+    "For #{payload.city}, try one outdoor option like #{payload.outdoor_activity} and one indoor option like #{payload.indoor_activity}. " <>
+      "If conditions change, #{String.downcase(payload.backup_recommendation)}"
+  end
+end

--- a/lib/agent_jido_web/examples/simulated_showcase_live.ex
+++ b/lib/agent_jido_web/examples/simulated_showcase_live.ex
@@ -242,26 +242,6 @@ defmodule AgentJidoWeb.Examples.SimulatedShowcaseLive do
     }
   end
 
-  defp scenario_for("jido-ai-weather-multi-turn-context") do
-    %{
-      title: "Jido.AI Weather Multi-Turn Context",
-      steps: [
-        %{label: "Turn 1", detail: "Anchored forecast response to Seattle context"},
-        %{label: "Retry guard", detail: "Applied busy backoff policy before second turn"},
-        %{label: "Turn 2", detail: "Answered umbrella guidance while preserving city context"},
-        %{label: "Turn 3", detail: "Returned outdoor + indoor suggestions with city retained"}
-      ],
-      result: """
-      {
-        "model": "simulated:haiku",
-        "city_context_preserved": true,
-        "retry_count": 1,
-        "turns": 3
-      }
-      """
-    }
-  end
-
   defp scenario_for("jido-ai-weather-reasoning-strategy-suite") do
     %{
       title: "Jido.AI Weather Reasoning Strategy Suite",

--- a/lib/agent_jido_web/examples/weather_multi_turn_context_live.ex
+++ b/lib/agent_jido_web/examples/weather_multi_turn_context_live.ex
@@ -1,0 +1,245 @@
+defmodule AgentJidoWeb.Examples.WeatherMultiTurnContextLive do
+  @moduledoc """
+  Interactive demo for deterministic multi-turn weather context carryover.
+  """
+
+  use AgentJidoWeb, :live_view
+
+  alias AgentJido.Demos.WeatherMultiTurnContext.RuntimeDemo
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {:ok, assign(socket, :demo, RuntimeDemo.new())}
+  end
+
+  @impl true
+  def render(assigns) do
+    assigns = assign(assigns, :assistant, assigns.demo.assistant)
+
+    ~H"""
+    <div id="weather-multi-turn-context-demo" class="rounded-lg border border-border bg-card p-6 space-y-6">
+      <div class="flex items-center justify-between gap-4">
+        <div>
+          <div class="text-sm font-semibold text-foreground">Jido.AI Weather Multi-Turn Context</div>
+          <div class="text-[11px] text-muted-foreground">
+            Real local weather-tool calls with preserved city context and deterministic retry/backoff behavior
+          </div>
+        </div>
+        <div class="text-[10px] font-mono text-muted-foreground bg-elevated px-2 py-1 rounded border border-border">
+          city: {@assistant.current_city || "unset"}
+        </div>
+      </div>
+
+      <div class="grid gap-3 sm:grid-cols-4">
+        <div class="rounded-md border border-border bg-elevated p-3 text-center">
+          <div class="text-[10px] uppercase tracking-wider text-muted-foreground">Selected City</div>
+          <div id="weather-selected-city" class="text-sm font-semibold text-foreground mt-2">
+            {@assistant.selected_city.city}
+          </div>
+        </div>
+        <div class="rounded-md border border-border bg-elevated p-3 text-center">
+          <div class="text-[10px] uppercase tracking-wider text-muted-foreground">Context City</div>
+          <div id="weather-context-city" class="text-sm font-semibold text-foreground mt-2">
+            {@assistant.current_city || "pending"}
+          </div>
+        </div>
+        <div class="rounded-md border border-border bg-elevated p-3 text-center">
+          <div class="text-[10px] uppercase tracking-wider text-muted-foreground">Turns Completed</div>
+          <div id="weather-turn-count" class="text-sm font-semibold text-foreground mt-2">
+            {length(@assistant.turns)}
+          </div>
+        </div>
+        <div class="rounded-md border border-border bg-elevated p-3 text-center">
+          <div class="text-[10px] uppercase tracking-wider text-muted-foreground">Retry Events</div>
+          <div id="weather-retry-count" class="text-sm font-semibold text-foreground mt-2">
+            {length(@assistant.retry_events)}
+          </div>
+        </div>
+      </div>
+
+      <div class="space-y-3">
+        <div class="text-[10px] uppercase tracking-wider text-muted-foreground">City presets</div>
+        <div class="flex gap-2 flex-wrap">
+          <%= for city <- RuntimeDemo.cities() do %>
+            <button
+              phx-click="select_city"
+              phx-value-city={city.id}
+              class={"px-3 py-2 rounded-md border text-xs transition-colors #{city_button_class(@assistant.selected_city_id == city.id)}"}
+            >
+              {city.city}
+            </button>
+          <% end %>
+        </div>
+      </div>
+
+      <div class="flex gap-3 flex-wrap">
+        <button
+          id="weather-run-turn-1-btn"
+          phx-click="run_turn"
+          phx-value-turn="forecast"
+          class="px-4 py-2 rounded-md bg-primary/10 border border-primary/30 text-primary hover:bg-primary/20 transition-colors text-sm font-semibold"
+        >
+          Run Turn 1
+        </button>
+        <button
+          id="weather-run-turn-2-btn"
+          phx-click="run_turn"
+          phx-value-turn="umbrella"
+          class="px-4 py-2 rounded-md bg-emerald-500/10 border border-emerald-500/30 text-emerald-300 hover:bg-emerald-500/20 transition-colors text-sm font-semibold"
+        >
+          Run Turn 2
+        </button>
+        <button
+          id="weather-run-turn-3-btn"
+          phx-click="run_turn"
+          phx-value-turn="activities"
+          class="px-4 py-2 rounded-md bg-accent-cyan/10 border border-accent-cyan/30 text-accent-cyan hover:bg-accent-cyan/20 transition-colors text-sm font-semibold"
+        >
+          Run Turn 3
+        </button>
+        <button
+          id="weather-run-all-btn"
+          phx-click="run_all"
+          class="px-4 py-2 rounded-md bg-amber-500/10 border border-amber-500/30 text-amber-300 hover:bg-amber-500/20 transition-colors text-sm font-semibold"
+        >
+          Run Full Conversation
+        </button>
+        <button
+          id="weather-reset-btn"
+          phx-click="reset_demo"
+          class="px-3 py-2 rounded-md bg-elevated border border-border text-muted-foreground hover:text-foreground hover:border-primary/40 transition-colors text-xs"
+        >
+          Reset
+        </button>
+      </div>
+
+      <div class="grid gap-4 xl:grid-cols-[1.1fr_0.9fr]">
+        <div class="space-y-4">
+          <div class="rounded-md border border-border bg-elevated p-4">
+            <div class="flex items-center justify-between mb-2">
+              <div class="text-[10px] uppercase tracking-wider text-muted-foreground">Conversation Transcript</div>
+              <div class="text-[10px] text-muted-foreground">{length(@assistant.turns)} turn(s)</div>
+            </div>
+
+            <div :if={@assistant.turns == []} class="text-xs text-muted-foreground">
+              Run the first turn to anchor the city context, then follow up without repeating the location.
+            </div>
+
+            <div :if={@assistant.turns != []} id="weather-turns" class="space-y-3">
+              <%= for turn <- @assistant.turns do %>
+                <div class="rounded-md border border-border bg-background/70 p-3 space-y-3">
+                  <div class="flex items-center justify-between gap-3">
+                    <div class="text-xs font-semibold text-foreground">{turn.title}</div>
+                    <div class="text-[10px] uppercase tracking-wider text-muted-foreground">
+                      {turn.attempts} attempt(s)
+                    </div>
+                  </div>
+                  <div>
+                    <div class="text-[10px] uppercase tracking-wider text-muted-foreground mb-1">Prompt</div>
+                    <div class="text-[11px] text-foreground whitespace-pre-wrap">{turn.prompt}</div>
+                  </div>
+                  <div>
+                    <div class="text-[10px] uppercase tracking-wider text-muted-foreground mb-1">Response</div>
+                    <div class="text-[11px] text-foreground whitespace-pre-wrap">{turn.response}</div>
+                  </div>
+                </div>
+              <% end %>
+            </div>
+          </div>
+
+          <div class="rounded-md border border-border bg-elevated p-4">
+            <div class="flex items-center justify-between mb-2">
+              <div class="text-[10px] uppercase tracking-wider text-muted-foreground">Retry and Backoff</div>
+              <div class="text-[10px] text-muted-foreground">{length(@assistant.retry_events)} event(s)</div>
+            </div>
+
+            <div :if={@assistant.retry_events == []} class="text-xs text-muted-foreground">
+              The umbrella follow-up triggers one deterministic busy response, then retries after a local backoff.
+            </div>
+
+            <div :if={@assistant.retry_events != []} id="weather-retry-log" class="space-y-2">
+              <%= for retry <- @assistant.retry_events do %>
+                <div class="rounded-md border border-border bg-background/70 px-3 py-2">
+                  <div class="text-[11px] font-semibold text-foreground">{retry.turn} retry</div>
+                  <div class="text-[11px] text-muted-foreground">
+                    {retry.city} returned busy on attempt {retry.attempt}; backed off {retry.backoff_ms}ms.
+                  </div>
+                </div>
+              <% end %>
+            </div>
+          </div>
+        </div>
+
+        <div class="space-y-4">
+          <div class="rounded-md border border-border bg-elevated p-4">
+            <div class="flex items-center justify-between mb-2">
+              <div class="text-[10px] uppercase tracking-wider text-muted-foreground">Tool Calls</div>
+              <div class="text-[10px] text-muted-foreground">{length(@assistant.tool_calls)} call(s)</div>
+            </div>
+
+            <div :if={@assistant.tool_calls == []} class="text-xs text-muted-foreground">
+              Each turn records the underlying local weather-tool call and whether it succeeded or retried.
+            </div>
+
+            <div :if={@assistant.tool_calls != []} id="weather-tool-calls" class="space-y-2 max-h-[20rem] overflow-y-auto">
+              <%= for call <- @assistant.tool_calls do %>
+                <div class="rounded-md border border-border bg-background/70 p-3">
+                  <div class="flex items-center justify-between gap-3">
+                    <div class="text-[11px] font-semibold text-foreground">{call.turn}</div>
+                    <div class="text-[10px] uppercase tracking-wider text-muted-foreground">{call.status}</div>
+                  </div>
+                  <div class="text-[11px] text-muted-foreground mt-1">
+                    {call.city} · attempt {call.attempt}
+                  </div>
+                  <pre class="text-[11px] text-foreground whitespace-pre-wrap font-mono mt-2"><%= inspect(call.payload, pretty: true, width: 60) %></pre>
+                </div>
+              <% end %>
+            </div>
+          </div>
+
+          <div class="rounded-md border border-border bg-elevated p-4">
+            <div class="flex items-center justify-between mb-2">
+              <div class="text-[10px] uppercase tracking-wider text-muted-foreground">Activity Log</div>
+              <div class="text-[10px] text-muted-foreground">{length(@demo.log)} entry(s)</div>
+            </div>
+
+            <div :if={@demo.log == []} class="text-xs text-muted-foreground">
+              Run the conversation to inspect context carryover and retry notes.
+            </div>
+
+            <div :if={@demo.log != []} class="space-y-2 max-h-[18rem] overflow-y-auto">
+              <%= for entry <- @demo.log do %>
+                <div class="rounded-md border border-border bg-background/70 px-3 py-2">
+                  <div class="text-[11px] font-semibold text-foreground">{entry.label}</div>
+                  <div class="text-[11px] text-muted-foreground">{entry.detail}</div>
+                </div>
+              <% end %>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  @impl true
+  def handle_event("select_city", %{"city" => city_id}, socket) do
+    {:noreply, assign(socket, :demo, RuntimeDemo.select_city(socket.assigns.demo, city_id))}
+  end
+
+  def handle_event("run_turn", %{"turn" => turn}, socket) do
+    turn_id = String.to_existing_atom(turn)
+    {:noreply, assign(socket, :demo, RuntimeDemo.run_turn(socket.assigns.demo, turn_id))}
+  end
+
+  def handle_event("run_all", _params, socket) do
+    {:noreply, assign(socket, :demo, RuntimeDemo.run_all(socket.assigns.demo))}
+  end
+
+  def handle_event("reset_demo", _params, socket) do
+    {:noreply, assign(socket, :demo, RuntimeDemo.reset(socket.assigns.demo))}
+  end
+
+  defp city_button_class(true), do: "border-primary/40 bg-primary/10 text-primary"
+  defp city_button_class(false), do: "border-border bg-elevated text-muted-foreground hover:text-foreground hover:border-primary/30"
+end

--- a/priv/examples/jido-ai-weather-multi-turn-context.md
+++ b/priv/examples/jido-ai-weather-multi-turn-context.md
@@ -1,7 +1,7 @@
 %{
   title: "Jido.AI Weather Multi-Turn Context",
-  description: "Conversation demo showing city context carryover and resilient retry behavior across turns.",
-  tags: ["primary", "showcase", "simulated", "ai", "l2", "ai-tool-use", "weather", "jido_ai"],
+  description: "Local weather assistant demo showing real city context carryover, deterministic tool calls, and one intentional retry/backoff event across turns.",
+  tags: ["primary", "showcase", "ai", "l2", "ai-tool-use", "weather", "jido_ai"],
   category: :ai,
   emoji: "🌦",
   related_resources: [
@@ -20,9 +20,13 @@
     }
   ],
   source_files: [
-    "lib/agent_jido_web/examples/simulated_showcase_live.ex"
+    "lib/agent_jido/demos/weather_multi_turn_context/fixtures.ex",
+    "lib/agent_jido/demos/weather_multi_turn_context/forecast_action.ex",
+    "lib/agent_jido/demos/weather_multi_turn_context/weather_assistant.ex",
+    "lib/agent_jido/demos/weather_multi_turn_context/runtime_demo.ex",
+    "lib/agent_jido_web/examples/weather_multi_turn_context_live.ex"
   ],
-  live_view_module: "AgentJidoWeb.Examples.SimulatedShowcaseLive",
+  live_view_module: "AgentJidoWeb.Examples.WeatherMultiTurnContextLive",
   difficulty: :intermediate,
   status: :live,
   scenario_cluster: :ai_tool_use,
@@ -31,17 +35,17 @@
   content_intent: :tutorial,
   capability_theme: :ai_intelligence,
   evidence_surface: :runnable_example,
-  demo_mode: :simulated,
+  demo_mode: :real,
   sort_order: 21
 }
 ---
 
 ## What you'll learn
 
-- How multi-turn prompts preserve location context across follow-ups
-- How retry/backoff behavior can be modeled for transient busy responses
-- How to validate semantic constraints in weather assistant responses
+- How multi-turn prompts preserve location context across follow-ups without repeating the city
+- How a local weather tool can trigger deterministic retry/backoff behavior on a transient busy response
+- How to inspect preserved context, retry events, and tool-call payloads from a real local example
 
 ## Demo note
 
-This demo uses deterministic turn outcomes and retry traces for predictable interaction and testability.
+This page now runs a real local weather assistant workflow. The weather data is deterministic and local, but the turn execution, context carryover, retry handling, and transcript are all produced by the shipped demo modules rather than a replayed transcript.

--- a/test/agent_jido/demos/weather_multi_turn_context/runtime_demo_test.exs
+++ b/test/agent_jido/demos/weather_multi_turn_context/runtime_demo_test.exs
@@ -1,0 +1,30 @@
+defmodule AgentJido.Demos.WeatherMultiTurnContext.RuntimeDemoTest do
+  use ExUnit.Case, async: true
+
+  alias AgentJido.Demos.WeatherMultiTurnContext.RuntimeDemo
+
+  test "full conversation preserves city context and records one deterministic retry" do
+    demo =
+      RuntimeDemo.new("seattle")
+      |> RuntimeDemo.run_all()
+
+    assert demo.assistant.current_city == "Seattle"
+    assert length(demo.assistant.turns) == 3
+    assert length(demo.assistant.retry_events) == 1
+    assert Enum.at(demo.assistant.turns, 1).response =~ "Seattle"
+    assert Enum.at(demo.assistant.turns, 1).response =~ "umbrella"
+    assert Enum.at(demo.assistant.turns, 2).response =~ "outdoor"
+    assert Enum.at(demo.assistant.turns, 2).response =~ "indoor"
+  end
+
+  test "city presets reset the conversation and follow the selected location" do
+    demo =
+      RuntimeDemo.new()
+      |> RuntimeDemo.select_city("denver")
+      |> RuntimeDemo.run_turn(:forecast)
+
+    assert demo.assistant.selected_city.city == "Denver"
+    assert demo.assistant.current_city == "Denver"
+    assert List.last(demo.assistant.turns).response =~ "Denver"
+  end
+end

--- a/test/agent_jido/examples_test.exs
+++ b/test/agent_jido/examples_test.exs
@@ -19,7 +19,7 @@ defmodule AgentJido.ExamplesTest do
     {"runic-delegating-orchestrator", "AgentJidoWeb.Examples.RunicDelegatingOrchestratorLive"},
     {"jido-ai-actions-runtime-demos", "AgentJidoWeb.Examples.ActionsRuntimeDemoLive"},
     {"jido-ai-browser-web-workflow", "AgentJidoWeb.Examples.BrowserDocsScoutAgentLive"},
-    {"jido-ai-weather-multi-turn-context", "AgentJidoWeb.Examples.SimulatedShowcaseLive"},
+    {"jido-ai-weather-multi-turn-context", "AgentJidoWeb.Examples.WeatherMultiTurnContextLive"},
     {"jido-ai-task-execution-workflow", "AgentJidoWeb.Examples.TaskExecutionWorkflowLive"},
     {"jido-ai-skills-runtime-foundations", "AgentJidoWeb.Examples.SkillsRuntimeFoundationsLive"},
     {"jido-ai-skills-multi-agent-orchestration", "AgentJidoWeb.Examples.SkillsMultiAgentOrchestrationLive"},

--- a/test/agent_jido_web/live/jido_example_live_test.exs
+++ b/test/agent_jido_web/live/jido_example_live_test.exs
@@ -8,7 +8,6 @@ defmodule AgentJidoWeb.JidoExampleLiveTest do
 
   @endpoint AgentJidoWeb.Endpoint
   @new_simulated_showcase_examples [
-    {"jido-ai-weather-multi-turn-context", "Jido.AI Weather Multi-Turn Context"},
     {"jido-ai-weather-reasoning-strategy-suite", "Jido.AI Weather Reasoning Strategy Suite"},
     {"jido-ai-operational-agents-pack", "Jido.AI Operational Agents Pack"}
   ]
@@ -473,6 +472,67 @@ defmodule AgentJidoWeb.JidoExampleLiveTest do
                "lib/agent_jido/demos/runic_delegating_orchestrator/orchestrator_agent.ex",
                "lib/agent_jido/demos/runic_delegating_orchestrator/runtime_demo.ex",
                "lib/agent_jido_web/examples/runic_delegating_orchestrator_live.ex"
+             ]
+
+      assert Enum.map(example.sources, & &1.path) == example.source_files
+    end
+  end
+
+  describe "/examples/jido-ai-weather-multi-turn-context" do
+    test "renders explanation tab with real local weather-tool guidance", %{conn: conn} do
+      {:ok, _view, html} = live(conn, "/examples/jido-ai-weather-multi-turn-context?tab=explanation")
+
+      assert html =~ "Jido.AI Weather Multi-Turn Context"
+      assert html =~ "real local weather assistant workflow"
+      assert html =~ "context carryover"
+      assert html =~ "retry/backoff"
+    end
+
+    test "renders source tab for the dedicated weather example", %{conn: conn} do
+      {:ok, _view, html} = live(conn, "/examples/jido-ai-weather-multi-turn-context?tab=source")
+
+      assert html =~ "fixtures.ex"
+      assert html =~ "forecast_action.ex"
+      assert html =~ "weather_assistant.ex"
+      assert html =~ "runtime_demo.ex"
+      assert html =~ "weather_multi_turn_context_live.ex"
+      refute html =~ "simulated_showcase_live.ex"
+    end
+
+    test "demo tab preserves context and records the deterministic retry", %{conn: conn} do
+      {:ok, view, html} = live(conn, "/examples/jido-ai-weather-multi-turn-context?tab=demo")
+
+      assert html =~ "Jido.AI Weather Multi-Turn Context"
+      refute html =~ "Simulated demo"
+
+      demo_view = find_live_child(view, "demo-jido-ai-weather-multi-turn-context")
+
+      html =
+        demo_view
+        |> element("#weather-multi-turn-context-demo button[phx-click='run_all']")
+        |> render_click()
+
+      assert has_element?(demo_view, "#weather-context-city", "Seattle")
+      assert has_element?(demo_view, "#weather-turn-count", "3")
+      assert has_element?(demo_view, "#weather-retry-count", "1")
+      assert html =~ "Should I bring an umbrella?"
+      assert html =~ "Seattle"
+      assert html =~ "outdoor"
+      assert html =~ "indoor"
+    end
+
+    test "example registry metadata resolves new weather source files", %{conn: _conn} do
+      example = Examples.get_example!("jido-ai-weather-multi-turn-context")
+
+      assert example.title == "Jido.AI Weather Multi-Turn Context"
+      assert example.live_view_module == "AgentJidoWeb.Examples.WeatherMultiTurnContextLive"
+
+      assert example.source_files == [
+               "lib/agent_jido/demos/weather_multi_turn_context/fixtures.ex",
+               "lib/agent_jido/demos/weather_multi_turn_context/forecast_action.ex",
+               "lib/agent_jido/demos/weather_multi_turn_context/weather_assistant.ex",
+               "lib/agent_jido/demos/weather_multi_turn_context/runtime_demo.ex",
+               "lib/agent_jido_web/examples/weather_multi_turn_context_live.ex"
              ]
 
       assert Enum.map(example.sources, & &1.path) == example.source_files


### PR DESCRIPTION
## Summary
- replace the simulated weather multi-turn page with a deterministic local weather assistant demo
- wire the slug to dedicated source files that preserve city context and record a retry/backoff event
- add runtime and LiveView regression coverage for turn carryover, retry behavior, and source wiring

## Testing
- ASDF_ELIXIR_VERSION=1.18.4-otp-27 ASDF_ERLANG_VERSION=27.3 CONTENTOPS_CHAT_ENABLED=false mix test
- ASDF_ELIXIR_VERSION=1.18.4-otp-27 ASDF_ERLANG_VERSION=27.3 CONTENTOPS_CHAT_ENABLED=false mix credo --strict
- managed pre_push hook (`mix credo --strict`, `mix test`, `mix dialyzer`)

Closes #66