### PR TITLE
Rework weather reasoning strategy suite comparison surface

### DIFF
--- a/lib/agent_jido/demos/weather_reasoning_strategy_suite/comparison_lab.ex
+++ b/lib/agent_jido/demos/weather_reasoning_strategy_suite/comparison_lab.ex
@@ -1,0 +1,92 @@
+defmodule AgentJido.Demos.WeatherReasoningStrategySuite.ComparisonLab do
+  @moduledoc """
+  Deterministic comparison harness for the weather reasoning strategy suite.
+  """
+
+  alias AgentJido.Demos.WeatherReasoningStrategySuite.Fixtures
+
+  defstruct selected_preset_id: nil,
+            selected_preset: nil,
+            selected_strategy_id: nil,
+            selected_strategy: nil,
+            log: []
+
+  @type log_entry :: %{
+          required(:label) => String.t(),
+          required(:detail) => String.t()
+        }
+
+  @type t :: %__MODULE__{
+          selected_preset_id: String.t(),
+          selected_preset: Fixtures.preset(),
+          selected_strategy_id: atom(),
+          selected_strategy: Fixtures.strategy_entry(),
+          log: [log_entry()]
+        }
+
+  @doc "Returns the deterministic preset catalog shown in the lab."
+  @spec presets() :: [Fixtures.preset()]
+  def presets, do: Fixtures.catalog()
+
+  @doc "Creates a new comparison lab state."
+  @spec new(String.t() | nil) :: t()
+  def new(preset_id \\ nil) do
+    preset = Fixtures.fetch!(preset_id)
+    strategy_id = preset.recommendation.strategy_id
+
+    %__MODULE__{
+      selected_preset_id: preset.id,
+      selected_preset: preset,
+      selected_strategy_id: strategy_id,
+      selected_strategy: Fixtures.strategy!(preset, strategy_id),
+      log: [log_entry("Loaded", "Opened #{preset.title} with #{preset.recommendation.label} preselected.")]
+    }
+  end
+
+  @doc "Changes the selected preset and resets the selected strategy to the recommended one."
+  @spec select_preset(t(), String.t()) :: t()
+  def select_preset(%__MODULE__{} = lab, preset_id) do
+    preset = Fixtures.fetch!(preset_id)
+    strategy_id = preset.recommendation.strategy_id
+
+    %{
+      lab
+      | selected_preset_id: preset.id,
+        selected_preset: preset,
+        selected_strategy_id: strategy_id,
+        selected_strategy: Fixtures.strategy!(preset, strategy_id),
+        log: [
+          log_entry("Scenario", "Loaded #{preset.title}. Recommended starting point: #{preset.recommendation.label}.")
+          | lab.log
+        ]
+    }
+    |> cap_log()
+  end
+
+  @doc "Selects a specific strategy within the active preset."
+  @spec select_strategy(t(), atom() | String.t()) :: t()
+  def select_strategy(%__MODULE__{} = lab, strategy_id) when is_binary(strategy_id) do
+    select_strategy(lab, String.to_existing_atom(strategy_id))
+  end
+
+  def select_strategy(%__MODULE__{} = lab, strategy_id) when is_atom(strategy_id) do
+    strategy = Fixtures.strategy!(lab.selected_preset, strategy_id)
+
+    %{
+      lab
+      | selected_strategy_id: strategy_id,
+        selected_strategy: strategy,
+        log: [
+          log_entry("Strategy", "Focused #{strategy.name} for the #{lab.selected_preset.title} scenario.")
+          | lab.log
+        ]
+    }
+    |> cap_log()
+  end
+
+  defp cap_log(%__MODULE__{} = lab) do
+    %{lab | log: Enum.take(lab.log, 12)}
+  end
+
+  defp log_entry(label, detail), do: %{label: label, detail: detail}
+end

--- a/lib/agent_jido/demos/weather_reasoning_strategy_suite/fixtures.ex
+++ b/lib/agent_jido/demos/weather_reasoning_strategy_suite/fixtures.ex
@@ -1,0 +1,330 @@
+defmodule AgentJido.Demos.WeatherReasoningStrategySuite.Fixtures do
+  @moduledoc """
+  Deterministic fixtures for the weather reasoning strategy comparison lab.
+  """
+
+  @strategy_profiles %{
+    react: %{
+      id: :react,
+      name: "ReAct",
+      style: "Reason/act loop with explicit tool boundaries",
+      latency: "medium",
+      output_shape: "fact-check, then recommendation",
+      best_for: "Weather flows that genuinely need tool calls or live data refreshes",
+      tradeoff: "Needs well-scoped Actions and clear retry policy"
+    },
+    cod: %{
+      id: :cod,
+      name: "CoD",
+      style: "Minimal drafting with fast refinement",
+      latency: "low",
+      output_shape: "compressed answer with quick rationale",
+      best_for: "Fast first-pass guidance when brevity matters",
+      tradeoff: "Can skip nuance or hedge too aggressively"
+    },
+    aot: %{
+      id: :aot,
+      name: "AoT",
+      style: "Algorithmic decomposition into explicit checks",
+      latency: "medium",
+      output_shape: "procedural checklist",
+      best_for: "Threshold-driven or formula-like weather decisions",
+      tradeoff: "Feels rigid on open-ended planning prompts"
+    },
+    cot: %{
+      id: :cot,
+      name: "CoT",
+      style: "Linear step-by-step reasoning",
+      latency: "medium",
+      output_shape: "ordered factors and conclusion",
+      best_for: "Single recommendation decisions that need transparent reasoning",
+      tradeoff: "Explores one path rather than multiple options"
+    },
+    tot: %{
+      id: :tot,
+      name: "ToT",
+      style: "Branching exploration with candidate scoring",
+      latency: "high",
+      output_shape: "multiple options with ranking",
+      best_for: "Comparing alternate plans under uncertainty",
+      tradeoff: "More orchestration and explanation overhead"
+    },
+    got: %{
+      id: :got,
+      name: "GoT",
+      style: "Interdependent graph of considerations",
+      latency: "high",
+      output_shape: "dependency-aware synthesis",
+      best_for: "Complex planning where constraints interact",
+      tradeoff: "Harder to explain and maintain than simpler strategies"
+    },
+    trm: %{
+      id: :trm,
+      name: "TRM",
+      style: "Answer, critique, then revise",
+      latency: "high",
+      output_shape: "reviewed recommendation with explicit self-check",
+      best_for: "Higher-stakes weather or safety decisions",
+      tradeoff: "Costs an extra reflection pass"
+    },
+    adaptive: %{
+      id: :adaptive,
+      name: "Adaptive",
+      style: "Meta-selection over available strategies",
+      latency: "medium-high",
+      output_shape: "chosen strategy plus routed output",
+      best_for: "Mixed workloads where callers should not choose strategy manually",
+      tradeoff: "Adds routing logic before the answer is produced"
+    }
+  }
+
+  @type badge :: %{
+          required(:strategy_id) => atom(),
+          required(:label) => String.t(),
+          required(:reason) => String.t()
+        }
+
+  @type strategy_entry :: %{
+          required(:id) => atom(),
+          required(:name) => String.t(),
+          required(:style) => String.t(),
+          required(:latency) => String.t(),
+          required(:output_shape) => String.t(),
+          required(:best_for) => String.t(),
+          required(:tradeoff) => String.t(),
+          required(:fit) => String.t(),
+          required(:why) => String.t(),
+          required(:sample) => String.t()
+        }
+
+  @type preset :: %{
+          required(:id) => String.t(),
+          required(:title) => String.t(),
+          required(:question) => String.t(),
+          required(:summary) => String.t(),
+          required(:recommendation) => badge(),
+          required(:fastest) => badge(),
+          required(:exploratory) => badge(),
+          required(:strategies) => [strategy_entry()]
+        }
+
+  @doc "Returns the default preset shown in the comparison lab."
+  @spec default_preset_id() :: String.t()
+  def default_preset_id, do: "commute-window"
+
+  @doc "Returns the full deterministic comparison catalog."
+  @spec catalog() :: [preset()]
+  def catalog do
+    [
+      %{
+        id: "commute-window",
+        title: "Commuter Decision",
+        question: "Should I bike or drive to work if it is 45°F with a 30% chance of rain and a 20-minute commute?",
+        summary: "One practical recommendation with moderate uncertainty and a clear personal tradeoff.",
+        recommendation: badge(:cot, "CoT keeps the answer transparent without spending extra effort exploring branches."),
+        fastest: badge(:cod, "CoD is the quickest way to ship a concise recommendation when the user just wants the call."),
+        exploratory: badge(:tot, "ToT is useful if you want multiple commute options rather than one recommendation."),
+        strategies: [
+          strategy_entry(
+            :react,
+            "Strong",
+            "Great if the answer depends on fetching the latest forecast before deciding.",
+            "Check the weather tool, verify the rain window, then recommend biking only if the rain risk stays outside commute time."
+          ),
+          strategy_entry(
+            :cod,
+            "Strong",
+            "Fast and concise when the user wants a short recommendation with one or two reasons.",
+            "Bike if you can tolerate cool air and carry a shell; otherwise drive if rain tolerance is low."
+          ),
+          strategy_entry(
+            :aot,
+            "Situational",
+            "Useful if you want an explicit threshold rule for temperature, rain, and commute length.",
+            "If rain chance stays below 40%, wind is manageable, and travel time is under 25 minutes, biking remains acceptable."
+          ),
+          strategy_entry(
+            :cot,
+            "Best fit",
+            "Linear reasoning makes the commute factors easy to audit and explain.",
+            "Rain risk is modest, the commute is short, and 45°F is manageable with layers, so biking is reasonable if you are comfortable carrying a light shell."
+          ),
+          strategy_entry(
+            :tot,
+            "Situational",
+            "Helpful only if you want to compare bike, drive, and hybrid options side by side.",
+            "Option A bike with shell, option B transit plus walk, option C drive; score each by comfort, speed, and rain tolerance."
+          ),
+          strategy_entry(
+            :got,
+            "Overkill",
+            "The dependency graph adds complexity without much payoff for a short commute decision.",
+            "Link temperature, precipitation timing, clothing insulation, and arrival flexibility before synthesizing a recommendation."
+          ),
+          strategy_entry(
+            :trm,
+            "Situational",
+            "Valuable if the recommendation must be especially cautious or self-reviewed.",
+            "Initial answer says bike; reflection step adds the caveat that uncertain rain timing could justify driving if punctuality is critical."
+          ),
+          strategy_entry(
+            :adaptive,
+            "Strong",
+            "Good if this prompt lives inside a mixed assistant that routes many different weather requests.",
+            "Route this commute prompt to CoT, then return the step-by-step recommendation with the chosen strategy noted."
+          )
+        ]
+      },
+      %{
+        id: "weekend-trip",
+        title: "Weekend Trip Planning",
+        question: "Plan a weekend hiking trip for Portland with changing mountain weather, backup indoor options, and a packing list.",
+        summary: "Several viable plans exist, and the answer should compare alternatives instead of locking into one too early.",
+        recommendation: badge(:tot, "ToT shines when the user needs multiple weather-resilient plans ranked against each other."),
+        fastest: badge(:cod, "CoD can draft a quick shortlist, but it will miss richer branch comparison."),
+        exploratory: badge(:got, "GoT is strongest if you want linked constraints like route, shelter, travel time, and gear to interact."),
+        strategies: [
+          strategy_entry(
+            :react,
+            "Strong",
+            "Useful when you want the planner to pull fresh conditions and trail facts before responding.",
+            "Fetch forecast and trail data, then propose one primary trail plan plus one fallback museum itinerary."
+          ),
+          strategy_entry(
+            :cod,
+            "Strong",
+            "Good for a quick shortlist when the user values speed over a full comparison matrix.",
+            "Pack layers, waterproof shells, and pick one low-risk trail plus one indoor backup."
+          ),
+          strategy_entry(
+            :aot,
+            "Situational",
+            "Works if you want to encode explicit packing and go or no-go thresholds.",
+            "Check rainfall, wind, travel time, and elevation in sequence before generating the final plan."
+          ),
+          strategy_entry(
+            :cot,
+            "Strong",
+            "Provides a clear recommendation but still tends to settle on one primary plan.",
+            "Explain the forecast, walk through gear implications, then recommend a single best trip outline."
+          ),
+          strategy_entry(
+            :tot,
+            "Best fit",
+            "This prompt benefits from branching into multiple weekend plans and ranking them.",
+            "Generate three plans across low, medium, and high weather risk, then score them by resilience and fun."
+          ),
+          strategy_entry(
+            :got,
+            "Strong",
+            "GoT is compelling when route, shelter, packing, and transport constraints affect each other.",
+            "Build a dependency graph across trail exposure, shelter availability, drive time, and rain gear before deciding."
+          ),
+          strategy_entry(
+            :trm,
+            "Situational",
+            "Useful when you want a final plan reviewed for missing safety caveats.",
+            "Draft the trip, critique exposure and backup coverage, then revise the weekend recommendation."
+          ),
+          strategy_entry(
+            :adaptive,
+            "Strong",
+            "A good mixed-workload surface because this prompt should likely route to ToT or GoT automatically.",
+            "Recognize planning complexity, route to ToT, and return the ranked trip options with backup plans."
+          )
+        ]
+      },
+      %{
+        id: "storm-operations",
+        title: "Storm Operations Call",
+        question: "Should a school district delay outdoor sports if a spring storm may bring hail, lightning, and shifting arrival times?",
+        summary: "The response is higher stakes and benefits from explicit self-review rather than a quick first-pass answer.",
+        recommendation: badge(:trm, "TRM adds a deliberate critique pass before making a weather safety recommendation."),
+        fastest: badge(:react, "ReAct is the fastest route if live alert checks matter more than comparative reasoning."),
+        exploratory: badge(:adaptive, "Adaptive is useful when the same operations assistant handles both simple and high-stakes prompts."),
+        strategies: [
+          strategy_entry(
+            :react,
+            "Strong",
+            "Great when the system must check current advisories, radar, and district policies first.",
+            "Query alerts and district rules, then recommend delaying play if lightning timing overlaps the event window."
+          ),
+          strategy_entry(
+            :cod,
+            "Overkill",
+            "A fast draft is risky here because the prompt needs careful safety framing.",
+            "Delay if uncertainty stays high, but the compressed rationale may under-explain hail and lightning thresholds."
+          ),
+          strategy_entry(
+            :aot,
+            "Strong",
+            "Helpful when the district wants explicit threshold checks for hail, lightning, and timing windows.",
+            "Evaluate alert severity, confidence interval, and safe shelter availability before the final recommendation."
+          ),
+          strategy_entry(
+            :cot,
+            "Strong",
+            "A transparent step-by-step answer works if one final recommendation is still enough.",
+            "Walk through storm timing, severity, shelter access, and consequence of being wrong before recommending delay or cancellation."
+          ),
+          strategy_entry(
+            :tot,
+            "Situational",
+            "Useful if leadership wants multiple operating plans, but it is not always necessary.",
+            "Compare proceed, delay, and cancel options with clear safety and logistics scores."
+          ),
+          strategy_entry(
+            :got,
+            "Situational",
+            "Worth it when transportation, staffing, shelters, and weather timing interact heavily.",
+            "Link bus schedules, field drainage, staffing coverage, and storm arrival into one synthesis graph."
+          ),
+          strategy_entry(
+            :trm,
+            "Best fit",
+            "The self-review pass is a good match for a safety-sensitive call with uncertain timing.",
+            "Initial answer recommends delay; reflection confirms lightning uncertainty and tight shelter margins justify the safer call."
+          ),
+          strategy_entry(
+            :adaptive,
+            "Strong",
+            "Strong option when the assistant should decide whether to route to CoT, ToT, or TRM on its own.",
+            "Classify this as high stakes, route to TRM, and return a safety-first recommendation with the selected strategy noted."
+          )
+        ]
+      }
+    ]
+  end
+
+  @doc "Fetches a preset by id or raises."
+  @spec fetch!(String.t() | nil) :: preset()
+  def fetch!(nil), do: fetch!(default_preset_id())
+
+  def fetch!(id) when is_binary(id) do
+    Enum.find(catalog(), &(&1.id == id)) ||
+      raise ArgumentError, "unknown weather reasoning preset: #{inspect(id)}"
+  end
+
+  @doc "Fetches one strategy row from a preset or raises."
+  @spec strategy!(preset(), atom()) :: strategy_entry()
+  def strategy!(preset, strategy_id) when is_map(preset) and is_atom(strategy_id) do
+    Enum.find(preset.strategies, &(&1.id == strategy_id)) ||
+      raise ArgumentError, "unknown strategy #{inspect(strategy_id)} for preset #{inspect(preset.id)}"
+  end
+
+  defp badge(strategy_id, reason) do
+    %{strategy_id: strategy_id, label: strategy_name(strategy_id), reason: reason}
+  end
+
+  defp strategy_entry(strategy_id, fit, why, sample) do
+    @strategy_profiles
+    |> Map.fetch!(strategy_id)
+    |> Map.merge(%{fit: fit, why: why, sample: sample})
+  end
+
+  defp strategy_name(strategy_id) do
+    @strategy_profiles
+    |> Map.fetch!(strategy_id)
+    |> Map.fetch!(:name)
+  end
+end

--- a/lib/agent_jido_web/examples/simulated_showcase_live.ex
+++ b/lib/agent_jido_web/examples/simulated_showcase_live.ex
@@ -242,25 +242,6 @@ defmodule AgentJidoWeb.Examples.SimulatedShowcaseLive do
     }
   end
 
-  defp scenario_for("jido-ai-weather-reasoning-strategy-suite") do
-    %{
-      title: "Jido.AI Weather Reasoning Strategy Suite",
-      steps: [
-        %{label: "Shared scenario", detail: "Applied one travel-weather prompt across eight strategies"},
-        %{label: "Collect outputs", detail: "Captured style and structure per strategy family"},
-        %{label: "Compare tradeoffs", detail: "Ranked concise vs exploratory vs synthesis-heavy outputs"},
-        %{label: "Recommendation", detail: "Selected best-fit strategy per task complexity class"}
-      ],
-      result: """
-      {
-        "model": "simulated:router",
-        "strategies": ["react","cod","aot","cot","tot","got","trm","adaptive"],
-        "comparison_ready": true
-      }
-      """
-    }
-  end
-
   defp scenario_for("jido-ai-operational-agents-pack") do
     %{
       title: "Jido.AI Operational Agents Pack",

--- a/lib/agent_jido_web/examples/weather_reasoning_strategy_suite_live.ex
+++ b/lib/agent_jido_web/examples/weather_reasoning_strategy_suite_live.ex
@@ -1,0 +1,210 @@
+defmodule AgentJidoWeb.Examples.WeatherReasoningStrategySuiteLive do
+  @moduledoc """
+  Interactive comparison lab for weather reasoning strategies.
+  """
+
+  use AgentJidoWeb, :live_view
+
+  alias AgentJido.Demos.WeatherReasoningStrategySuite.ComparisonLab
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {:ok, assign(socket, :lab, ComparisonLab.new())}
+  end
+
+  @impl true
+  def render(assigns) do
+    assigns =
+      assigns
+      |> assign(:preset, assigns.lab.selected_preset)
+      |> assign(:strategy, assigns.lab.selected_strategy)
+
+    ~H"""
+    <div id="weather-reasoning-strategy-suite-demo" class="rounded-lg border border-border bg-card p-6 space-y-6">
+      <div class="flex items-center justify-between gap-4">
+        <div>
+          <div class="text-sm font-semibold text-foreground">Jido.AI Weather Reasoning Strategy Suite</div>
+          <div class="text-[11px] text-muted-foreground">
+            Deterministic comparison lab for choosing a strategy, not a single copy-pasteable weather agent
+          </div>
+        </div>
+        <div class="text-[10px] font-semibold uppercase tracking-wider rounded border border-amber-400/30 bg-amber-400/10 text-amber-300 px-2 py-1">
+          reference
+        </div>
+      </div>
+
+      <div class="rounded-md border border-border bg-elevated p-4 text-xs text-muted-foreground space-y-1">
+        <div>No live model provider, browser session, or weather API call runs in this tab.</div>
+        <div>The harness compares deterministic strategy profiles so you can choose the right implementation path before building a focused agent.</div>
+      </div>
+
+      <div class="space-y-3">
+        <div class="text-[10px] uppercase tracking-wider text-muted-foreground">Scenario presets</div>
+        <div class="flex gap-2 flex-wrap">
+          <%= for preset <- ComparisonLab.presets() do %>
+            <button
+              phx-click="select_preset"
+              phx-value-preset={preset.id}
+              class={"px-3 py-2 rounded-md border text-xs transition-colors #{preset_button_class(@lab.selected_preset_id == preset.id)}"}
+            >
+              {preset.title}
+            </button>
+          <% end %>
+        </div>
+      </div>
+
+      <div class="rounded-md border border-border bg-elevated p-4 space-y-2">
+        <div class="text-[10px] uppercase tracking-wider text-muted-foreground">Active scenario</div>
+        <div id="weather-reasoning-selected-preset" class="text-sm font-semibold text-foreground">
+          {@preset.title}
+        </div>
+        <div id="weather-reasoning-question" class="text-[11px] text-foreground whitespace-pre-wrap">
+          {@preset.question}
+        </div>
+        <div class="text-[11px] text-muted-foreground">
+          {@preset.summary}
+        </div>
+      </div>
+
+      <div class="grid gap-3 sm:grid-cols-3">
+        <div class="rounded-md border border-border bg-elevated p-3">
+          <div class="text-[10px] uppercase tracking-wider text-muted-foreground">Recommended</div>
+          <div id="weather-reasoning-recommended-strategy" class="text-sm font-semibold text-foreground mt-2">
+            {@preset.recommendation.label}
+          </div>
+          <div class="text-[11px] text-muted-foreground mt-2">{@preset.recommendation.reason}</div>
+        </div>
+        <div class="rounded-md border border-border bg-elevated p-3">
+          <div class="text-[10px] uppercase tracking-wider text-muted-foreground">Fastest path</div>
+          <div class="text-sm font-semibold text-foreground mt-2">{@preset.fastest.label}</div>
+          <div class="text-[11px] text-muted-foreground mt-2">{@preset.fastest.reason}</div>
+        </div>
+        <div class="rounded-md border border-border bg-elevated p-3">
+          <div class="text-[10px] uppercase tracking-wider text-muted-foreground">Exploratory path</div>
+          <div class="text-sm font-semibold text-foreground mt-2">{@preset.exploratory.label}</div>
+          <div class="text-[11px] text-muted-foreground mt-2">{@preset.exploratory.reason}</div>
+        </div>
+      </div>
+
+      <div class="space-y-3">
+        <div class="text-[10px] uppercase tracking-wider text-muted-foreground">Strategy cards</div>
+        <div id="weather-reasoning-comparison-grid" class="grid gap-3 lg:grid-cols-2">
+          <%= for strategy <- @preset.strategies do %>
+            <button
+              id={"weather-reasoning-strategy-#{strategy.id}"}
+              phx-click="select_strategy"
+              phx-value-strategy={strategy.id}
+              class={"rounded-md border p-4 text-left transition-colors #{strategy_card_class(@lab.selected_strategy_id == strategy.id)}"}
+            >
+              <div class="flex items-start justify-between gap-3">
+                <div>
+                  <div class="text-sm font-semibold text-foreground">{strategy.name}</div>
+                  <div class="text-[11px] text-muted-foreground mt-1">{strategy.style}</div>
+                </div>
+                <div class={"text-[10px] uppercase tracking-wider rounded px-2 py-1 #{fit_class(strategy.fit)}"}>
+                  {strategy.fit}
+                </div>
+              </div>
+
+              <div class="grid gap-2 sm:grid-cols-2 mt-4 text-[11px]">
+                <div>
+                  <div class="uppercase tracking-wider text-muted-foreground">Latency</div>
+                  <div class="text-foreground mt-1">{strategy.latency}</div>
+                </div>
+                <div>
+                  <div class="uppercase tracking-wider text-muted-foreground">Output</div>
+                  <div class="text-foreground mt-1">{strategy.output_shape}</div>
+                </div>
+              </div>
+
+              <div class="text-[11px] text-muted-foreground mt-3">{strategy.why}</div>
+            </button>
+          <% end %>
+        </div>
+      </div>
+
+      <div class="grid gap-4 xl:grid-cols-[1fr_0.9fr]">
+        <div class="rounded-md border border-border bg-elevated p-4 space-y-4">
+          <div>
+            <div class="text-[10px] uppercase tracking-wider text-muted-foreground">Selected strategy</div>
+            <div id="weather-reasoning-selected-strategy" class="text-sm font-semibold text-foreground mt-2">
+              {@strategy.name}
+            </div>
+            <div class="text-[11px] text-muted-foreground mt-2">{@strategy.style}</div>
+          </div>
+
+          <div class="grid gap-3 sm:grid-cols-2">
+            <div class="rounded-md border border-border bg-background/70 p-3">
+              <div class="text-[10px] uppercase tracking-wider text-muted-foreground">Best for</div>
+              <div class="text-[11px] text-foreground mt-2">{@strategy.best_for}</div>
+            </div>
+            <div class="rounded-md border border-border bg-background/70 p-3">
+              <div class="text-[10px] uppercase tracking-wider text-muted-foreground">Tradeoff</div>
+              <div class="text-[11px] text-foreground mt-2">{@strategy.tradeoff}</div>
+            </div>
+          </div>
+
+          <div class="rounded-md border border-border bg-background/70 p-3">
+            <div class="text-[10px] uppercase tracking-wider text-muted-foreground">Why this fit changes on this prompt</div>
+            <div class="text-[11px] text-foreground mt-2">{@strategy.why}</div>
+          </div>
+
+          <div class="rounded-md border border-border bg-background/70 p-3">
+            <div class="text-[10px] uppercase tracking-wider text-muted-foreground">Reference snippet</div>
+            <div id="weather-reasoning-reference-snippet" class="text-[11px] text-foreground whitespace-pre-wrap mt-2">
+              {@strategy.sample}
+            </div>
+          </div>
+        </div>
+
+        <div class="rounded-md border border-border bg-elevated p-4">
+          <div class="flex items-center justify-between mb-2">
+            <div class="text-[10px] uppercase tracking-wider text-muted-foreground">Activity</div>
+            <div class="text-[10px] text-muted-foreground">{length(@lab.log)} note(s)</div>
+          </div>
+
+          <div id="weather-reasoning-log" class="space-y-2 max-h-[26rem] overflow-y-auto">
+            <%= for entry <- @lab.log do %>
+              <div class="rounded-md border border-border bg-background/70 px-3 py-2">
+                <div class="text-[11px] font-semibold text-foreground">{entry.label}</div>
+                <div class="text-[11px] text-muted-foreground">{entry.detail}</div>
+              </div>
+            <% end %>
+          </div>
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  @impl true
+  def handle_event("select_preset", %{"preset" => preset_id}, socket) do
+    {:noreply, assign(socket, :lab, ComparisonLab.select_preset(socket.assigns.lab, preset_id))}
+  end
+
+  def handle_event("select_strategy", %{"strategy" => strategy_id}, socket) do
+    {:noreply, assign(socket, :lab, ComparisonLab.select_strategy(socket.assigns.lab, strategy_id))}
+  end
+
+  defp preset_button_class(true) do
+    "bg-primary/10 border-primary/30 text-primary"
+  end
+
+  defp preset_button_class(false) do
+    "bg-background border-border text-muted-foreground hover:text-foreground hover:border-primary/30"
+  end
+
+  defp strategy_card_class(true) do
+    "border-primary/40 bg-primary/10 shadow-sm"
+  end
+
+  defp strategy_card_class(false) do
+    "border-border bg-background/70 hover:border-primary/20"
+  end
+
+  defp fit_class("Best fit"), do: "bg-emerald-500/10 text-emerald-300 border border-emerald-500/30"
+  defp fit_class("Strong"), do: "bg-primary/10 text-primary border border-primary/30"
+  defp fit_class("Situational"), do: "bg-amber-400/10 text-amber-300 border border-amber-400/30"
+  defp fit_class("Overkill"), do: "bg-rose-400/10 text-rose-300 border border-rose-400/30"
+  defp fit_class(_other), do: "bg-elevated text-muted-foreground border border-border"
+end

--- a/priv/examples/jido-ai-weather-reasoning-strategy-suite.md
+++ b/priv/examples/jido-ai-weather-reasoning-strategy-suite.md
@@ -1,7 +1,7 @@
 %{
   title: "Jido.AI Weather Reasoning Strategy Suite",
-  description: "Side-by-side strategy showcase across ReAct, CoD, AoT, CoT, ToT, GoT, TRM, and Adaptive weather agents.",
-  tags: ["primary", "showcase", "simulated", "ai", "l2", "ai-tool-use", "weather", "reasoning", "jido_ai"],
+  description: "Deterministic comparison lab for choosing between ReAct, CoD, AoT, CoT, ToT, GoT, TRM, and Adaptive weather reasoning strategies.",
+  tags: ["primary", "showcase", "ai", "l2", "ai-tool-use", "weather", "reasoning", "jido_ai", "comparison", "reference"],
   category: :ai,
   emoji: "🧠",
   related_resources: [
@@ -20,32 +20,56 @@
     }
   ],
   source_files: [
-    "lib/agent_jido_web/examples/simulated_showcase_live.ex"
+    "lib/agent_jido/demos/weather_reasoning_strategy_suite/fixtures.ex",
+    "lib/agent_jido/demos/weather_reasoning_strategy_suite/comparison_lab.ex",
+    "lib/agent_jido_web/examples/weather_reasoning_strategy_suite_live.ex"
   ],
-  live_view_module: "AgentJidoWeb.Examples.SimulatedShowcaseLive",
+  live_view_module: "AgentJidoWeb.Examples.WeatherReasoningStrategySuiteLive",
   difficulty: :advanced,
   status: :live,
   scenario_cluster: :ai_tool_use,
   wave: :l2,
   journey_stage: :evaluation,
-  content_intent: :decision_brief,
+  content_intent: :reference,
   capability_theme: :ai_intelligence,
-  evidence_surface: :runnable_example,
-  demo_mode: :simulated,
+  evidence_surface: :docs_reference,
+  demo_mode: :real,
   sort_order: 25
 }
 ---
 
 ## What you'll learn
 
-- How one scenario differs across eight reasoning strategies
-- How to evaluate strategy tradeoffs for output shape, latency, and complexity
-- How to communicate strategy selection without live provider variance
+- How the same weather prompt shifts across eight reasoning strategies
+- How to choose between transparent, fast, exploratory, and self-review-heavy reasoning surfaces
+- How to frame this page as a strategy comparison reference instead of a single runnable example
+
+## What this page is
+
+This page is a deterministic comparison lab. It helps you decide which reasoning strategy to build around for a weather scenario, but it is not one copy-pasteable weather agent implementation.
+
+The interactive tab compares fixed scenario presets, recommended strategy fits, and deterministic reference snippets. The source tab shows the actual comparison harness that powers those cards.
 
 ## Strategy set
 
 ReAct, CoD, AoT, CoT, ToT, GoT, TRM, and Adaptive.
 
+## How to use the comparison
+
+Start with the preset that best matches your use case:
+
+- short single-answer decisions like commute calls
+- multi-option planning questions like trips and packing
+- higher-stakes operational calls where self-review matters
+
+Then use the comparison cards to decide whether you want:
+
+- a transparent single path
+- a quick draft
+- a branching planner
+- a reflected safety-first answer
+- or an adaptive router that chooses for you
+
 ## Demo note
 
-Comparisons on this page are deterministic fixtures for repeatable side-by-side evaluation.
+No live model or weather API call runs here. The page uses deterministic fixtures and a dedicated comparison harness so the framing matches the product surface.

--- a/test/agent_jido/demos/weather_reasoning_strategy_suite/comparison_lab_test.exs
+++ b/test/agent_jido/demos/weather_reasoning_strategy_suite/comparison_lab_test.exs
@@ -1,0 +1,38 @@
+defmodule AgentJido.Demos.WeatherReasoningStrategySuite.ComparisonLabTest do
+  use ExUnit.Case, async: true
+
+  alias AgentJido.Demos.WeatherReasoningStrategySuite.ComparisonLab
+
+  test "starts on the default preset with the recommended strategy selected" do
+    lab = ComparisonLab.new()
+
+    assert lab.selected_preset_id == "commute-window"
+    assert lab.selected_preset.title == "Commuter Decision"
+    assert lab.selected_strategy_id == :cot
+    assert lab.selected_strategy.name == "CoT"
+    assert hd(lab.log).detail =~ "Commuter Decision"
+  end
+
+  test "select_preset resets selection to the new preset recommendation" do
+    lab =
+      ComparisonLab.new()
+      |> ComparisonLab.select_preset("weekend-trip")
+
+    assert lab.selected_preset_id == "weekend-trip"
+    assert lab.selected_preset.title == "Weekend Trip Planning"
+    assert lab.selected_strategy_id == :tot
+    assert lab.selected_strategy.name == "ToT"
+    assert hd(lab.log).detail =~ "Weekend Trip Planning"
+  end
+
+  test "select_strategy focuses one strategy inside the active preset" do
+    lab =
+      ComparisonLab.new("storm-operations")
+      |> ComparisonLab.select_strategy("adaptive")
+
+    assert lab.selected_strategy_id == :adaptive
+    assert lab.selected_strategy.name == "Adaptive"
+    assert lab.selected_strategy.why =~ "assistant should decide"
+    assert hd(lab.log).detail =~ "Adaptive"
+  end
+end

--- a/test/agent_jido/examples_test.exs
+++ b/test/agent_jido/examples_test.exs
@@ -23,7 +23,7 @@ defmodule AgentJido.ExamplesTest do
     {"jido-ai-task-execution-workflow", "AgentJidoWeb.Examples.TaskExecutionWorkflowLive"},
     {"jido-ai-skills-runtime-foundations", "AgentJidoWeb.Examples.SkillsRuntimeFoundationsLive"},
     {"jido-ai-skills-multi-agent-orchestration", "AgentJidoWeb.Examples.SkillsMultiAgentOrchestrationLive"},
-    {"jido-ai-weather-reasoning-strategy-suite", "AgentJidoWeb.Examples.SimulatedShowcaseLive"},
+    {"jido-ai-weather-reasoning-strategy-suite", "AgentJidoWeb.Examples.WeatherReasoningStrategySuiteLive"},
     {"jido-ai-operational-agents-pack", "AgentJidoWeb.Examples.SimulatedShowcaseLive"}
   ]
 

--- a/test/agent_jido_web/live/jido_example_live_test.exs
+++ b/test/agent_jido_web/live/jido_example_live_test.exs
@@ -7,8 +7,7 @@ defmodule AgentJidoWeb.JidoExampleLiveTest do
   alias AgentJido.Examples
 
   @endpoint AgentJidoWeb.Endpoint
-  @new_simulated_showcase_examples [
-    {"jido-ai-weather-reasoning-strategy-suite", "Jido.AI Weather Reasoning Strategy Suite"},
+  @remaining_simulated_showcase_examples [
     {"jido-ai-operational-agents-pack", "Jido.AI Operational Agents Pack"}
   ]
 
@@ -939,9 +938,75 @@ defmodule AgentJidoWeb.JidoExampleLiveTest do
     end
   end
 
-  describe "new simulated showcase examples" do
+  describe "/examples/jido-ai-weather-reasoning-strategy-suite" do
+    test "renders explanation tab with explicit comparison framing", %{conn: conn} do
+      {:ok, _view, html} = live(conn, "/examples/jido-ai-weather-reasoning-strategy-suite?tab=explanation")
+
+      assert html =~ "Jido.AI Weather Reasoning Strategy Suite"
+      assert html =~ "deterministic comparison lab"
+      assert html =~ "not one copy-pasteable weather agent implementation"
+      assert html =~ "The source tab shows the actual comparison harness"
+    end
+
+    test "renders source tab for the dedicated comparison harness", %{conn: conn} do
+      {:ok, _view, html} = live(conn, "/examples/jido-ai-weather-reasoning-strategy-suite?tab=source")
+
+      assert html =~ "fixtures.ex"
+      assert html =~ "comparison_lab.ex"
+      assert html =~ "weather_reasoning_strategy_suite_live.ex"
+      refute html =~ "simulated_showcase_live.ex"
+    end
+
+    test "demo tab switches presets and strategy details without simulated framing", %{conn: conn} do
+      {:ok, view, html} = live(conn, "/examples/jido-ai-weather-reasoning-strategy-suite?tab=demo")
+
+      assert html =~ "Jido.AI Weather Reasoning Strategy Suite"
+      refute html =~ "Simulated demo"
+      assert html =~ "reference"
+      assert html =~ "Commuter Decision"
+      assert has_element?(view, "#weather-reasoning-recommended-strategy", "CoT")
+
+      demo_view = find_live_child(view, "demo-jido-ai-weather-reasoning-strategy-suite")
+
+      html =
+        demo_view
+        |> element("#weather-reasoning-strategy-suite-demo button[phx-value-preset='weekend-trip']")
+        |> render_click()
+
+      assert html =~ "Weekend Trip Planning"
+      assert html =~ "ToT"
+
+      html =
+        demo_view
+        |> element("#weather-reasoning-strategy-suite-demo button[phx-value-strategy='adaptive']")
+        |> render_click()
+
+      assert html =~ ~s(id="weather-reasoning-selected-strategy")
+      assert html =~ "Adaptive"
+      assert html =~ "route to ToT or GoT automatically"
+    end
+
+    test "example registry metadata resolves comparison source files", %{conn: _conn} do
+      example = Examples.get_example!("jido-ai-weather-reasoning-strategy-suite")
+
+      assert example.title == "Jido.AI Weather Reasoning Strategy Suite"
+      assert example.live_view_module == "AgentJidoWeb.Examples.WeatherReasoningStrategySuiteLive"
+      assert example.evidence_surface == :docs_reference
+      assert example.demo_mode == :real
+
+      assert example.source_files == [
+               "lib/agent_jido/demos/weather_reasoning_strategy_suite/fixtures.ex",
+               "lib/agent_jido/demos/weather_reasoning_strategy_suite/comparison_lab.ex",
+               "lib/agent_jido_web/examples/weather_reasoning_strategy_suite_live.ex"
+             ]
+
+      assert Enum.map(example.sources, & &1.path) == example.source_files
+    end
+  end
+
+  describe "remaining simulated showcase examples" do
     test "render explanation tabs", %{conn: conn} do
-      Enum.each(@new_simulated_showcase_examples, fn {slug, title} ->
+      Enum.each(@remaining_simulated_showcase_examples, fn {slug, title} ->
         {:ok, _view, html} = live(conn, "/examples/#{slug}?tab=explanation")
         assert html =~ title
         assert html =~ "simulated"
@@ -949,7 +1014,7 @@ defmodule AgentJidoWeb.JidoExampleLiveTest do
     end
 
     test "run deterministic interactive traces", %{conn: conn} do
-      Enum.each(@new_simulated_showcase_examples, fn {slug, title} ->
+      Enum.each(@remaining_simulated_showcase_examples, fn {slug, title} ->
         {:ok, view, html} = live(conn, "/examples/#{slug}?tab=demo")
         assert html =~ title
         assert html =~ "Simulated demo"


### PR DESCRIPTION
Closes #67

## Summary
- replace the generic simulated weather reasoning page with a dedicated deterministic comparison lab
- reframe the example metadata and explanation as a reference surface instead of a runnable single-agent example
- add comparison harness coverage and LiveView regression tests for the new source and demo tabs

## Verification
- ASDF_ELIXIR_VERSION=1.18.4-otp-27 ASDF_ERLANG_VERSION=27.3 mix test
- ASDF_ELIXIR_VERSION=1.18.4-otp-27 ASDF_ERLANG_VERSION=27.3 mix credo --strict
- ASDF_ELIXIR_VERSION=1.18.4-otp-27 ASDF_ERLANG_VERSION=27.3 mix dialyzer