### PR TITLE
Rework operational agents pack into an overview index

### DIFF
--- a/lib/agent_jido/demos/operational_agents_pack/catalog.ex
+++ b/lib/agent_jido/demos/operational_agents_pack/catalog.ex
@@ -1,0 +1,119 @@
+defmodule AgentJido.Demos.OperationalAgentsPack.Catalog do
+  @moduledoc """
+  Deterministic catalog for the operational agents pack overview page.
+
+  This page is intentionally an index, not a runnable "one pack does everything"
+  demo. It links to narrower deterministic examples that already exist in the
+  workbench and preserves upstream source references for the original Jido.AI
+  operational agents.
+  """
+
+  alias AgentJido.Examples
+
+  @local_entries [
+    %{
+      id: "task-execution",
+      slug: "jido-ai-task-execution-workflow",
+      operational_focus: "Release lifecycle coordination",
+      why: "Use this when you want a deterministic stand-in for release or handoff workflows with explicit task state transitions.",
+      capabilities: ["task seeding", "task start/complete", "workflow lifecycle", "operator-friendly state view"]
+    },
+    %{
+      id: "schedule-directive",
+      slug: "schedule-directive-agent",
+      operational_focus: "Scheduled follow-up and remediation",
+      why: "Use this when operational work needs delayed follow-up, reminders, or retry windows instead of immediate execution.",
+      capabilities: ["schedule directives", "future dispatch", "safe deferred work", "operational timing control"]
+    },
+    %{
+      id: "persistence-storage",
+      slug: "persistence-storage-agent",
+      operational_focus: "Durable state and recovery",
+      why: "Use this when the operational workflow must survive restarts and preserve agent state across runs.",
+      capabilities: ["durable storage", "state inspection", "restart continuity", "recovery-friendly demos"]
+    }
+  ]
+
+  @upstream_refs [
+    %{
+      id: "api-smoke-test",
+      title: "API Smoke Test Agent",
+      label: "api smoke test agent",
+      href: "https://github.com/agentjido/jido_ai/blob/main/lib/examples/agents/api_smoke_test_agent.ex",
+      description: "ReAct-driven API endpoint testing and debugging.",
+      focus: "external verification and endpoint diagnostics"
+    },
+    %{
+      id: "issue-triage",
+      title: "Issue Triage Agent",
+      label: "issue triage agent",
+      href: "https://github.com/agentjido/jido_ai/blob/main/lib/examples/agents/issue_triage_agent.ex",
+      description: "Secure token injection pattern and safe GitHub operations.",
+      focus: "triage workflows and safe repo automation"
+    },
+    %{
+      id: "release-notes",
+      title: "Release Notes Agent",
+      label: "release notes agent",
+      href: "https://github.com/agentjido/jido_ai/blob/main/lib/examples/agents/release_notes_agent.ex",
+      description: "Graph-of-Thoughts synthesis for release note generation.",
+      focus: "structured release synthesis and editorial review"
+    }
+  ]
+
+  @type local_entry :: %{
+          required(:id) => String.t(),
+          required(:slug) => String.t(),
+          required(:title) => String.t(),
+          required(:route) => String.t(),
+          required(:description) => String.t(),
+          required(:difficulty) => atom(),
+          required(:demo_mode) => atom(),
+          required(:source_files) => [String.t()],
+          required(:operational_focus) => String.t(),
+          required(:why) => String.t(),
+          required(:capabilities) => [String.t()]
+        }
+
+  @type upstream_ref :: %{
+          required(:id) => String.t(),
+          required(:title) => String.t(),
+          required(:label) => String.t(),
+          required(:href) => String.t(),
+          required(:description) => String.t(),
+          required(:focus) => String.t()
+        }
+
+  @doc "Returns the local deterministic examples this index promotes."
+  @spec local_entries() :: [local_entry()]
+  def local_entries do
+    Enum.map(@local_entries, fn entry ->
+      example = Examples.get_example!(entry.slug)
+
+      entry
+      |> Map.put(:title, example.title)
+      |> Map.put(:route, "/examples/#{example.slug}")
+      |> Map.put(:description, example.description)
+      |> Map.put(:difficulty, example.difficulty)
+      |> Map.put(:demo_mode, example.demo_mode)
+      |> Map.put(:source_files, example.source_files)
+    end)
+  end
+
+  @doc "Returns the upstream operational source references preserved from the original page."
+  @spec upstream_refs() :: [upstream_ref()]
+  def upstream_refs, do: @upstream_refs
+
+  @doc "Returns the default local example entry."
+  @spec default_local_entry() :: local_entry()
+  def default_local_entry do
+    local_entries() |> List.first()
+  end
+
+  @doc "Fetches one local entry by id or raises."
+  @spec local_entry!(String.t()) :: local_entry()
+  def local_entry!(id) when is_binary(id) do
+    Enum.find(local_entries(), &(&1.id == id)) ||
+      raise ArgumentError, "unknown operational catalog entry: #{inspect(id)}"
+  end
+end

--- a/lib/agent_jido_web/examples/operational_agents_pack_live.ex
+++ b/lib/agent_jido_web/examples/operational_agents_pack_live.ex
@@ -1,0 +1,212 @@
+defmodule AgentJidoWeb.Examples.OperationalAgentsPackLive do
+  @moduledoc """
+  Overview/index surface for the operational agents pack.
+  """
+
+  use AgentJidoWeb, :live_view
+
+  alias AgentJido.Demos.OperationalAgentsPack.Catalog
+
+  @impl true
+  def mount(_params, _session, socket) do
+    selected = Catalog.default_local_entry()
+
+    {:ok,
+     socket
+     |> assign(:local_entries, Catalog.local_entries())
+     |> assign(:upstream_refs, Catalog.upstream_refs())
+     |> assign(:selected_entry, selected)
+     |> assign(:activity, [
+       %{
+         label: "Overview",
+         detail: "Opened the operational index with #{selected.title} selected as the first deterministic example."
+       }
+     ])}
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div id="operational-agents-pack-demo" class="rounded-lg border border-border bg-card p-6 space-y-6">
+      <div class="flex items-center justify-between gap-4">
+        <div>
+          <div class="text-sm font-semibold text-foreground">Jido.AI Operational Agents Pack</div>
+          <div class="text-[11px] text-muted-foreground">
+            Operational overview that links to narrow deterministic examples instead of pretending one simulator is a runnable pack
+          </div>
+        </div>
+        <div class="text-[10px] font-semibold uppercase tracking-wider rounded border border-amber-400/30 bg-amber-400/10 text-amber-300 px-2 py-1">
+          overview
+        </div>
+      </div>
+
+      <div class="rounded-md border border-border bg-elevated p-4 text-xs text-muted-foreground space-y-1">
+        <div>This page is an index for operational patterns.</div>
+        <div>
+          Open the linked deterministic examples for runnable proof; use the upstream source links when you want the original Jido.AI ops-agent implementations.
+        </div>
+      </div>
+
+      <div class="grid gap-3 sm:grid-cols-3">
+        <div class="rounded-md border border-border bg-elevated p-3">
+          <div class="text-[10px] uppercase tracking-wider text-muted-foreground">Local deterministic examples</div>
+          <div id="operational-local-count" class="text-sm font-semibold text-foreground mt-2">
+            {length(@local_entries)}
+          </div>
+        </div>
+        <div class="rounded-md border border-border bg-elevated p-3">
+          <div class="text-[10px] uppercase tracking-wider text-muted-foreground">Upstream references</div>
+          <div id="operational-upstream-count" class="text-sm font-semibold text-foreground mt-2">
+            {length(@upstream_refs)}
+          </div>
+        </div>
+        <div class="rounded-md border border-border bg-elevated p-3">
+          <div class="text-[10px] uppercase tracking-wider text-muted-foreground">Selected route</div>
+          <div id="operational-selected-route" class="text-sm font-semibold text-foreground mt-2">
+            {@selected_entry.route}
+          </div>
+        </div>
+      </div>
+
+      <div class="space-y-3">
+        <div class="text-[10px] uppercase tracking-wider text-muted-foreground">Deterministic local examples</div>
+        <div class="grid gap-3 lg:grid-cols-3">
+          <%= for entry <- @local_entries do %>
+            <button
+              id={"operational-entry-#{entry.id}"}
+              phx-click="select_entry"
+              phx-value-entry={entry.id}
+              class={"rounded-md border p-4 text-left transition-colors #{entry_class(@selected_entry.id == entry.id)}"}
+            >
+              <div class="text-sm font-semibold text-foreground">{entry.title}</div>
+              <div class="text-[11px] text-muted-foreground mt-1">{entry.operational_focus}</div>
+              <div class="text-[11px] text-muted-foreground mt-3">{entry.why}</div>
+            </button>
+          <% end %>
+        </div>
+      </div>
+
+      <div class="grid gap-4 xl:grid-cols-[1fr_0.9fr]">
+        <div class="space-y-4">
+          <div class="rounded-md border border-border bg-elevated p-4 space-y-4">
+            <div>
+              <div class="text-[10px] uppercase tracking-wider text-muted-foreground">Selected deterministic example</div>
+              <div id="operational-selected-title" class="text-sm font-semibold text-foreground mt-2">
+                {@selected_entry.title}
+              </div>
+              <div class="text-[11px] text-muted-foreground mt-2">{@selected_entry.description}</div>
+            </div>
+
+            <div class="grid gap-3 sm:grid-cols-3">
+              <div class="rounded-md border border-border bg-background/70 p-3">
+                <div class="text-[10px] uppercase tracking-wider text-muted-foreground">Focus</div>
+                <div class="text-[11px] text-foreground mt-2">{@selected_entry.operational_focus}</div>
+              </div>
+              <div class="rounded-md border border-border bg-background/70 p-3">
+                <div class="text-[10px] uppercase tracking-wider text-muted-foreground">Difficulty</div>
+                <div class="text-[11px] text-foreground mt-2">{@selected_entry.difficulty}</div>
+              </div>
+              <div class="rounded-md border border-border bg-background/70 p-3">
+                <div class="text-[10px] uppercase tracking-wider text-muted-foreground">Demo mode</div>
+                <div class="text-[11px] text-foreground mt-2">{@selected_entry.demo_mode}</div>
+              </div>
+            </div>
+
+            <div class="rounded-md border border-border bg-background/70 p-3">
+              <div class="text-[10px] uppercase tracking-wider text-muted-foreground">Why this belongs in the pack</div>
+              <div class="text-[11px] text-foreground mt-2">{@selected_entry.why}</div>
+            </div>
+
+            <div class="rounded-md border border-border bg-background/70 p-3">
+              <div class="flex items-center justify-between gap-3">
+                <div class="text-[10px] uppercase tracking-wider text-muted-foreground">Capabilities</div>
+                <.link
+                  id="operational-open-selected-example"
+                  navigate={@selected_entry.route}
+                  class="text-[11px] font-semibold text-primary hover:text-primary/80"
+                >
+                  Open example
+                </.link>
+              </div>
+              <div class="flex gap-2 flex-wrap mt-3">
+                <%= for capability <- @selected_entry.capabilities do %>
+                  <span class="text-[10px] px-2 py-1 rounded bg-elevated border border-border text-muted-foreground">
+                    {capability}
+                  </span>
+                <% end %>
+              </div>
+            </div>
+
+            <div class="rounded-md border border-border bg-background/70 p-3">
+              <div class="text-[10px] uppercase tracking-wider text-muted-foreground">Source files</div>
+              <div id="operational-selected-source-files" class="mt-3 space-y-2">
+                <%= for path <- @selected_entry.source_files do %>
+                  <div class="text-[11px] font-mono text-foreground">{path}</div>
+                <% end %>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="space-y-4">
+          <div class="rounded-md border border-border bg-elevated p-4">
+            <div class="text-[10px] uppercase tracking-wider text-muted-foreground mb-3">Upstream operational agent references</div>
+            <div class="space-y-3">
+              <%= for ref <- @upstream_refs do %>
+                <div class="rounded-md border border-border bg-background/70 p-3">
+                  <div class="flex items-center justify-between gap-3">
+                    <div>
+                      <div class="text-sm font-semibold text-foreground">{ref.title}</div>
+                      <div class="text-[11px] text-muted-foreground mt-1">{ref.description}</div>
+                    </div>
+                    <a
+                      href={ref.href}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      class="text-[11px] font-semibold text-primary hover:text-primary/80"
+                    >
+                      Open source
+                    </a>
+                  </div>
+                  <div class="text-[11px] text-muted-foreground mt-3">{ref.focus}</div>
+                </div>
+              <% end %>
+            </div>
+          </div>
+
+          <div class="rounded-md border border-border bg-elevated p-4">
+            <div class="flex items-center justify-between mb-2">
+              <div class="text-[10px] uppercase tracking-wider text-muted-foreground">Activity</div>
+              <div class="text-[10px] text-muted-foreground">{length(@activity)} note(s)</div>
+            </div>
+            <div id="operational-pack-activity" class="space-y-2 max-h-[18rem] overflow-y-auto">
+              <%= for entry <- @activity do %>
+                <div class="rounded-md border border-border bg-background/70 px-3 py-2">
+                  <div class="text-[11px] font-semibold text-foreground">{entry.label}</div>
+                  <div class="text-[11px] text-muted-foreground">{entry.detail}</div>
+                </div>
+              <% end %>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  @impl true
+  def handle_event("select_entry", %{"entry" => entry_id}, socket) do
+    entry = Catalog.local_entry!(entry_id)
+
+    {:noreply,
+     socket
+     |> assign(:selected_entry, entry)
+     |> update(:activity, fn activity ->
+       [%{label: "Selected", detail: "Focused #{entry.title} as the current deterministic operational example."} | activity]
+       |> Enum.take(12)
+     end)}
+  end
+
+  defp entry_class(true), do: "border-primary/40 bg-primary/10 shadow-sm"
+  defp entry_class(false), do: "border-border bg-background/70 hover:border-primary/20"
+end

--- a/lib/agent_jido_web/examples/simulated_showcase_live.ex
+++ b/lib/agent_jido_web/examples/simulated_showcase_live.ex
@@ -242,25 +242,6 @@ defmodule AgentJidoWeb.Examples.SimulatedShowcaseLive do
     }
   end
 
-  defp scenario_for("jido-ai-operational-agents-pack") do
-    %{
-      title: "Jido.AI Operational Agents Pack",
-      steps: [
-        %{label: "API smoke run", detail: "Validated endpoint status and response diagnostics"},
-        %{label: "Issue triage run", detail: "Categorized issue queue with safe write policy disabled"},
-        %{label: "Release synthesis", detail: "Generated themed release notes draft via GoT pattern"},
-        %{label: "Security checks", detail: "Confirmed token-context injection and write guard behavior"}
-      ],
-      result: """
-      {
-        "model": "simulated:ops-coordinator",
-        "workflows": ["api_smoke","issue_triage","release_notes"],
-        "safe_by_default": true
-      }
-      """
-    }
-  end
-
   defp scenario_for(_slug) do
     %{
       title: "Simulated Example",

--- a/priv/examples/jido-ai-operational-agents-pack.md
+++ b/priv/examples/jido-ai-operational-agents-pack.md
@@ -1,7 +1,7 @@
 %{
   title: "Jido.AI Operational Agents Pack",
-  description: "Operational workflows for API smoke tests, GitHub issue triage, and release notes synthesis.",
-  tags: ["primary", "showcase", "simulated", "ai", "l2", "ops-governance", "jido_ai", "operations"],
+  description: "Operational overview/index linking to deterministic workbench examples and upstream Jido.AI ops-agent sources.",
+  tags: ["primary", "reference", "ai", "l2", "ops-governance", "jido_ai", "operations", "overview"],
   category: :ai,
   emoji: "🛠",
   related_resources: [
@@ -34,34 +34,49 @@
     }
   ],
   source_files: [
-    "lib/agent_jido_web/examples/simulated_showcase_live.ex"
+    "lib/agent_jido/demos/operational_agents_pack/catalog.ex",
+    "lib/agent_jido_web/examples/operational_agents_pack_live.ex"
   ],
-  live_view_module: "AgentJidoWeb.Examples.SimulatedShowcaseLive",
+  live_view_module: "AgentJidoWeb.Examples.OperationalAgentsPackLive",
   difficulty: :advanced,
   status: :live,
   scenario_cluster: :ops_governance,
   wave: :l2,
   journey_stage: :operationalization,
-  content_intent: :case_study,
+  content_intent: :reference,
   capability_theme: :operations_observability,
-  evidence_surface: :runnable_example,
-  demo_mode: :simulated,
+  evidence_surface: :docs_reference,
+  demo_mode: :real,
   sort_order: 26
 }
 ---
 
 ## What you'll learn
 
-- How operational agents combine tool-use and safety controls
-- How secure context injection patterns keep credentials out of model context
-- How to package practical operations workflows into reproducible demos
+- How to break a broad operational pack into narrower deterministic examples
+- How to choose which local workbench example best matches your ops workflow
+- Where to go for upstream Jido.AI ops-agent sources that preserve the original API smoke, triage, and release-notes concepts
+
+## What this page is
+
+This page is an overview/index. It is not one runnable “operational pack” demo.
+
+The demo tab now points to a dedicated operational index surface that links to real deterministic examples already in this repo. Use those linked pages when you want runnable proof, and use the upstream source links when you want the original Jido.AI operational agent implementations.
 
 ## Included workflows
 
+- release or handoff workflow coordination
+- scheduled follow-up and remediation
+- durable state and restart-friendly operational flows
+
+## Upstream source references
+
+The original pack concepts are still preserved as source references:
+
 - API smoke testing
 - GitHub issue triage
-- Release notes synthesis
+- release notes synthesis
 
 ## Demo note
 
-This page simulates operational traces and explicitly avoids live write operations or external API calls.
+No simulator-backed “run this whole pack” trace remains on this page. The interactive tab is a navigable operational index, and the linked local examples are the deterministic runnable surfaces.

--- a/test/agent_jido/demos/operational_agents_pack/catalog_test.exs
+++ b/test/agent_jido/demos/operational_agents_pack/catalog_test.exs
@@ -1,0 +1,37 @@
+defmodule AgentJido.Demos.OperationalAgentsPack.CatalogTest do
+  use ExUnit.Case, async: true
+
+  alias AgentJido.Demos.OperationalAgentsPack.Catalog
+
+  test "local entries resolve to real deterministic examples with source files" do
+    entries = Catalog.local_entries()
+
+    assert length(entries) == 3
+
+    assert Enum.map(entries, & &1.slug) == [
+             "jido-ai-task-execution-workflow",
+             "schedule-directive-agent",
+             "persistence-storage-agent"
+           ]
+
+    assert Enum.all?(entries, fn entry ->
+             entry.demo_mode == :real and entry.source_files != [] and Enum.all?(entry.source_files, &File.exists?/1)
+           end)
+  end
+
+  test "default_local_entry returns the first deterministic operational example" do
+    entry = Catalog.default_local_entry()
+
+    assert entry.id == "task-execution"
+    assert entry.title == "Jido.AI Task Execution Workflow"
+  end
+
+  test "upstream refs preserve the original operational pack concepts" do
+    refs = Catalog.upstream_refs()
+
+    assert Enum.map(refs, & &1.id) == ["api-smoke-test", "issue-triage", "release-notes"]
+    assert Enum.any?(refs, &String.contains?(&1.href, "api_smoke_test_agent.ex"))
+    assert Enum.any?(refs, &String.contains?(&1.href, "issue_triage_agent.ex"))
+    assert Enum.any?(refs, &String.contains?(&1.href, "release_notes_agent.ex"))
+  end
+end

--- a/test/agent_jido/examples_test.exs
+++ b/test/agent_jido/examples_test.exs
@@ -24,7 +24,7 @@ defmodule AgentJido.ExamplesTest do
     {"jido-ai-skills-runtime-foundations", "AgentJidoWeb.Examples.SkillsRuntimeFoundationsLive"},
     {"jido-ai-skills-multi-agent-orchestration", "AgentJidoWeb.Examples.SkillsMultiAgentOrchestrationLive"},
     {"jido-ai-weather-reasoning-strategy-suite", "AgentJidoWeb.Examples.WeatherReasoningStrategySuiteLive"},
-    {"jido-ai-operational-agents-pack", "AgentJidoWeb.Examples.SimulatedShowcaseLive"}
+    {"jido-ai-operational-agents-pack", "AgentJidoWeb.Examples.OperationalAgentsPackLive"}
   ]
 
   test "draft examples are hidden from default lookups" do

--- a/test/agent_jido_web/live/jido_example_live_test.exs
+++ b/test/agent_jido_web/live/jido_example_live_test.exs
@@ -7,10 +7,6 @@ defmodule AgentJidoWeb.JidoExampleLiveTest do
   alias AgentJido.Examples
 
   @endpoint AgentJidoWeb.Endpoint
-  @remaining_simulated_showcase_examples [
-    {"jido-ai-operational-agents-pack", "Jido.AI Operational Agents Pack"}
-  ]
-
   setup_all do
     ensure_started(:telemetry)
     ensure_started(:phoenix_pubsub)
@@ -1004,33 +1000,71 @@ defmodule AgentJidoWeb.JidoExampleLiveTest do
     end
   end
 
-  describe "remaining simulated showcase examples" do
-    test "render explanation tabs", %{conn: conn} do
-      Enum.each(@remaining_simulated_showcase_examples, fn {slug, title} ->
-        {:ok, _view, html} = live(conn, "/examples/#{slug}?tab=explanation")
-        assert html =~ title
-        assert html =~ "simulated"
-      end)
+  describe "/examples/jido-ai-operational-agents-pack" do
+    test "renders explanation tab with explicit overview framing", %{conn: conn} do
+      {:ok, _view, html} = live(conn, "/examples/jido-ai-operational-agents-pack?tab=explanation")
+
+      assert html =~ "Jido.AI Operational Agents Pack"
+      assert html =~ "This page is an overview/index."
+      assert html =~ "not one runnable"
+      assert html =~ "Use those linked pages when you want runnable proof"
     end
 
-    test "run deterministic interactive traces", %{conn: conn} do
-      Enum.each(@remaining_simulated_showcase_examples, fn {slug, title} ->
-        {:ok, view, html} = live(conn, "/examples/#{slug}?tab=demo")
-        assert html =~ title
-        assert html =~ "Simulated demo"
+    test "renders source tab for the dedicated operational index modules", %{conn: conn} do
+      {:ok, _view, html} = live(conn, "/examples/jido-ai-operational-agents-pack?tab=source")
 
-        demo_view = find_live_child(view, "demo-#{slug}")
+      assert html =~ "catalog.ex"
+      assert html =~ "operational_agents_pack_live.ex"
+      refute html =~ "simulated_showcase_live.ex"
+    end
 
+    test "demo tab selects deterministic local example cards and exposes real routes", %{conn: conn} do
+      {:ok, view, html} = live(conn, "/examples/jido-ai-operational-agents-pack?tab=demo")
+
+      assert html =~ "Jido.AI Operational Agents Pack"
+      refute html =~ "Simulated demo"
+      assert html =~ "overview"
+      assert html =~ "Jido.AI Task Execution Workflow"
+      assert has_element?(view, "#operational-selected-route", "/examples/jido-ai-task-execution-workflow")
+
+      demo_view = find_live_child(view, "demo-jido-ai-operational-agents-pack")
+
+      html =
         demo_view
-        |> element("#simulated-showcase-demo-#{slug} button[phx-click='run_demo']")
+        |> element("#operational-agents-pack-demo button[phx-value-entry='schedule-directive']")
         |> render_click()
 
-        Enum.each(1..8, fn _ -> send(demo_view.pid, :advance_step) end)
+      assert html =~ "Schedule Directive Agent"
+      assert html =~ "/examples/schedule-directive-agent"
+      assert html =~ "schedule directives"
 
-        final_html = render(demo_view)
-        assert final_html =~ "Simulated Result"
-        assert final_html =~ "simulated:"
-      end)
+      html =
+        demo_view
+        |> element("#operational-agents-pack-demo button[phx-value-entry='persistence-storage']")
+        |> render_click()
+
+      assert html =~ "Persistence Storage Agent"
+      assert html =~ "/examples/persistence-storage-agent"
+      assert html =~ "durable storage"
+      assert html =~ "API Smoke Test Agent"
+      assert html =~ "Issue Triage Agent"
+      assert html =~ "Release Notes Agent"
+    end
+
+    test "example registry metadata resolves operational index source files", %{conn: _conn} do
+      example = Examples.get_example!("jido-ai-operational-agents-pack")
+
+      assert example.title == "Jido.AI Operational Agents Pack"
+      assert example.live_view_module == "AgentJidoWeb.Examples.OperationalAgentsPackLive"
+      assert example.evidence_surface == :docs_reference
+      assert example.demo_mode == :real
+
+      assert example.source_files == [
+               "lib/agent_jido/demos/operational_agents_pack/catalog.ex",
+               "lib/agent_jido_web/examples/operational_agents_pack_live.ex"
+             ]
+
+      assert Enum.map(example.sources, & &1.path) == example.source_files
     end
   end
 


### PR DESCRIPTION
Closes #68

## Summary
- replace the simulated operational pack page with a dedicated overview/index surface
- anchor the page to real deterministic local examples already implemented in this repo
- preserve upstream Jido.AI operational agent sources as explicit reference links instead of pretending one simulator-backed pack is runnable

## Verification
- ASDF_ELIXIR_VERSION=1.18.4-otp-27 ASDF_ERLANG_VERSION=27.3 mix test
- ASDF_ELIXIR_VERSION=1.18.4-otp-27 ASDF_ERLANG_VERSION=27.3 mix credo --strict
- ASDF_ELIXIR_VERSION=1.18.4-otp-27 ASDF_ERLANG_VERSION=27.3 mix dialyzer