### PR TITLE
Add builder skill catalog demo

### DIFF
--- a/lib/agent_jido/demos/skills_runtime_foundations/runtime_demo.ex
+++ b/lib/agent_jido/demos/skills_runtime_foundations/runtime_demo.ex
@@ -10,7 +10,44 @@ defmodule AgentJido.Demos.SkillsRuntimeFoundations.RuntimeDemo do
   @project_root Path.expand("../../../..", __DIR__)
   @skills_root_source_path "priv/skills/skills-runtime-foundations"
   @primary_skill_source_path Path.join(@skills_root_source_path, "demo-code-review/SKILL.md")
-  @demo_skill_names ["demo-runtime-calculator", "demo-code-review", "demo-release-notes"]
+  @runtime_skill_names ["demo-runtime-calculator", "demo-code-review", "demo-release-notes"]
+  @builder_skill_names [
+    "builder-action-scaffold",
+    "builder-agent-scaffold",
+    "builder-plugin-scaffold",
+    "builder-adapter-package",
+    "builder-ecosystem-page-author",
+    "builder-example-tutorial-author",
+    "builder-package-review"
+  ]
+  @builder_skill_source_paths [
+    "priv/skills/builder-action-scaffold/SKILL.md",
+    "priv/skills/builder-agent-scaffold/SKILL.md",
+    "priv/skills/builder-plugin-scaffold/SKILL.md",
+    "priv/skills/builder-adapter-package/SKILL.md",
+    "priv/skills/builder-ecosystem-page-author/SKILL.md",
+    "priv/skills/builder-example-tutorial-author/SKILL.md",
+    "priv/skills/builder-package-review/SKILL.md"
+  ]
+  @builder_task %{
+    title: "Refresh Jido Skill package coverage",
+    summary: "Review jido_skill boundaries, tighten the workbench ecosystem page, and outline the next truthful companion example.",
+    target_package: "jido_skill",
+    reference_paths: [
+      "priv/ecosystem/jido_skill.md",
+      "priv/pages/docs/learn/multi-agent-orchestration.livemd",
+      "priv/examples/jido-ai-skills-runtime-foundations.md"
+    ],
+    deliverable_paths: [
+      "priv/ecosystem/jido_skill.md",
+      "priv/examples/jido-ai-skills-runtime-foundations.md"
+    ],
+    selected_skill_names: [
+      "builder-package-review",
+      "builder-ecosystem-page-author",
+      "builder-example-tutorial-author"
+    ]
+  }
 
   defstruct file_manifest: nil,
             module_manifest: nil,
@@ -18,13 +55,38 @@ defmodule AgentJido.Demos.SkillsRuntimeFoundations.RuntimeDemo do
             prompt: "",
             allowed_tools: [],
             loaded_count: 0,
+            builder_specs: [],
+            builder_loaded_count: 0,
+            builder_prompt: "",
+            builder_allowed_tools: [],
+            builder_task: @builder_task,
+            builder_selected_skill_names: [],
+            builder_runtime_targets: [],
+            builder_workflow_steps: [],
+            builder_boundary_notes: [],
             log: [],
             primary_skill_source_path: @primary_skill_source_path,
-            skills_root_source_path: @skills_root_source_path
+            skills_root_source_path: @skills_root_source_path,
+            builder_skill_source_paths: @builder_skill_source_paths
 
   @type log_entry :: %{
           required(:label) => String.t(),
           required(:detail) => String.t()
+        }
+
+  @type builder_task :: %{
+          required(:title) => String.t(),
+          required(:summary) => String.t(),
+          required(:target_package) => String.t(),
+          required(:reference_paths) => [String.t()],
+          required(:deliverable_paths) => [String.t()],
+          required(:selected_skill_names) => [String.t()]
+        }
+
+  @type builder_workflow_step :: %{
+          required(:title) => String.t(),
+          required(:detail) => String.t(),
+          required(:deliverable) => String.t()
         }
 
   @type t :: %__MODULE__{
@@ -34,9 +96,19 @@ defmodule AgentJido.Demos.SkillsRuntimeFoundations.RuntimeDemo do
           prompt: String.t(),
           allowed_tools: [String.t()],
           loaded_count: non_neg_integer(),
+          builder_specs: [Spec.t()],
+          builder_loaded_count: non_neg_integer(),
+          builder_prompt: String.t(),
+          builder_allowed_tools: [String.t()],
+          builder_task: builder_task(),
+          builder_selected_skill_names: [String.t()],
+          builder_runtime_targets: [String.t()],
+          builder_workflow_steps: [builder_workflow_step()],
+          builder_boundary_notes: [String.t()],
           log: [log_entry()],
           primary_skill_source_path: String.t(),
-          skills_root_source_path: String.t()
+          skills_root_source_path: String.t(),
+          builder_skill_source_paths: [String.t()]
         }
 
   @doc "Builds a new demo state and removes any previously registered demo skills."
@@ -80,6 +152,20 @@ defmodule AgentJido.Demos.SkillsRuntimeFoundations.RuntimeDemo do
     |> refresh()
   end
 
+  @doc "Loads the checked-in builder skill catalog for contributor workflows."
+  @spec load_builder_catalog(t()) :: t()
+  def load_builder_catalog(%__MODULE__{} = demo) do
+    {:ok, count} = Registry.load_from_paths(builder_skill_paths())
+
+    demo
+    |> Map.put(:builder_loaded_count, count)
+    |> append_log(
+      "Builder catalog",
+      "Loaded #{count} builder SKILL.md file(s) from priv/skills/builder-*/SKILL.md."
+    )
+    |> refresh()
+  end
+
   @doc "Renders the combined prompt for the currently registered demo skills."
   @spec render_prompt(t()) :: t()
   def render_prompt(%__MODULE__{} = demo) do
@@ -108,6 +194,34 @@ defmodule AgentJido.Demos.SkillsRuntimeFoundations.RuntimeDemo do
     end
   end
 
+  @doc "Runs one real workbench builder workflow against the checked-in jido_skill package page."
+  @spec run_builder_workflow(t()) :: t()
+  def run_builder_workflow(%__MODULE__{} = demo) do
+    demo =
+      case demo.builder_specs do
+        [] -> load_builder_catalog(demo)
+        _specs -> refresh(demo)
+      end
+
+    selected_skill_names = demo.builder_task.selected_skill_names
+    selected_specs = resolve_specs(selected_skill_names)
+    builder_prompt = Prompt.render(selected_specs, include_body: true)
+    builder_allowed_tools = Prompt.collect_allowed_tools(selected_specs)
+
+    demo
+    |> Map.put(:builder_selected_skill_names, selected_skill_names)
+    |> Map.put(:builder_prompt, builder_prompt)
+    |> Map.put(:builder_allowed_tools, builder_allowed_tools)
+    |> Map.put(:builder_runtime_targets, metadata_values(selected_specs, "intended_runtimes"))
+    |> Map.put(:builder_boundary_notes, metadata_values(selected_specs, "boundary"))
+    |> Map.put(:builder_workflow_steps, build_builder_workflow_steps(selected_specs, demo.builder_task))
+    |> append_log(
+      "Builder workflow",
+      "Rendered a builder workflow for #{demo.builder_task.target_package} using #{length(selected_specs)} catalog skill(s)."
+    )
+    |> refresh()
+  end
+
   @doc "Removes the demo skills from the registry and restores the initial state."
   @spec reset(t()) :: t()
   def reset(%__MODULE__{}) do
@@ -119,22 +233,17 @@ defmodule AgentJido.Demos.SkillsRuntimeFoundations.RuntimeDemo do
   end
 
   defp refresh(%__MODULE__{} = demo) do
-    registry_specs =
-      @demo_skill_names
-      |> Enum.flat_map(fn name ->
-        case Registry.lookup(name) do
-          {:ok, spec} -> [spec]
-          {:error, _reason} -> []
-        end
-      end)
-
-    %{demo | registry_specs: registry_specs}
+    %{
+      demo
+      | registry_specs: resolve_specs(@runtime_skill_names ++ @builder_skill_names),
+        builder_specs: resolve_specs(@builder_skill_names)
+    }
   end
 
   defp cleanup_demo_skills do
     :ok = Registry.ensure_started()
 
-    Enum.each(@demo_skill_names, fn name ->
+    Enum.each(@runtime_skill_names ++ @builder_skill_names, fn name ->
       try do
         case Registry.unregister(name) do
           :ok -> :ok
@@ -146,8 +255,76 @@ defmodule AgentJido.Demos.SkillsRuntimeFoundations.RuntimeDemo do
     end)
   end
 
+  defp resolve_specs(names) do
+    Enum.flat_map(names, fn name ->
+      case Registry.lookup(name) do
+        {:ok, spec} -> [spec]
+        {:error, _reason} -> []
+      end
+    end)
+  end
+
+  defp build_builder_workflow_steps(selected_specs, builder_task) do
+    Enum.map(selected_specs, fn spec ->
+      case spec.name do
+        "builder-package-review" ->
+          %{
+            title: "Review #{builder_task.target_package} package boundaries",
+            detail: "Separate package-repo findings from workbench follow-up items before any docs changes land.",
+            deliverable: "package review findings + docs-gap summary"
+          }
+
+        "builder-ecosystem-page-author" ->
+          %{
+            title: "Refresh #{builder_task.target_package} ecosystem page copy",
+            detail: "Update boundary lines, limitations, and companion links in #{Enum.at(builder_task.deliverable_paths, 0)}.",
+            deliverable: "ecosystem page refresh"
+          }
+
+        "builder-example-tutorial-author" ->
+          %{
+            title: "Outline the next truthful companion example",
+            detail:
+              "Turn the package source into a deterministic follow-up example or tutorial plan in #{Enum.at(builder_task.deliverable_paths, 1)}.",
+            deliverable: "example or tutorial outline"
+          }
+
+        _other ->
+          %{
+            title: spec.name,
+            detail: spec.description,
+            deliverable: "builder workflow step"
+          }
+      end
+    end)
+  end
+
+  defp metadata_values(specs, key) do
+    specs
+    |> Enum.flat_map(fn spec ->
+      case spec.metadata do
+        %{} = metadata -> metadata |> Map.get(key, "") |> metadata_list()
+        _other -> []
+      end
+    end)
+    |> Enum.map(&String.trim/1)
+    |> Enum.reject(&(&1 == ""))
+    |> Enum.uniq()
+  end
+
+  defp metadata_list(values) when is_list(values), do: values
+
+  defp metadata_list(value) when is_binary(value) do
+    value
+    |> String.split(",")
+    |> Enum.map(&String.trim/1)
+  end
+
+  defp metadata_list(_other), do: []
+
   defp primary_skill_path, do: Path.join(@project_root, @primary_skill_source_path)
   defp skills_root_path, do: Path.join(@project_root, @skills_root_source_path)
+  defp builder_skill_paths, do: Enum.map(@builder_skill_source_paths, &Path.join(@project_root, &1))
 
   defp append_log(%__MODULE__{} = demo, label, detail) do
     entry = %{label: label, detail: detail}

--- a/lib/agent_jido_web/examples/skills_runtime_foundations_live.ex
+++ b/lib/agent_jido_web/examples/skills_runtime_foundations_live.ex
@@ -28,7 +28,7 @@ defmodule AgentJidoWeb.Examples.SkillsRuntimeFoundationsLive do
         </div>
       </div>
 
-      <div class="grid gap-3 sm:grid-cols-4">
+      <div class="grid gap-3 sm:grid-cols-3 xl:grid-cols-6">
         <div class="rounded-md border border-border bg-elevated p-3 text-center">
           <div class="text-[10px] uppercase tracking-wider text-muted-foreground">File Manifest</div>
           <div class="text-sm font-semibold text-foreground mt-2">
@@ -49,6 +49,18 @@ defmodule AgentJidoWeb.Examples.SkillsRuntimeFoundationsLive do
           <div class="text-[10px] uppercase tracking-wider text-muted-foreground">Prompt Ready</div>
           <div class="text-sm font-semibold text-foreground mt-2">
             {if @demo.prompt != "", do: "yes", else: "no"}
+          </div>
+        </div>
+        <div class="rounded-md border border-border bg-elevated p-3 text-center">
+          <div class="text-[10px] uppercase tracking-wider text-muted-foreground">Builder Catalog</div>
+          <div class="text-sm font-semibold text-foreground mt-2">
+            {if @demo.builder_specs == [], do: "pending", else: "#{length(@demo.builder_specs)} loaded"}
+          </div>
+        </div>
+        <div class="rounded-md border border-border bg-elevated p-3 text-center">
+          <div class="text-[10px] uppercase tracking-wider text-muted-foreground">Builder Workflow</div>
+          <div class="text-sm font-semibold text-foreground mt-2">
+            {if @demo.builder_workflow_steps == [], do: "pending", else: "ready"}
           </div>
         </div>
       </div>
@@ -76,11 +88,25 @@ defmodule AgentJidoWeb.Examples.SkillsRuntimeFoundationsLive do
           Load Runtime Directory
         </button>
         <button
+          id="skills-load-builder-btn"
+          phx-click="load_builder_catalog"
+          class="px-4 py-2 rounded-md bg-fuchsia-500/10 border border-fuchsia-500/30 text-fuchsia-200 hover:bg-fuchsia-500/20 transition-colors text-sm font-semibold"
+        >
+          Load Builder Catalog
+        </button>
+        <button
           id="skills-render-prompt-btn"
           phx-click="render_prompt"
           class="px-4 py-2 rounded-md bg-amber-500/10 border border-amber-500/30 text-amber-300 hover:bg-amber-500/20 transition-colors text-sm font-semibold"
         >
           Render Prompt
+        </button>
+        <button
+          id="skills-run-builder-btn"
+          phx-click="run_builder_workflow"
+          class="px-4 py-2 rounded-md bg-indigo-500/10 border border-indigo-500/30 text-indigo-200 hover:bg-indigo-500/20 transition-colors text-sm font-semibold"
+        >
+          Run Builder Workflow
         </button>
         <button
           id="skills-reset-btn"
@@ -153,6 +179,31 @@ defmodule AgentJidoWeb.Examples.SkillsRuntimeFoundationsLive do
               <% end %>
             </div>
           </div>
+
+          <div class="rounded-md border border-border bg-elevated p-4">
+            <div class="flex items-center justify-between mb-2">
+              <div class="text-[10px] uppercase tracking-wider text-muted-foreground">Builder Skill Catalog</div>
+              <div id="skills-builder-count" class="text-[10px] text-muted-foreground">
+                {@demo.builder_loaded_count} file skill(s) loaded
+              </div>
+            </div>
+
+            <div :if={@demo.builder_specs == []} class="text-xs text-muted-foreground">
+              Load the builder catalog to inspect the checked-in workbench contributor skills.
+            </div>
+
+            <div :if={@demo.builder_specs != []} id="skills-builder-list" class="space-y-2">
+              <%= for spec <- @demo.builder_specs do %>
+                <div class="rounded-md border border-border bg-background/70 p-3">
+                  <div class="text-xs font-semibold text-foreground">{spec.name}</div>
+                  <div class="text-[11px] text-muted-foreground mt-1">{spec.description}</div>
+                  <div class="text-[11px] text-muted-foreground mt-2">
+                    boundary: {Map.get(spec.metadata, "boundary")}
+                  </div>
+                </div>
+              <% end %>
+            </div>
+          </div>
         </div>
 
         <div class="space-y-4">
@@ -166,6 +217,75 @@ defmodule AgentJidoWeb.Examples.SkillsRuntimeFoundationsLive do
           <div class="rounded-md border border-border bg-elevated p-4">
             <div class="text-[10px] uppercase tracking-wider text-muted-foreground mb-2">Rendered Prompt</div>
             <pre id="skills-prompt-output" class="text-[11px] text-foreground whitespace-pre-wrap font-mono"><%= if @demo.prompt == "", do: "Render the prompt to inspect the combined skill instructions.", else: @demo.prompt %></pre>
+          </div>
+
+          <div class="rounded-md border border-border bg-elevated p-4 space-y-3">
+            <div class="flex items-center justify-between">
+              <div class="text-[10px] uppercase tracking-wider text-muted-foreground">Builder Workflow Task</div>
+              <div id="skills-builder-runtime-targets" class="text-[10px] text-muted-foreground">
+                {if @demo.builder_runtime_targets == [], do: "runtime targets pending", else: Enum.join(@demo.builder_runtime_targets, ", ")}
+              </div>
+            </div>
+
+            <div id="skills-builder-task-summary" class="space-y-2 text-[11px] text-foreground">
+              <div><span class="font-semibold">task:</span> {@demo.builder_task.title}</div>
+              <div><span class="font-semibold">target package:</span> {@demo.builder_task.target_package}</div>
+              <div><span class="font-semibold">summary:</span> {@demo.builder_task.summary}</div>
+            </div>
+
+            <div>
+              <div class="text-[10px] uppercase tracking-wider text-muted-foreground mb-2">Reference Paths</div>
+              <div id="skills-builder-reference-paths" class="space-y-1 text-[11px] text-foreground">
+                <%= for path <- @demo.builder_task.reference_paths do %>
+                  <div>{path}</div>
+                <% end %>
+              </div>
+            </div>
+
+            <div>
+              <div class="text-[10px] uppercase tracking-wider text-muted-foreground mb-2">Deliverables</div>
+              <div id="skills-builder-deliverables" class="space-y-1 text-[11px] text-foreground">
+                <%= for path <- @demo.builder_task.deliverable_paths do %>
+                  <div>{path}</div>
+                <% end %>
+              </div>
+            </div>
+
+            <div :if={@demo.builder_selected_skill_names != []}>
+              <div class="text-[10px] uppercase tracking-wider text-muted-foreground mb-2">Selected Builder Skills</div>
+              <div id="skills-builder-selected-skills" class="space-y-1 text-[11px] text-foreground">
+                <%= for skill_name <- @demo.builder_selected_skill_names do %>
+                  <div>{skill_name}</div>
+                <% end %>
+              </div>
+            </div>
+
+            <div :if={@demo.builder_workflow_steps != []}>
+              <div class="text-[10px] uppercase tracking-wider text-muted-foreground mb-2">Workflow Steps</div>
+              <div id="skills-builder-workflow-steps" class="space-y-2">
+                <%= for step <- @demo.builder_workflow_steps do %>
+                  <div class="rounded-md border border-border bg-background/70 p-3">
+                    <div class="text-xs font-semibold text-foreground">{step.title}</div>
+                    <div class="text-[11px] text-muted-foreground mt-1">{step.detail}</div>
+                    <div class="text-[11px] text-muted-foreground mt-2">deliverable: {step.deliverable}</div>
+                  </div>
+                <% end %>
+              </div>
+            </div>
+
+            <div :if={@demo.builder_boundary_notes != []}>
+              <div class="text-[10px] uppercase tracking-wider text-muted-foreground mb-2">Boundary Notes</div>
+              <div id="skills-builder-boundary-notes" class="space-y-1 text-[11px] text-foreground">
+                <%= for note <- @demo.builder_boundary_notes do %>
+                  <div>{note}</div>
+                <% end %>
+              </div>
+            </div>
+          </div>
+
+          <div class="rounded-md border border-border bg-elevated p-4">
+            <div class="text-[10px] uppercase tracking-wider text-muted-foreground mb-2">Builder Prompt</div>
+            <pre id="skills-builder-prompt-output" class="text-[11px] text-foreground whitespace-pre-wrap font-mono"><%= if @demo.builder_prompt == "", do: "Run the builder workflow to inspect the contributor prompt assembled from the catalog.", else: @demo.builder_prompt %></pre>
           </div>
 
           <div class="rounded-md border border-border bg-elevated p-4">
@@ -206,8 +326,16 @@ defmodule AgentJidoWeb.Examples.SkillsRuntimeFoundationsLive do
     {:noreply, assign_demo(socket, RuntimeDemo.load_runtime_skills(socket.assigns.demo))}
   end
 
+  def handle_event("load_builder_catalog", _params, socket) do
+    {:noreply, assign_demo(socket, RuntimeDemo.load_builder_catalog(socket.assigns.demo))}
+  end
+
   def handle_event("render_prompt", _params, socket) do
     {:noreply, assign_demo(socket, RuntimeDemo.render_prompt(socket.assigns.demo))}
+  end
+
+  def handle_event("run_builder_workflow", _params, socket) do
+    {:noreply, assign_demo(socket, RuntimeDemo.run_builder_workflow(socket.assigns.demo))}
   end
 
   def handle_event("reset_demo", _params, socket) do

--- a/priv/ecosystem/jido_skill.md
+++ b/priv/ecosystem/jido_skill.md
@@ -47,6 +47,29 @@ Jido Skill is the dedicated skill runtime package for teams standardizing markdo
 - Provides CLI and mix-task operational interfaces for skill runtime workflows.
 - Does not own general command orchestration, chat transport integration, or provider-specific adapter behavior.
 
+## Builder Skill Catalog In This Workbench
+
+This repo now carries a starter builder-skill catalog under `priv/skills/builder-*/SKILL.md` for ecosystem work that touches `jido_skill` and companion packages.
+
+- Load individual builder skills with `Jido.AI.Skill.Loader.load/1`.
+- Load the full checked-in catalog with `Jido.AI.Skill.Registry.load_from_paths/1`.
+- The intended runtime targets for this catalog are `Jido.AI`, `jido_skill`, and Codex-style contributor workflows.
+
+The package boundary stays explicit:
+
+- `jido_skill` owns markdown-skill runtime behavior, registry and dispatch surfaces, CLI/mix tasks, and release artifacts.
+- `jido_run` owns the ecosystem page, example/tutorial presentation, and contributor-facing narrative around how those skills are used.
+
+### Current Builder Catalog
+
+- `builder-action-scaffold`
+- `builder-agent-scaffold`
+- `builder-plugin-scaffold`
+- `builder-adapter-package`
+- `builder-ecosystem-page-author`
+- `builder-example-tutorial-author`
+- `builder-package-review`
+
 ## Major Components
 
 ### Skill Registry
@@ -64,4 +87,3 @@ Provides commands for run/list/reload/routes/watch/signal operations in local en
 ### Runtime Observability
 
 Exposes lifecycle signal streams for tracking skill execution and registry events.
-

--- a/priv/examples/jido-ai-skills-runtime-foundations.md
+++ b/priv/examples/jido-ai-skills-runtime-foundations.md
@@ -1,6 +1,7 @@
 %{
   title: "Jido.AI Skills Runtime Foundations",
-  description: "Real skill manifest loading, registry setup, and prompt rendering with checked-in `SKILL.md` fixtures.",
+  description:
+    "Real skill manifest loading, registry setup, prompt rendering, and builder-skill catalog walkthroughs with checked-in `SKILL.md` fixtures.",
   tags: ["primary", "showcase", "ai", "l2", "ai-tool-use", "skills", "runtime", "jido_ai"],
   category: :ai,
   emoji: "📚",
@@ -30,6 +31,14 @@
     "lib/agent_jido/demos/skills_runtime_foundations/calculator_skill.ex",
     "lib/agent_jido/demos/skills_runtime_foundations/runtime_demo.ex",
     "lib/agent_jido_web/examples/skills_runtime_foundations_live.ex",
+    "priv/ecosystem/jido_skill.md",
+    "priv/skills/builder-action-scaffold/SKILL.md",
+    "priv/skills/builder-agent-scaffold/SKILL.md",
+    "priv/skills/builder-plugin-scaffold/SKILL.md",
+    "priv/skills/builder-adapter-package/SKILL.md",
+    "priv/skills/builder-ecosystem-page-author/SKILL.md",
+    "priv/skills/builder-example-tutorial-author/SKILL.md",
+    "priv/skills/builder-package-review/SKILL.md",
     "priv/skills/skills-runtime-foundations/demo-code-review/SKILL.md",
     "priv/skills/skills-runtime-foundations/demo-release-notes/SKILL.md"
   ],
@@ -52,6 +61,9 @@
 - How `Jido.AI.Skill.Loader.load/1` parses checked-in `SKILL.md` files into runtime manifests
 - How `Jido.AI.Skill.Registry.load_from_paths/1` and `Jido.AI.Skill.Registry.register/1` populate one deterministic registry
 - How `Jido.AI.Skill.Prompt.render/2` turns those registered skills into reusable prompt instructions
+- Where the builder-skill catalog lives under `priv/skills/builder-*/SKILL.md`
+- How the same builder skills can support `Jido.AI`, `jido_skill`, and Codex-oriented contributor workflows
+- How one real workbench task for `jido_skill` is assembled from checked-in builder skills
 
 ## How this demo stays truthful
 
@@ -59,9 +71,28 @@ This page runs **real skills runtime code**.
 
 - One skill is defined as an Elixir module with `use Jido.AI.Skill`.
 - Two skills are loaded from checked-in `priv/skills/.../SKILL.md` files.
-- The demo registers only those three demo skills, renders the combined prompt, and never calls external services.
+- Seven builder skills are loaded from checked-in `priv/skills/builder-*/SKILL.md` files.
+- The demo uses those builder skills to render a real contributor workflow for refreshing the `jido_skill` ecosystem package coverage in this repo.
+- The demo renders prompts and workflow plans only. It does not call external services or mutate package repos.
 
 No API keys, LLM providers, or network access are required for this example.
+
+## Builder catalog included here
+
+The checked-in builder catalog currently includes:
+
+- `builder-action-scaffold`
+- `builder-agent-scaffold`
+- `builder-plugin-scaffold`
+- `builder-adapter-package`
+- `builder-ecosystem-page-author`
+- `builder-example-tutorial-author`
+- `builder-package-review`
+
+The catalog is intentionally split across package-repo and workbench-repo boundaries:
+
+- package repos own implementation modules, tests, changelog updates, and release work
+- this workbench owns ecosystem pages, examples, tutorials, and contributor-facing guidance
 
 ## Pull the pattern into your own app
 
@@ -71,3 +102,4 @@ Keep the same runtime steps in your own project:
 - add file-backed `SKILL.md` assets when you want editable runtime instructions
 - register those skills into the runtime registry
 - render the combined prompt text once your agent or workflow needs it
+- keep boundary notes inside the skill metadata so package-repo work and workbench follow-up stay explicit

--- a/priv/skills/builder-action-scaffold/SKILL.md
+++ b/priv/skills/builder-action-scaffold/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: builder-action-scaffold
+description: Scaffolds a new Jido.Action with schema, tests, and workbench follow-up notes for ecosystem contributors.
+license: Apache-2.0
+compatibility: Jido.AI >= 2.0
+allowed-tools: read_file write_file grep scaffold_action_module scaffold_action_test update_docs
+metadata:
+  author: agent-jido-workbench
+  version: "1.0.0"
+  host_repo: jido.run
+  intended_runtimes: Jido.AI, jido_skill, Codex
+  boundary: package repo implementation with workbench docs and example follow-up
+tags:
+  - builder
+  - scaffold
+  - action
+  - workbench
+---
+
+# Builder Action Scaffold
+
+Use this skill when the task is to add a new `Jido.Action` and keep the surrounding contributor workflow consistent.
+
+## Workflow
+
+1. Capture the action name, schema, return contract, and deterministic fallback behavior.
+2. Generate the module with explicit validation, tagged tuple errors, and any helper actions it needs.
+3. Add focused tests that cover success, validation failures, and operational edge cases.
+4. Record the workbench follow-up items: example page, ecosystem entry, and docs references if needed.
+
+## Package Boundary
+
+- Package repo: action module, tests, changelog, and package README updates.
+- Workbench repo: ecosystem page updates, example/tutorial references, and contributor-facing docs.
+
+## Deliverables
+
+- action module scaffold
+- companion test outline
+- workbench follow-up checklist

--- a/priv/skills/builder-adapter-package/SKILL.md
+++ b/priv/skills/builder-adapter-package/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: builder-adapter-package
+description: Plans or scaffolds a new adapter or integration package for provider, browser, MCP, or tooling interoperability.
+license: Apache-2.0
+compatibility: Jido.AI >= 2.0
+allowed-tools: read_file write_file grep draft_package_layout map_boundaries update_docs
+metadata:
+  author: agent-jido-workbench
+  version: "1.0.0"
+  host_repo: jido.run
+  intended_runtimes: Jido.AI, jido_skill, Codex
+  boundary: package repo owns adapter logic; workbench owns narrative, examples, and ecosystem inventory
+tags:
+  - builder
+  - adapter
+  - integration
+  - package
+---
+
+# Builder Adapter Package
+
+Use this skill when the work is a new adapter or integration package for provider tooling, MCP, browser flows, or workbench interoperability.
+
+## Workflow
+
+1. Define the package boundary, public API, runtime dependencies, and failure modes.
+2. Draft the package layout with clear separation between integration edges and core Jido abstractions.
+3. Identify the deterministic fixtures or adapters needed for tests and examples.
+4. Record the workbench deliverables: ecosystem page, example/tutorial ideas, and migration notes.
+
+## Package Boundary
+
+- Package repo: adapter modules, integration tests, release assets, and compatibility notes.
+- Workbench repo: package page, examples/tutorials, and contributor-facing guidance.
+
+## Deliverables
+
+- package boundary map
+- adapter package skeleton
+- workbench follow-up checklist

--- a/priv/skills/builder-agent-scaffold/SKILL.md
+++ b/priv/skills/builder-agent-scaffold/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: builder-agent-scaffold
+description: Scaffolds a new Jido or Jido.AI agent with strategy, runtime policy, and workbench documentation follow-up.
+license: Apache-2.0
+compatibility: Jido.AI >= 2.0
+allowed-tools: read_file write_file grep scaffold_agent_module scaffold_agent_test update_docs
+metadata:
+  author: agent-jido-workbench
+  version: "1.0.0"
+  host_repo: jido.run
+  intended_runtimes: Jido.AI, jido_skill, Codex
+  boundary: package repo implementation with workbench docs and example follow-up
+tags:
+  - builder
+  - scaffold
+  - agent
+  - strategy
+---
+
+# Builder Agent Scaffold
+
+Use this skill when the task is to create a new agent and the caller needs a clear split between strategy wiring, tools, and docs.
+
+## Workflow
+
+1. Identify the agent type, strategy, plugins, skills, and runtime guardrails.
+2. Generate the module with explicit timeouts, retry posture, tool boundaries, and signal routes.
+3. Add tests for the core command path, error handling, and deterministic local fixtures.
+4. Capture the follow-up work needed in the workbench: examples, ecosystem notes, and migration guidance.
+
+## Package Boundary
+
+- Package repo: agent module, local fixtures, tests, and release notes.
+- Workbench repo: ecosystem page narrative, example/demo surface, and contributor docs.
+
+## Deliverables
+
+- agent module scaffold
+- runtime/test checklist
+- workbench publishing checklist

--- a/priv/skills/builder-ecosystem-page-author/SKILL.md
+++ b/priv/skills/builder-ecosystem-page-author/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: builder-ecosystem-page-author
+description: Authors or updates a workbench ecosystem package page with boundaries, features, limitations, and companion links.
+license: Apache-2.0
+compatibility: Jido.AI >= 2.0
+allowed-tools: read_file grep summarize_changes update_markdown validate_links
+metadata:
+  author: agent-jido-workbench
+  version: "1.0.0"
+  host_repo: jido.run
+  intended_runtimes: Jido.AI, jido_skill, Codex
+  boundary: workbench-only skill for package inventory and ecosystem documentation
+tags:
+  - builder
+  - docs
+  - ecosystem
+  - catalog
+---
+
+# Builder Ecosystem Page Author
+
+Use this skill when the task is to add or refresh a package page in the workbench ecosystem catalog.
+
+## Workflow
+
+1. Gather the package purpose, boundary lines, maturity, dependencies, and limitations from source material.
+2. Write or update the ecosystem page with concise package positioning and honest status notes.
+3. Link the package to the right examples, guides, and upstream repositories.
+4. Verify the page makes the repo boundary explicit: package repo implementation vs workbench narrative and examples.
+
+## Package Boundary
+
+- Package repo: code, changelog, versioning, and API specifics.
+- Workbench repo: package overview, capability framing, limitations, and companion links.
+
+## Deliverables
+
+- ecosystem page draft or update
+- related links checklist
+- boundary and limitation summary

--- a/priv/skills/builder-example-tutorial-author/SKILL.md
+++ b/priv/skills/builder-example-tutorial-author/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: builder-example-tutorial-author
+description: Turns package source material into a runnable example or tutorial plan for the workbench.
+license: Apache-2.0
+compatibility: Jido.AI >= 2.0
+allowed-tools: read_file grep summarize_changes draft_example_outline draft_tutorial_outline update_docs
+metadata:
+  author: agent-jido-workbench
+  version: "1.0.0"
+  host_repo: jido.run
+  intended_runtimes: Jido.AI, jido_skill, Codex
+  boundary: package repo provides source truth; workbench owns example/tutorial presentation
+tags:
+  - builder
+  - example
+  - tutorial
+  - docs
+---
+
+# Builder Example or Tutorial Author
+
+Use this skill when the task is to turn package source material into a runnable example page or a docs/tutorial flow in the workbench.
+
+## Workflow
+
+1. Extract the smallest truthful workflow from the package source.
+2. Decide whether the work belongs as an example, tutorial, cookbook, or reference page.
+3. Define the deterministic fixture plan so the surface is testable without external credentials.
+4. Produce the content outline, implementation targets, and verification checklist.
+
+## Package Boundary
+
+- Package repo: implementation modules, test fixtures, and public API examples.
+- Workbench repo: example page, tutorial copy, live demo surface, and narrative sequencing.
+
+## Deliverables
+
+- example or tutorial outline
+- deterministic fixture plan
+- implementation and verification checklist

--- a/priv/skills/builder-package-review/SKILL.md
+++ b/priv/skills/builder-package-review/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: builder-package-review
+description: Reviews a Jido ecosystem package for boundaries, dependencies, testing gaps, and missing workbench documentation.
+license: Apache-2.0
+compatibility: Jido.AI >= 2.0
+allowed-tools: read_file grep git_diff inspect_deps summarize_changes update_docs
+metadata:
+  author: agent-jido-workbench
+  version: "1.0.0"
+  host_repo: jido.run
+  intended_runtimes: Jido.AI, jido_skill, Codex
+  boundary: review can span package repo and workbench, but findings should separate the two clearly
+tags:
+  - builder
+  - review
+  - boundaries
+  - dependencies
+---
+
+# Builder Package Review
+
+Use this skill when the task is to review a package for architectural boundaries, dependency fit, test gaps, or missing docs and examples.
+
+## Workflow
+
+1. Read the package boundary lines, public API, and dependency set.
+2. Flag mismatches between implementation claims, tests, and workbench documentation.
+3. Separate package-repo findings from workbench follow-up items.
+4. Summarize the highest-risk gaps first, then note docs, example, or ecosystem-page work still needed.
+
+## Package Boundary
+
+- Package repo: architecture, dependencies, tests, changelog, and release readiness.
+- Workbench repo: ecosystem page accuracy, examples, tutorials, and migration notes.
+
+## Deliverables
+
+- package review findings
+- dependency and docs-gap summary
+- package-vs-workbench follow-up split

--- a/priv/skills/builder-plugin-scaffold/SKILL.md
+++ b/priv/skills/builder-plugin-scaffold/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: builder-plugin-scaffold
+description: Scaffolds a Jido plugin with signal routes, actions, and docs notes for workbench consumers.
+license: Apache-2.0
+compatibility: Jido.AI >= 2.0
+allowed-tools: read_file write_file grep scaffold_plugin_module scaffold_plugin_test update_docs
+metadata:
+  author: agent-jido-workbench
+  version: "1.0.0"
+  host_repo: jido.run
+  intended_runtimes: Jido.AI, jido_skill, Codex
+  boundary: package repo signal/runtime implementation with workbench usage docs
+tags:
+  - builder
+  - scaffold
+  - plugin
+  - signals
+---
+
+# Builder Plugin Scaffold
+
+Use this skill when the task is to add a plugin that introduces new signal routes, runtime policy, or reusable operational behavior.
+
+## Workflow
+
+1. Capture the signal routes, required actions, plugin opts, and failure boundaries.
+2. Generate the plugin module with explicit route mapping and minimal hidden behavior.
+3. Add tests for route registration, action dispatch, and misconfiguration handling.
+4. Document how the plugin should appear in examples, docs, and ecosystem package pages.
+
+## Package Boundary
+
+- Package repo: plugin module, actions, tests, and configuration docs.
+- Workbench repo: example usage, docs snippets, and ecosystem positioning.
+
+## Deliverables
+
+- plugin scaffold
+- route and action checklist
+- workbench usage notes

--- a/test/agent_jido/demos/skills_runtime_foundations_runtime_demo_test.exs
+++ b/test/agent_jido/demos/skills_runtime_foundations_runtime_demo_test.exs
@@ -47,6 +47,22 @@ defmodule AgentJido.Demos.SkillsRuntimeFoundationsRuntimeDemoTest do
            ]
   end
 
+  test "loads the builder skill catalog from checked-in SKILL.md files", %{demo: demo} do
+    demo = RuntimeDemo.load_builder_catalog(demo)
+
+    assert demo.builder_loaded_count == 7
+
+    assert Enum.map(demo.builder_specs, & &1.name) == [
+             "builder-action-scaffold",
+             "builder-agent-scaffold",
+             "builder-plugin-scaffold",
+             "builder-adapter-package",
+             "builder-ecosystem-page-author",
+             "builder-example-tutorial-author",
+             "builder-package-review"
+           ]
+  end
+
   test "renders a combined prompt and tool union from the registered demo skills", %{demo: demo} do
     demo =
       demo
@@ -60,5 +76,33 @@ defmodule AgentJido.Demos.SkillsRuntimeFoundationsRuntimeDemoTest do
     assert demo.prompt =~ "demo-release-notes"
     assert "add" in demo.allowed_tools
     assert "format_release_notes" in demo.allowed_tools
+  end
+
+  test "runs one real builder workflow against the jido_skill workbench task", %{demo: demo} do
+    demo = RuntimeDemo.run_builder_workflow(demo)
+
+    assert demo.builder_task.target_package == "jido_skill"
+
+    assert demo.builder_selected_skill_names == [
+             "builder-package-review",
+             "builder-ecosystem-page-author",
+             "builder-example-tutorial-author"
+           ]
+
+    assert demo.builder_prompt =~ "Builder Package Review"
+    assert demo.builder_prompt =~ "Builder Ecosystem Page Author"
+    assert demo.builder_prompt =~ "Builder Example or Tutorial Author"
+    assert demo.builder_runtime_targets == ["Jido.AI", "jido_skill", "Codex"]
+    assert "update_docs" in demo.builder_allowed_tools
+    assert "summarize_changes" in demo.builder_allowed_tools
+
+    assert Enum.map(demo.builder_workflow_steps, & &1.title) == [
+             "Review jido_skill package boundaries",
+             "Refresh jido_skill ecosystem page copy",
+             "Outline the next truthful companion example"
+           ]
+
+    assert Enum.any?(demo.builder_boundary_notes, &String.contains?(&1, "package repo"))
+    assert Enum.any?(demo.log, &(&1.label == "Builder workflow"))
   end
 end

--- a/test/agent_jido_web/live/jido_example_live_test.exs
+++ b/test/agent_jido_web/live/jido_example_live_test.exs
@@ -776,6 +776,8 @@ defmodule AgentJidoWeb.JidoExampleLiveTest do
       assert html =~ "Jido.AI.Skill.Loader.load/1"
       assert html =~ "Jido.AI.Skill.Registry.load_from_paths/1"
       assert html =~ "Jido.AI.Skill.Prompt.render/2"
+      assert html =~ "priv/skills/builder-*/SKILL.md"
+      assert html =~ "jido_skill"
       assert html =~ "No API keys, LLM providers, or network access are required for this example."
     end
 
@@ -785,11 +787,12 @@ defmodule AgentJidoWeb.JidoExampleLiveTest do
       assert html =~ "calculator_skill.ex"
       assert html =~ "runtime_demo.ex"
       assert html =~ "skills_runtime_foundations_live.ex"
+      assert html =~ "jido_skill.md"
       assert html =~ "SKILL.md"
       refute html =~ "simulated_showcase_live.ex"
     end
 
-    test "demo tab runs the deterministic skills runtime flow", %{conn: conn} do
+    test "demo tab runs the deterministic skills runtime and builder workflow flows", %{conn: conn} do
       {:ok, view, html} = live(conn, "/examples/jido-ai-skills-runtime-foundations?tab=demo")
 
       assert html =~ "Jido.AI Skills Runtime Foundations"
@@ -831,6 +834,26 @@ defmodule AgentJidoWeb.JidoExampleLiveTest do
       assert html =~ "demo-runtime-calculator"
       assert html =~ "demo-code-review"
       assert html =~ "format_release_notes"
+
+      html =
+        demo_view
+        |> element("#skills-runtime-foundations-demo button[phx-click='load_builder_catalog']")
+        |> render_click()
+
+      assert html =~ "Loaded 7 builder SKILL.md file(s)"
+      assert html =~ "builder-action-scaffold"
+      assert html =~ "builder-package-review"
+
+      html =
+        demo_view
+        |> element("#skills-runtime-foundations-demo button[phx-click='run_builder_workflow']")
+        |> render_click()
+
+      assert html =~ "Refresh Jido Skill package coverage"
+      assert html =~ "priv/ecosystem/jido_skill.md"
+      assert html =~ "builder-ecosystem-page-author"
+      assert html =~ "Builder Ecosystem Page Author"
+      assert html =~ "Jido.AI, jido_skill, Codex"
     end
 
     test "example registry metadata resolves new skills runtime source files", %{conn: _conn} do
@@ -843,6 +866,14 @@ defmodule AgentJidoWeb.JidoExampleLiveTest do
                "lib/agent_jido/demos/skills_runtime_foundations/calculator_skill.ex",
                "lib/agent_jido/demos/skills_runtime_foundations/runtime_demo.ex",
                "lib/agent_jido_web/examples/skills_runtime_foundations_live.ex",
+               "priv/ecosystem/jido_skill.md",
+               "priv/skills/builder-action-scaffold/SKILL.md",
+               "priv/skills/builder-agent-scaffold/SKILL.md",
+               "priv/skills/builder-plugin-scaffold/SKILL.md",
+               "priv/skills/builder-adapter-package/SKILL.md",
+               "priv/skills/builder-ecosystem-page-author/SKILL.md",
+               "priv/skills/builder-example-tutorial-author/SKILL.md",
+               "priv/skills/builder-package-review/SKILL.md",
                "priv/skills/skills-runtime-foundations/demo-code-review/SKILL.md",
                "priv/skills/skills-runtime-foundations/demo-release-notes/SKILL.md"
              ]


### PR DESCRIPTION
Summary
- add a checked-in builder skill catalog under priv/skills/builder-*
- extend the skills runtime foundations example to load the catalog and run a real jido_skill workbench task
- document catalog boundaries, loading paths, and intended runtimes in the example and jido_skill ecosystem page

Verification
- ASDF_ELIXIR_VERSION=1.18.4-otp-27 ASDF_ERLANG_VERSION=27.3 mix test test/agent_jido/demos/skills_runtime_foundations_runtime_demo_test.exs test/agent_jido_web/live/jido_example_live_test.exs
- ASDF_ELIXIR_VERSION=1.18.4-otp-27 ASDF_ERLANG_VERSION=27.3 mix test
- ASDF_ELIXIR_VERSION=1.18.4-otp-27 ASDF_ERLANG_VERSION=27.3 mix credo --strict
- ASDF_ELIXIR_VERSION=1.18.4-otp-27 ASDF_ERLANG_VERSION=27.3 mix dialyzer

Closes #51