### PR TITLE
Add vendored upstream Jido skills catalog page

### DIFF
--- a/lib/agent_jido/upstream_skill_catalog.ex
+++ b/lib/agent_jido/upstream_skill_catalog.ex
@@ -1,0 +1,145 @@
+defmodule AgentJido.UpstreamSkillCatalog do
+  @moduledoc """
+  Static catalog for the vendored `arrowcircle/jido-skills` package skills.
+  """
+
+  alias Jido.AI.Skill.Loader
+
+  @catalog_root Application.app_dir(:agent_jido, "priv/skills/arrowcircle-jido-skills")
+  @skills_root Path.join(@catalog_root, "skills")
+  @repo_url "https://github.com/arrowcircle/jido-skills"
+  @readme_source_path "priv/skills/arrowcircle-jido-skills/README.md"
+  @source_prompt_source_path "priv/skills/arrowcircle-jido-skills/source/prompts.md"
+
+  @catalog_files Path.wildcard(Path.join(@catalog_root, "**/*"))
+                 |> Enum.filter(&File.regular?/1)
+                 |> Enum.sort()
+
+  Enum.each(@catalog_files, &Module.put_attribute(__MODULE__, :external_resource, &1))
+
+  @type category :: :package | :router
+
+  @type entry :: %{
+          id: String.t(),
+          name: String.t(),
+          title: String.t(),
+          description: String.t(),
+          category: category(),
+          skill_source_path: String.t(),
+          upstream_url: String.t(),
+          ecosystem_package_id: String.t() | nil,
+          ecosystem_path: String.t() | nil,
+          agent_files: [String.t()],
+          reference_files: [String.t()]
+        }
+
+  @spec all_entries() :: [entry()]
+  def all_entries do
+    skill_paths()
+    |> Enum.map(&build_entry!/1)
+  end
+
+  @spec package_entries() :: [entry()]
+  def package_entries do
+    Enum.filter(all_entries(), &(&1.category == :package))
+  end
+
+  @spec router_entries() :: [entry()]
+  def router_entries do
+    Enum.filter(all_entries(), &(&1.category == :router))
+  end
+
+  @spec count() :: non_neg_integer()
+  def count, do: length(all_entries())
+
+  @spec package_count() :: non_neg_integer()
+  def package_count, do: length(package_entries())
+
+  @spec router_count() :: non_neg_integer()
+  def router_count, do: length(router_entries())
+
+  @spec repo_url() :: String.t()
+  def repo_url, do: @repo_url
+
+  @spec readme_source_path() :: String.t()
+  def readme_source_path, do: @readme_source_path
+
+  @spec source_prompt_source_path() :: String.t()
+  def source_prompt_source_path, do: @source_prompt_source_path
+
+  @spec skills_root_source_path() :: String.t()
+  def skills_root_source_path, do: "priv/skills/arrowcircle-jido-skills/skills"
+
+  @spec support_file_count() :: non_neg_integer()
+  def support_file_count do
+    all_entries()
+    |> Enum.map(&(length(&1.agent_files) + length(&1.reference_files)))
+    |> Enum.sum()
+  end
+
+  defp build_entry!(skill_path) do
+    {:ok, spec} = Loader.load(skill_path)
+
+    skill_dir = Path.dirname(skill_path)
+    id = Path.basename(skill_dir)
+    category = if id == "jido-skill-router", do: :router, else: :package
+    ecosystem_package_id = ecosystem_package_id(id, category)
+    ecosystem_path = ecosystem_path(ecosystem_package_id)
+
+    %{
+      id: id,
+      name: spec.name,
+      title: title_for(id, category),
+      description: spec.description,
+      category: category,
+      skill_source_path: relative_to_cwd(skill_path),
+      upstream_url: "#{@repo_url}/tree/main/skills/#{id}",
+      ecosystem_package_id: ecosystem_package_id,
+      ecosystem_path: ecosystem_path,
+      agent_files: support_files(skill_dir, "agents"),
+      reference_files: support_files(skill_dir, "references")
+    }
+  end
+
+  defp support_files(skill_dir, subdir) do
+    skill_dir
+    |> Path.join("#{subdir}/**/*")
+    |> Path.wildcard()
+    |> Enum.filter(&File.regular?/1)
+    |> Enum.map(&relative_to_cwd/1)
+    |> Enum.sort()
+  end
+
+  defp skill_paths do
+    @skills_root
+    |> Path.join("*/SKILL.md")
+    |> Path.wildcard()
+    |> Enum.sort()
+  end
+
+  defp ecosystem_package_id(_id, :router), do: nil
+  defp ecosystem_package_id(id, :package), do: String.replace(id, "-", "_")
+
+  defp ecosystem_path(nil), do: nil
+
+  defp ecosystem_path(package_id) do
+    if AgentJido.Ecosystem.get_public_package(package_id) do
+      "/ecosystem/#{package_id}"
+    else
+      nil
+    end
+  end
+
+  defp title_for(_id, :router), do: "Jido Skill Router"
+
+  defp title_for("llm-db", :package), do: "LLM DB"
+  defp title_for("req-llm", :package), do: "Req LLM"
+
+  defp title_for(id, :package) do
+    id
+    |> String.split("-")
+    |> Enum.map_join(" ", &String.capitalize/1)
+  end
+
+  defp relative_to_cwd(path), do: Path.relative_to(path, Application.app_dir(:agent_jido))
+end

--- a/lib/agent_jido_web/components/jido/nav.ex
+++ b/lib/agent_jido_web/components/jido/nav.ex
@@ -12,6 +12,7 @@ defmodule AgentJidoWeb.Jido.Nav do
 
   @primary_nav_links [
     {"Features", "/features"},
+    {"Skills", "/skills"},
     {"Ecosystem", "/ecosystem"},
     {"Examples", "/examples"},
     {"Community", "/community"},
@@ -65,6 +66,7 @@ defmodule AgentJidoWeb.Jido.Nav do
   def footer_resource_links do
     [
       {"Docs", primary_nav_path!("Docs")},
+      {"Skills", primary_nav_path!("Skills")},
       {"Examples", primary_nav_path!("Examples")},
       {"Compare", "/compare"}
     ]

--- a/lib/agent_jido_web/controllers/llms_txt_controller.ex
+++ b/lib/agent_jido_web/controllers/llms_txt_controller.ex
@@ -19,6 +19,7 @@ defmodule AgentJidoWeb.LLMSTxtController do
       - /docs*
       - /blog*
       - /ecosystem*
+      - /skills
       - /features*
       - /build*
       - /community*
@@ -31,6 +32,7 @@ defmodule AgentJidoWeb.LLMSTxtController do
     - Docs: #{endpoint_url}/docs
     - Blog: #{endpoint_url}/blog
     - Ecosystem: #{endpoint_url}/ecosystem
+    - Skills: #{endpoint_url}/skills
     - Features: #{endpoint_url}/features
     - Build: #{endpoint_url}/build
     - Community: #{endpoint_url}/community

--- a/lib/agent_jido_web/controllers/sitemap_html/index.xml.eex
+++ b/lib/agent_jido_web/controllers/sitemap_html/index.xml.eex
@@ -15,6 +15,11 @@
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
+  <url>
+    <loc><%= AgentJidoWeb.Endpoint.url() %>/skills</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.65</priority>
+  </url>
   <%= for pkg <- @ecosystem_packages do %>
   <url>
     <loc><%= AgentJidoWeb.Endpoint.url() %>/ecosystem/<%= pkg.id %></loc>

--- a/lib/agent_jido_web/live/jido_skills_live.ex
+++ b/lib/agent_jido_web/live/jido_skills_live.ex
@@ -1,0 +1,222 @@
+defmodule AgentJidoWeb.JidoSkillsLive do
+  @moduledoc """
+  Standalone catalog page for the vendored upstream Jido package skills.
+  """
+
+  use AgentJidoWeb, :live_view
+
+  alias AgentJido.UpstreamSkillCatalog
+
+  import AgentJidoWeb.Jido.MarketingLayouts
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {:ok,
+     assign(socket,
+       page_title: "Jido Skills Catalog",
+       meta_description: "Browse the vendored upstream Jido package skills catalog, including package-focused skills and the router skill.",
+       entries: UpstreamSkillCatalog.all_entries(),
+       package_entries: UpstreamSkillCatalog.package_entries(),
+       router_entries: UpstreamSkillCatalog.router_entries(),
+       skills_root_source_path: UpstreamSkillCatalog.skills_root_source_path(),
+       source_prompt_source_path: UpstreamSkillCatalog.source_prompt_source_path(),
+       readme_source_path: UpstreamSkillCatalog.readme_source_path(),
+       repo_url: UpstreamSkillCatalog.repo_url(),
+       total_count: UpstreamSkillCatalog.count(),
+       package_count: UpstreamSkillCatalog.package_count(),
+       router_count: UpstreamSkillCatalog.router_count(),
+       support_file_count: UpstreamSkillCatalog.support_file_count()
+     )}
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <.marketing_layout
+      current_path="/skills"
+      current_scope={@current_scope}
+      analytics_identity={@analytics_identity}
+    >
+      <div class="container max-w-[1040px] mx-auto px-6 py-12">
+        <section class="mb-14">
+          <div class="inline-block px-4 py-2 rounded mb-5 bg-primary/10 border border-primary/30">
+            <span class="text-primary text-[11px] font-semibold tracking-widest uppercase">
+              JIDO SKILLS CATALOG
+            </span>
+          </div>
+
+          <h1 class="text-4xl font-bold mb-4 tracking-tight">
+            Vendored package skills for the Jido ecosystem
+          </h1>
+          <p class="copy-measure-wide text-sm leading-relaxed text-secondary-foreground mb-8">
+            This page lists the upstream package-oriented skills copied from <a
+              href={@repo_url}
+              target="_blank"
+              rel="noopener noreferrer"
+              class="text-primary hover:opacity-80 transition-opacity"
+            >arrowcircle/jido-skills</a>.
+            They complement the workbench-first builder skills we added in the runtime foundations demo by covering package boundaries directly.
+          </p>
+
+          <div class="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+            <div class="rounded-md border border-border bg-elevated p-4">
+              <div class="text-[10px] uppercase tracking-wider text-muted-foreground">Total Skills</div>
+              <div class="mt-2 text-2xl font-bold text-foreground">{@total_count}</div>
+            </div>
+            <div class="rounded-md border border-border bg-elevated p-4">
+              <div class="text-[10px] uppercase tracking-wider text-muted-foreground">Package Skills</div>
+              <div class="mt-2 text-2xl font-bold text-foreground">{@package_count}</div>
+            </div>
+            <div class="rounded-md border border-border bg-elevated p-4">
+              <div class="text-[10px] uppercase tracking-wider text-muted-foreground">Router Skills</div>
+              <div class="mt-2 text-2xl font-bold text-foreground">{@router_count}</div>
+            </div>
+            <div class="rounded-md border border-border bg-elevated p-4">
+              <div class="text-[10px] uppercase tracking-wider text-muted-foreground">Support Files</div>
+              <div class="mt-2 text-2xl font-bold text-foreground">{@support_file_count}</div>
+            </div>
+          </div>
+        </section>
+
+        <section class="grid gap-5 xl:grid-cols-[1.05fr_0.95fr] mb-14">
+          <article class="rounded-lg border border-border bg-card p-6">
+            <div class="text-[10px] uppercase tracking-wider text-muted-foreground mb-3">How To Load The Catalog</div>
+            <p class="text-sm text-secondary-foreground leading-relaxed mb-4">
+              The copied skills live under a dedicated local root so they can be loaded without mixing them into the builder skill catalog.
+            </p>
+            <pre
+              class="rounded-md border border-border bg-elevated p-4 text-[11px] whitespace-pre-wrap font-mono text-foreground"
+              id="skills-load-snippet"
+            ><%= "Jido.AI.Skill.Registry.load_from_paths([\"#{@skills_root_source_path}\"])" %></pre>
+            <div class="mt-4 text-[11px] text-muted-foreground space-y-1">
+              <div>local readme: {@readme_source_path}</div>
+              <div>generation prompt: {@source_prompt_source_path}</div>
+            </div>
+          </article>
+
+          <article class="rounded-lg border border-border bg-card p-6">
+            <div class="text-[10px] uppercase tracking-wider text-muted-foreground mb-3">How This Fits With The Existing Builder Skills</div>
+            <div class="space-y-3 text-sm text-secondary-foreground leading-relaxed">
+              <p>
+                These upstream skills are package-first. They help Codex or other skill-aware runtimes anchor work to a specific Jido package such as `jido-action`, `req-llm`, or `jido-browser`.
+              </p>
+              <p>
+                The workbench builder skills remain workflow-first. They focus on contributor jobs like scaffolding actions, authoring ecosystem pages, and outlining truthful examples.
+              </p>
+              <div class="flex flex-wrap gap-3 pt-2">
+                <.link
+                  navigate="/examples/jido-ai-skills-runtime-foundations?tab=demo"
+                  class="text-xs font-semibold px-3 py-2 rounded border border-primary/30 bg-primary/10 text-primary hover:bg-primary/15 transition-colors"
+                >
+                  Open Builder Skills Demo
+                </.link>
+                <a
+                  href={@repo_url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="text-xs font-semibold px-3 py-2 rounded border border-border text-muted-foreground hover:text-foreground hover:border-foreground/40 transition-colors"
+                >
+                  View Upstream Repo
+                </a>
+              </div>
+            </div>
+          </article>
+        </section>
+
+        <section :if={@router_entries != []} class="mb-14">
+          <div class="flex items-center justify-between mb-5">
+            <span class="text-sm font-bold tracking-wider uppercase">Router Skill</span>
+            <span class="text-[11px] text-muted-foreground">start here when package boundaries are unclear</span>
+          </div>
+
+          <%= for entry <- @router_entries do %>
+            <article class="rounded-lg border border-primary/30 bg-primary/5 p-6">
+              <div class="flex flex-wrap items-center gap-3 mb-3">
+                <span class="text-[10px] uppercase tracking-wider text-primary font-semibold">Router</span>
+                <span class="text-[10px] text-muted-foreground">{entry.name}</span>
+              </div>
+              <h2 class="text-2xl font-bold text-foreground mb-3">{entry.title}</h2>
+              <p class="text-sm text-secondary-foreground leading-relaxed mb-5">{entry.description}</p>
+
+              <div class="grid gap-4 md:grid-cols-3">
+                <div class="rounded-md border border-border bg-background/70 p-4">
+                  <div class="text-[10px] uppercase tracking-wider text-muted-foreground mb-2">Source Path</div>
+                  <div class="text-[11px] text-foreground break-all">{entry.skill_source_path}</div>
+                </div>
+                <div class="rounded-md border border-border bg-background/70 p-4">
+                  <div class="text-[10px] uppercase tracking-wider text-muted-foreground mb-2">Agent Files</div>
+                  <div class="text-[11px] text-foreground">{length(entry.agent_files)}</div>
+                </div>
+                <div class="rounded-md border border-border bg-background/70 p-4">
+                  <div class="text-[10px] uppercase tracking-wider text-muted-foreground mb-2">Reference Files</div>
+                  <div class="text-[11px] text-foreground">{length(entry.reference_files)}</div>
+                </div>
+              </div>
+
+              <div class="mt-5 flex flex-wrap gap-3">
+                <a
+                  href={entry.upstream_url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="text-xs font-semibold px-3 py-2 rounded border border-primary/30 bg-primary/10 text-primary hover:bg-primary/15 transition-colors"
+                >
+                  Open Upstream Skill
+                </a>
+              </div>
+            </article>
+          <% end %>
+        </section>
+
+        <section>
+          <div class="flex items-center justify-between mb-5">
+            <span class="text-sm font-bold tracking-wider uppercase">Package Skills</span>
+            <span class="text-[11px] text-muted-foreground">package-first skills copied into the local workbench</span>
+          </div>
+
+          <div class="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+            <%= for entry <- @package_entries do %>
+              <article id={"skill-card-#{entry.id}"} class="rounded-lg border border-border bg-card p-5">
+                <div class="flex items-center justify-between gap-3 mb-3">
+                  <div>
+                    <div class="text-[10px] uppercase tracking-wider text-muted-foreground">Package Skill</div>
+                    <h2 class="text-lg font-bold text-foreground">{entry.title}</h2>
+                  </div>
+                  <span class="text-[10px] font-mono text-muted-foreground bg-elevated px-2 py-1 rounded border border-border">
+                    {entry.name}
+                  </span>
+                </div>
+
+                <p class="text-sm text-secondary-foreground leading-relaxed mb-4">{entry.description}</p>
+
+                <div class="space-y-2 text-[11px] text-muted-foreground mb-5">
+                  <div>source: <span class="text-foreground break-all">{entry.skill_source_path}</span></div>
+                  <div>agent files: <span class="text-foreground">{length(entry.agent_files)}</span></div>
+                  <div>reference files: <span class="text-foreground">{length(entry.reference_files)}</span></div>
+                </div>
+
+                <div class="flex flex-wrap gap-2">
+                  <a
+                    href={entry.upstream_url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="text-xs font-semibold px-3 py-2 rounded border border-accent-cyan/30 bg-accent-cyan/10 text-accent-cyan hover:bg-accent-cyan/15 transition-colors"
+                  >
+                    Upstream Skill
+                  </a>
+                  <.link
+                    :if={entry.ecosystem_path}
+                    navigate={entry.ecosystem_path}
+                    class="text-xs font-semibold px-3 py-2 rounded border border-border text-muted-foreground hover:text-foreground hover:border-foreground/40 transition-colors"
+                  >
+                    Ecosystem Page
+                  </.link>
+                </div>
+              </article>
+            <% end %>
+          </div>
+        </section>
+      </div>
+    </.marketing_layout>
+    """
+  end
+end

--- a/lib/agent_jido_web/markdown_content.ex
+++ b/lib/agent_jido_web/markdown_content.ex
@@ -191,6 +191,11 @@ defmodule AgentJidoWeb.MarkdownContent do
     {:fallback, "Jido Features", "Runtime capabilities, orchestration strategies, and ecosystem components for reliable multi-agent systems."}
   end
 
+  defp resolve_misc("/skills") do
+    {:fallback, "Jido Skills Catalog",
+     "Vendored upstream Jido package skills plus the router skill, surfaced as a public catalog page in the workbench."}
+  end
+
   defp resolve_misc(_path), do: nil
 
   defp fallback_markdown(title, absolute_url, summary) do

--- a/lib/agent_jido_web/router.ex
+++ b/lib/agent_jido_web/router.ex
@@ -45,6 +45,7 @@ defmodule AgentJidoWeb.Router do
 
     live_session :public_site, session: {__MODULE__, :examples_live_session, []} do
       live "/", JidoHomeLive, :index
+      live "/skills", JidoSkillsLive, :index
       live "/ecosystem", JidoEcosystemLive, :index
       # Keep static route above /ecosystem/:id so this page never collides with package ids.
       live "/ecosystem/matrix", JidoEcosystemPackageMatrixLive, :index

--- a/priv/skills/arrowcircle-jido-skills/README.md
+++ b/priv/skills/arrowcircle-jido-skills/README.md
@@ -1,0 +1,72 @@
+# Jido Skills
+
+Builder-oriented Codex skills for the Jido ecosystem.
+
+This repository contains a generated catalog of skills for the public Jido ecosystem, plus a router skill that helps choose the right package skill for a task. The current catalog was generated automatically by ChatGPT Codex from public Jido ecosystem material, including Jido docs, HexDocs, `hex.pm`, and related source references, then validated with the local `skill-creator` tooling.
+
+## What Is Included
+
+- 12 package skills for the current Jido ecosystem:
+  - `llm-db`
+  - `req-llm`
+  - `jido-action`
+  - `jido-signal`
+  - `jido`
+  - `jido-browser`
+  - `jido-memory`
+  - `jido-behaviortree`
+  - `ash-jido`
+  - `jido-studio`
+  - `jido-messaging`
+  - `jido-otel`
+- 1 router skill:
+  - `jido-skill-router`
+- 1 generation prompt:
+  - [`source/prompts.md`](source/prompts.md)
+
+## How To Use
+
+If you already know the package boundary, invoke the package skill directly.
+
+Examples:
+
+```text
+Use $jido-action to scaffold a new Jido.Action for sending a webhook.
+Use $req-llm to add streaming support for Anthropic responses.
+Use $ash-jido to expose these Ash actions to a Jido agent.
+```
+
+If you do not know which package skill to start with, use the router skill first.
+
+```text
+Use $jido-skill-router to choose the right Jido ecosystem skills for an Ash-triggered agent workflow.
+Use $jido-skill-router to route this task across Jido memory, signals, and OpenTelemetry.
+```
+
+The router skill will:
+
+- identify the anchor package skill
+- pull in adjacent skills only when the task crosses their boundaries
+- avoid loading the entire ecosystem by default
+
+## Repository Layout
+
+- [`skills`](skills): all generated skills
+- [`skills/jido-skill-router`](skills/jido-skill-router): router skill for package selection and multi-skill handoffs
+- [`skills/jido-skill-router/references/skill-manifest.yaml`](skills/jido-skill-router/references/skill-manifest.yaml): machine-readable manifest for the current skill catalog
+- [`source/prompts.md`](source/prompts.md): generation prompt used to create the package skills
+
+## Notes
+
+- This catalog was generated automatically by ChatGPT Codex.
+- It is grounded in public Jido docs, but some ecosystem packages currently have thinner public documentation than others.
+- When docs are thin, the corresponding skills are intentionally narrow instead of guessing unsupported behavior.
+- Treat this repository as a practical starting point and review package-specific guidance before treating it as authoritative.
+
+## Regenerating
+
+To regenerate or extend the catalog:
+
+1. Update [`source/prompts.md`](source/prompts.md).
+2. Run the prompt through Codex or another compatible agent.
+3. Validate generated `SKILL.md` files with the local `skill-creator` validator.

--- a/priv/skills/arrowcircle-jido-skills/skills/ash-jido/SKILL.md
+++ b/priv/skills/arrowcircle-jido-skills/skills/ash-jido/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: ash-jido
+description: Builder-oriented guidance for the upstream `ash_jido` package. Use when Codex needs to expose Ash actions as Jido actions, wire Ash resources into agent workflows, emit or consume signals around Ash changes, or review boundary decisions between Ash domains and Jido agents.
+---
+
+# Ash Jido
+
+`ash_jido` is the upstream Hex package name.
+
+## Start Here
+
+Use this skill when the task crosses the Ash and Jido boundary.
+
+Good triggers:
+- "Expose these Ash actions to a Jido agent."
+- "Generate Jido actions from an Ash resource."
+- "Trigger an agent from an Ash change."
+- "Review whether this behavior belongs in Ash or in Jido."
+
+Read [references/builder-notes.md](references/builder-notes.md) before implementing when authorization, tenant context, or signal routing is involved.
+
+## Primary Workflows
+
+### Expose Ash actions to Jido
+
+- Start from the Ash action contract and generate only the agent-facing surface you actually need.
+- Preserve Ash domain, actor, and tenant context at the boundary.
+- Keep generated action names clear and stable so signal routes stay readable.
+
+### Trigger agents from Ash changes
+
+- Emit signals after successful Ash actions rather than mixing agent orchestration into the changeset body.
+- Pass only the identifiers and domain facts the agent needs.
+- Keep long-running work in Jido, not in the Ash transaction.
+
+### Turn docs into runnable examples
+
+- Prefer one Ash resource and one Jido agent.
+- Show the extension declaration, generated action, and one signal-driven workflow.
+- Include the required Ash context explicitly in the example.
+
+### Review boundaries
+
+- Keep business data rules and authorization in Ash.
+- Keep long-running orchestration and reactive workflows in Jido.
+- Keep signal contracts in `jido-signal`.
+
+## Build Checklist
+
+- Confirm which Ash actions should be exposed and why.
+- Preserve `domain`, `actor`, and `tenant` context where needed.
+- Keep generated Jido action names and descriptions obvious.
+- Add tests for authorization, domain context, and signal routing.
+
+## Boundaries
+
+- Do not bypass Ash policies or validations in generated agent paths.
+- Do not move domain logic out of Ash just because Jido can call it.
+- Do not let long-running external work execute inside the Ash transaction boundary.

--- a/priv/skills/arrowcircle-jido-skills/skills/ash-jido/agents/openai.yaml
+++ b/priv/skills/arrowcircle-jido-skills/skills/ash-jido/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Ash Jido"
+  short_description: "Expose Ash actions to Jido"
+  default_prompt: "Use $ash-jido to connect Ash resources, actions, and domains to Jido agents or skills."

--- a/priv/skills/arrowcircle-jido-skills/skills/ash-jido/references/builder-notes.md
+++ b/priv/skills/arrowcircle-jido-skills/skills/ash-jido/references/builder-notes.md
@@ -1,0 +1,31 @@
+# Ash Jido Builder Notes
+
+## Use This Reference For
+
+- Exposing Ash actions to Jido without breaking domain boundaries.
+- Preserving Ash context such as domain, actor, and tenant in generated actions.
+- Triggering agents from Ash changes after successful transactions.
+
+## Source Highlights
+
+- `ash_jido` bridges Ash resources with Jido agents and can generate `Jido.Action` modules from Ash actions.
+- The docs show exposing selected actions through an Ash DSL and using those actions in signal routes.
+- The Ash `domain` context is required for generated action execution.
+
+## Implementation Heuristics
+
+- Expose only the actions that make sense for agent use.
+- Keep Ash authorization and validation authoritative.
+- Emit signals after successful domain work instead of folding orchestration into resource actions.
+- Preserve naming clarity between Ash actions and generated Jido actions.
+
+## Narrowing Rules
+
+- If the request is ordinary Ash modeling with no Jido boundary, this is the wrong skill.
+- If the workflow is mostly agent orchestration, pair with `jido`.
+
+## Sources
+
+- https://jido.run/ecosystem
+- https://hexdocs.pm/jido/ash-integration.html
+- https://hex.pm/packages/ash_jido

--- a/priv/skills/arrowcircle-jido-skills/skills/jido-action/SKILL.md
+++ b/priv/skills/arrowcircle-jido-skills/skills/jido-action/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: jido-action
+description: Builder-oriented guidance for the upstream `jido_action` package. Use when Codex needs to scaffold or review `Jido.Action` modules, validate action inputs and outputs, compose actions into agent workflows, or turn action docs into runnable Elixir examples.
+---
+
+# Jido Action
+
+`jido_action` is the upstream Hex package name.
+
+## Start Here
+
+Use this skill when the task is centered on `Jido.Action` as the unit of executable work.
+
+Good triggers:
+- "Create a new `Jido.Action` for this side effect."
+- "Review this action for schema validation or output shape."
+- "Turn the action docs into a runnable example."
+- "Figure out whether this logic belongs in one action or in agent orchestration."
+
+Read [references/builder-notes.md](references/builder-notes.md) before editing when the task involves action contracts, composition, retries, or error boundaries.
+
+## Primary Workflows
+
+### Scaffold an action
+
+- Start from the action's boundary: one job, one clear input contract, one clear result shape.
+- Define parameters and validation up front instead of burying checks in `run/2`.
+- Keep side effects explicit so callers can reason about retries and compensation.
+
+### Extend or refactor an action
+
+- Split oversized actions when they hide orchestration, branching, or unrelated IO.
+- Preserve stable inputs and outputs when improving internals.
+- Prefer composition through other Jido layers over building a giant action with internal state machines.
+
+### Turn docs into runnable examples
+
+- Use realistic params and output values.
+- Show how an action is invoked in isolation before showing how an agent or directive uses it.
+- Include one error path if the action handles validation or external failures.
+
+### Review boundaries
+
+- Keep low-level units of work in `Jido.Action`.
+- Keep routing, branching, and multi-step control flow in `jido` or `jido-behaviortree`.
+- Keep signal schemas in `jido-signal`.
+
+## Build Checklist
+
+- Define the input schema first.
+- Decide whether the action is pure, IO-bound, or adapter-like.
+- Return consistent success and failure shapes.
+- Add focused tests for validation, happy path, and recoverable failure.
+
+## Boundaries
+
+- Do not use one action to represent a whole agent workflow.
+- Do not hide long-lived state inside the action module.
+- Do not mix unrelated side effects just because they happen in one feature.

--- a/priv/skills/arrowcircle-jido-skills/skills/jido-action/agents/openai.yaml
+++ b/priv/skills/arrowcircle-jido-skills/skills/jido-action/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Jido Action"
+  short_description: "Build validated Jido actions"
+  default_prompt: "Use $jido-action to design, scaffold, or review Jido.Action modules and execution flows."

--- a/priv/skills/arrowcircle-jido-skills/skills/jido-action/references/builder-notes.md
+++ b/priv/skills/arrowcircle-jido-skills/skills/jido-action/references/builder-notes.md
@@ -1,0 +1,32 @@
+# Jido Action Builder Notes
+
+## Use This Reference For
+
+- Designing action contracts before writing code.
+- Reviewing whether a module is truly one action or actually orchestration.
+- Mapping action composition to the right higher-level Jido package.
+
+## Source Highlights
+
+- `Jido.Action` is the package's central abstraction for executable units of work.
+- The docs emphasize explicit params, validation, and predictable execution.
+- Builder tasks usually fall into three buckets: new action scaffolds, adapter wrappers, and action reviews.
+
+## Implementation Heuristics
+
+- Keep actions small, typed, and composable.
+- Prefer deterministic outputs that other actions or agents can consume.
+- Push branching, planning, and scheduling up into agent/runtime layers.
+- Name actions after the business operation, not the calling screen or job queue.
+
+## Narrowing Rules
+
+- If the user is really building an agent loop, switch to `jido`.
+- If the main problem is event shape or dispatch, switch to `jido-signal`.
+
+## Sources
+
+- https://jido.run/ecosystem
+- https://hexdocs.pm/jido_action/readme.html
+- https://hex.pm/packages/jido_action
+- https://hexdocs.pm/jido/readme.html

--- a/priv/skills/arrowcircle-jido-skills/skills/jido-behaviortree/SKILL.md
+++ b/priv/skills/arrowcircle-jido-skills/skills/jido-behaviortree/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: jido-behaviortree
+description: Builder-oriented guidance for the upstream `jido_behaviortree` package. Use when Codex needs to model agent decision trees, selectors, sequences, or fallback paths in Jido, or when it needs to turn sparse behavior-tree docs into a concrete runnable example without inventing unsupported runtime features.
+---
+
+# Jido BehaviorTree
+
+`jido_behaviortree` is the upstream Hex package name.
+
+## Start Here
+
+Use this skill when the task is about explicit branching, selectors, sequences, guards, or fallback execution inside a Jido workflow.
+
+Good triggers:
+- "Model this agent logic as a behavior tree."
+- "Add fallback and guard behavior to a Jido agent."
+- "Turn the behavior tree docs into a small working example."
+- "Review whether this branching belongs in a tree or in regular Elixir control flow."
+
+Read [references/builder-notes.md](references/builder-notes.md) before coding because the public docs are thinner here than for the core Jido packages.
+
+## Primary Workflows
+
+### Model a tree deliberately
+
+- Start from the decision points: sequence, selector, guard, retry, or fallback.
+- Map each node to a small action or condition instead of embedding heavy logic in the tree itself.
+- Keep success, failure, and retry semantics explicit.
+
+### Integrate trees into Jido workflows
+
+- Use the tree to express control flow, not business logic internals.
+- Reuse `Jido.Action` modules for leaf work whenever possible.
+- Keep emitted signals or state updates visible at the edges of the tree.
+
+### Turn sparse docs into runnable examples
+
+- Build the smallest tree that demonstrates one branching idea clearly.
+- Explain any inferred behavior as an inference, not a documented guarantee.
+- Prefer examples with one selector and one fallback over a large autonomous demo.
+
+### Review boundaries
+
+- Keep branching semantics in `jido-behaviortree`.
+- Keep agent lifecycle and runtime concerns in `jido`.
+- Keep side-effectful leaf work in `jido-action`.
+
+## Build Checklist
+
+- Define node outcomes before implementing the nodes.
+- Keep guard conditions cheap and deterministic.
+- Make fallback branches observable in logs, signals, or tests.
+- Add tests that exercise each branch, not just the happy path.
+
+## Boundaries
+
+- Do not invent advanced tree node types that the docs do not mention.
+- Do not force every workflow into a tree when plain Elixir branching is clearer.
+- Do not hide IO-heavy work inside guard logic.

--- a/priv/skills/arrowcircle-jido-skills/skills/jido-behaviortree/agents/openai.yaml
+++ b/priv/skills/arrowcircle-jido-skills/skills/jido-behaviortree/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Jido BehaviorTree"
+  short_description: "Build Jido behavior tree flows"
+  default_prompt: "Use $jido-behaviortree to model agent decision trees, selectors, and fallback execution paths."

--- a/priv/skills/arrowcircle-jido-skills/skills/jido-behaviortree/references/builder-notes.md
+++ b/priv/skills/arrowcircle-jido-skills/skills/jido-behaviortree/references/builder-notes.md
@@ -1,0 +1,31 @@
+# Jido BehaviorTree Builder Notes
+
+## Use This Reference For
+
+- Turning branching requirements into explicit tree structures.
+- Keeping documented behavior separate from reasonable inference where docs are thin.
+- Reviewing whether a tree is clearer than normal Elixir control flow.
+
+## Source Highlights
+
+- Public material for this package is thinner than for core Jido packages.
+- The safest builder workflow is to model sequences, selectors, guards, and fallback paths without assuming undocumented node types.
+- The tree should orchestrate actions, not replace them.
+
+## Implementation Heuristics
+
+- Keep trees shallow until the need for deeper composition is obvious.
+- Name nodes by decision intent, not UI labels.
+- Surface branch outcomes through tests or signals.
+- Write examples that make each branch easy to reason about.
+
+## Narrowing Rules
+
+- If a behavior depends on undocumented runtime hooks, treat it as unsupported.
+- If plain Elixir branching is simpler and equally observable, prefer it.
+
+## Sources
+
+- https://jido.run/ecosystem
+- https://hexdocs.pm/jido/readme.html
+- https://github.com/agentjido/jido_run/issues/51

--- a/priv/skills/arrowcircle-jido-skills/skills/jido-browser/SKILL.md
+++ b/priv/skills/arrowcircle-jido-skills/skills/jido-browser/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: jido-browser
+description: Builder-oriented guidance for the upstream `jido_browser` package. Use when Codex needs to build browser-backed Jido automations, wrap navigation or extraction flows in actions, turn browser docs into runnable examples, or review `jido_browser` boundaries versus `req_llm` and app-specific scraping code.
+---
+
+# Jido Browser
+
+`jido_browser` is the upstream Hex package name.
+
+## Start Here
+
+Use this skill when the workflow needs a browser, page state, or DOM interaction rather than plain HTTP requests.
+
+Good triggers:
+- "Build a Jido agent that logs in and gathers data from a website."
+- "Wrap a browser step in a `Jido.Action`."
+- "Turn the browser package docs into a runnable demo."
+- "Review whether this should use browser automation or a simpler HTTP client."
+
+Read [references/builder-notes.md](references/builder-notes.md) before implementing when selectors, navigation state, or safety limits matter.
+
+## Primary Workflows
+
+### Build browser-backed actions
+
+- Separate navigation, observation, and mutation steps.
+- Keep selectors and site assumptions explicit so the action can fail predictably when a page changes.
+- Prefer small page operations over giant "do everything" browser actions.
+
+### Decide when browser automation is justified
+
+- Use `jido_browser` only when the target behavior depends on rendering, authentication state, or DOM interaction.
+- Prefer `req_llm`, Req, or API clients for stable JSON or HTML endpoints.
+- Minimize the amount of browser state that leaks into the rest of the agent runtime.
+
+### Turn docs into runnable examples
+
+- Choose one real browsing scenario such as login, extract, click, or form submit.
+- Show the browser step inside a broader Jido workflow only after the page-level behavior is clear.
+- Add waits, retries, or assertions only when the docs justify them.
+
+### Review boundaries
+
+- Keep DOM and navigation logic in `jido_browser`.
+- Keep prompt or reasoning loops in `jido` or `jido_ai`.
+- Keep site-specific product logic in the application layer.
+
+## Build Checklist
+
+- Confirm that the target site really requires browser automation.
+- Define selectors, navigation transitions, and failure conditions up front.
+- Capture only the page data the next step needs.
+- Add tests or examples that tolerate timing and rendering variability.
+
+## Boundaries
+
+- Do not use this skill for generic web scraping when plain HTTP is enough.
+- Do not hide brittle selectors inside unrelated business logic.
+- Do not promise support for site behaviors the docs do not cover.

--- a/priv/skills/arrowcircle-jido-skills/skills/jido-browser/agents/openai.yaml
+++ b/priv/skills/arrowcircle-jido-skills/skills/jido-browser/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Jido Browser"
+  short_description: "Build Jido browser automation"
+  default_prompt: "Use $jido-browser to build browser-backed Jido automations, actions, and agent workflows."

--- a/priv/skills/arrowcircle-jido-skills/skills/jido-browser/references/builder-notes.md
+++ b/priv/skills/arrowcircle-jido-skills/skills/jido-browser/references/builder-notes.md
@@ -1,0 +1,31 @@
+# Jido Browser Builder Notes
+
+## Use This Reference For
+
+- Deciding whether browser automation is the right tool.
+- Splitting page work into navigation, observation, and mutation steps.
+- Keeping browser workflows small enough to test and debug.
+
+## Source Highlights
+
+- The package is positioned as browser-use inspired AI browser automation for Elixir.
+- The builder value is controlled browser interaction inside Jido workflows, not generic scraping advice.
+- Browser state is usually the brittle part of the system, so the skill should keep that boundary obvious.
+
+## Implementation Heuristics
+
+- Prefer one page objective per action.
+- Treat selectors and waits as explicit assumptions.
+- Keep browser setup and teardown outside the business logic when possible.
+- Escalate to application-specific code when a site workflow is highly bespoke.
+
+## Narrowing Rules
+
+- If a plain HTTP request or API call can solve the task, do not use browser automation.
+- If the docs do not document a browser capability, avoid claiming it is supported.
+
+## Sources
+
+- https://jido.run/ecosystem
+- https://hexdocs.pm/jido_browser/readme.html
+- https://hex.pm/packages/jido_browser

--- a/priv/skills/arrowcircle-jido-skills/skills/jido-memory/SKILL.md
+++ b/priv/skills/arrowcircle-jido-skills/skills/jido-memory/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: jido-memory
+description: Builder-oriented guidance for the upstream `jido_memory` package. Use when Codex needs to add memory spaces, retrieval flows, summarization or recall hooks, or review memory boundaries in Jido applications that also use `jido`, `jido_ai`, and external storage backends.
+---
+
+# Jido Memory
+
+`jido_memory` is the upstream Hex package name.
+
+## Start Here
+
+Use this skill when an agent needs to remember, recall, summarize, or retrieve prior context over time.
+
+Good triggers:
+- "Add memory to this Jido agent."
+- "Choose how to store and recall prior interactions."
+- "Turn the memory docs into a runnable example."
+- "Review whether this memory behavior belongs in the agent loop or in storage infrastructure."
+
+Read [references/builder-notes.md](references/builder-notes.md) before implementing when the task touches memory scope, retrieval strategy, or external storage boundaries.
+
+## Primary Workflows
+
+### Add memory to an agent
+
+- Decide what should be remembered: conversation turns, tool results, summaries, domain facts, or episodic traces.
+- Define when writes happen and when reads happen before wiring storage.
+- Keep the agent interface small: ask for the minimum memory the next action needs.
+
+### Choose retrieval and persistence boundaries
+
+- Separate memory policy from the storage backend.
+- Keep embeddings, vector search, or persistence adapters behind explicit interfaces.
+- Use `jido_ai` docs only as conceptual support for AI-facing memory behavior; keep package-specific implementation grounded in `jido_memory`.
+
+### Turn docs into runnable examples
+
+- Show one write path, one retrieval path, and one agent behavior that changes because memory exists.
+- Keep the example local and inspectable rather than hiding memory inside a black-box agent.
+- Include one stale-data or missing-memory branch when it matters.
+
+### Review boundaries
+
+- Keep memory semantics in `jido_memory`.
+- Keep agent state machines in `jido`.
+- Keep storage engine concerns in the backend adapter or application layer.
+
+## Build Checklist
+
+- Define what is stored, when it expires, and who can read it.
+- Choose recall criteria before choosing a backend.
+- Keep retrieval payloads small and explainable.
+- Add tests for cold start, duplicate writes, and missing recall results.
+
+## Boundaries
+
+- Do not use this skill for generic database modeling unrelated to agent memory.
+- Do not mix durable domain records with ephemeral agent memory without a clear contract.
+- Do not promise retrieval quality that the chosen backend or docs do not support.

--- a/priv/skills/arrowcircle-jido-skills/skills/jido-memory/agents/openai.yaml
+++ b/priv/skills/arrowcircle-jido-skills/skills/jido-memory/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Jido Memory"
+  short_description: "Build Jido memory workflows"
+  default_prompt: "Use $jido-memory to add memory spaces, recall flows, and memory-aware agents to a Jido app."

--- a/priv/skills/arrowcircle-jido-skills/skills/jido-memory/references/builder-notes.md
+++ b/priv/skills/arrowcircle-jido-skills/skills/jido-memory/references/builder-notes.md
@@ -1,0 +1,31 @@
+# Jido Memory Builder Notes
+
+## Use This Reference For
+
+- Choosing what an agent should remember and why.
+- Separating memory policy from storage backend details.
+- Building examples where memory changes agent behavior in an observable way.
+
+## Source Highlights
+
+- The ecosystem positions memory as a distinct concern instead of hiding it in agent state alone.
+- Memory workflows depend on clear write/read timing and scope.
+- `jido_ai` can inform AI-facing memory behavior, but storage and recall boundaries must stay explicit.
+
+## Implementation Heuristics
+
+- Store only the data a later step can actually use.
+- Prefer explicit memory scopes such as run, conversation, or long-lived knowledge.
+- Keep recall criteria deterministic enough to test.
+- Treat summarization or embedding steps as separate concerns from persistence.
+
+## Narrowing Rules
+
+- If the task is generic persistence with no agent recall behavior, this is the wrong skill.
+- If the chosen backend imposes limits the docs do not cover, document the assumption instead of inventing features.
+
+## Sources
+
+- https://jido.run/ecosystem
+- https://hexdocs.pm/jido/readme.html
+- https://hexdocs.pm/jido_ai/readme.html

--- a/priv/skills/arrowcircle-jido-skills/skills/jido-messaging/SKILL.md
+++ b/priv/skills/arrowcircle-jido-skills/skills/jido-messaging/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: jido-messaging
+description: Builder-oriented guidance for the upstream `jido_messaging` package. Use when Codex needs to plan or review messaging adapters, bridge Jido signals onto external transports, or keep delivery semantics, retries, and routing boundaries explicit for Jido-based systems.
+---
+
+# Jido Messaging
+
+`jido_messaging` is the upstream Hex package name.
+
+## Start Here
+
+Use this skill when the task is about moving Jido signals across external transports such as queues, brokers, or pub/sub systems.
+
+Good triggers:
+- "Bridge Jido signals onto a message bus."
+- "Design a messaging adapter for this Jido app."
+- "Review delivery semantics and retries for external dispatch."
+- "Figure out whether this logic belongs in `jido_messaging` or `jido_signal`."
+
+Public docs for this package are thin. Require a concrete target transport or integration before getting specific, and keep any unsupported transport behavior explicit as an assumption.
+
+## Primary Workflows
+
+### Design an adapter boundary
+
+- Start from the signal contract, then map it onto transport topics, subjects, or queues.
+- Keep serialization, headers, and correlation ids explicit.
+- Separate transport delivery from core signal creation and validation.
+
+### Define delivery semantics
+
+- Decide whether the workflow needs at-most-once, at-least-once, ordering, or replay guarantees.
+- Keep retry and dead-letter behavior in the adapter boundary, not in the signal schema.
+- Surface ack or failure information in a way the application can observe.
+
+### Review package boundaries
+
+- Keep signal definitions in `jido-signal`.
+- Keep transport adapters and delivery concerns in `jido-messaging`.
+- Keep domain-specific message handling in the application layer.
+
+## Build Checklist
+
+- Identify the transport first.
+- Define serialization and routing keys before coding.
+- Make correlation and retry behavior observable.
+- Add tests for invalid payloads, redelivery, and missing consumers.
+
+## Boundaries
+
+- Do not invent support for a broker or transport that the docs do not mention.
+- Do not collapse signal schema and transport wiring into one module.
+- Do not hide delivery guarantees or failure modes from callers.

--- a/priv/skills/arrowcircle-jido-skills/skills/jido-messaging/agents/openai.yaml
+++ b/priv/skills/arrowcircle-jido-skills/skills/jido-messaging/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Jido Messaging"
+  short_description: "Plan Jido messaging adapters"
+  default_prompt: "Use $jido-messaging to design messaging adapters, buses, and delivery boundaries for Jido systems."

--- a/priv/skills/arrowcircle-jido-skills/skills/jido-otel/SKILL.md
+++ b/priv/skills/arrowcircle-jido-skills/skills/jido-otel/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: jido-otel
+description: Builder-oriented guidance for the upstream `jido_otel` package. Use when Codex needs to add OpenTelemetry tracing to Jido applications, implement a tracer backend for Jido observability hooks, or review how spans, correlation ids, and exported telemetry should cross package boundaries.
+---
+
+# Jido OpenTelemetry
+
+`jido_otel` is the upstream Hex package name.
+
+## Start Here
+
+Use this skill when the task is about tracing, spans, correlation ids, or wiring Jido observability into an OpenTelemetry pipeline.
+
+Good triggers:
+- "Add OpenTelemetry tracing to this Jido app."
+- "Implement the Jido tracer backend."
+- "Review which spans and attributes this workflow should emit."
+- "Turn the observability docs into a working tracer example."
+
+Read [references/builder-notes.md](references/builder-notes.md) before coding when the task touches `Jido.Observe`, `Jido.Observe.Tracer`, or exporter configuration.
+
+## Primary Workflows
+
+### Implement tracing cleanly
+
+- Start from the Jido observability hooks and span lifecycle instead of instrumenting random call sites.
+- Keep tracer code focused on translating Jido metadata into OpenTelemetry spans and events.
+- Preserve correlation ids and causation metadata when the docs expose them.
+
+### Configure exporters and runtime behavior
+
+- Separate tracer implementation from exporter configuration.
+- Keep production configuration explicit: endpoint, batching, redaction, and log level.
+- Prefer safe defaults that do not break core Jido behavior when tracing is unavailable.
+
+### Turn docs into runnable examples
+
+- Show one action or agent workflow producing spans.
+- Include the Jido tracer configuration and one exporter setup.
+- Keep examples small enough to inspect trace structure by hand.
+
+### Review boundaries
+
+- Keep the observability facade in `jido`.
+- Keep OpenTelemetry-specific integration in `jido-otel`.
+- Keep product-specific dashboards and alerting in the application layer.
+
+## Build Checklist
+
+- Confirm which Jido events should create spans.
+- Propagate correlation metadata consistently.
+- Decide what must be redacted before exporting.
+- Add tests or examples for success, exception, and missing-exporter paths.
+
+## Boundaries
+
+- Do not add direct OpenTelemetry dependencies to core `jido` behavior that the docs intentionally keep separate.
+- Do not emit high-cardinality attributes without a clear need.
+- Do not assume metrics or logs behavior beyond what the tracer integration documents.

--- a/priv/skills/arrowcircle-jido-skills/skills/jido-otel/agents/openai.yaml
+++ b/priv/skills/arrowcircle-jido-skills/skills/jido-otel/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Jido OpenTelemetry"
+  short_description: "Instrument Jido with OpenTelemetry"
+  default_prompt: "Use $jido-otel to add traces, events, and observability boundaries to a Jido application."

--- a/priv/skills/arrowcircle-jido-skills/skills/jido-otel/references/builder-notes.md
+++ b/priv/skills/arrowcircle-jido-skills/skills/jido-otel/references/builder-notes.md
@@ -1,0 +1,32 @@
+# Jido OpenTelemetry Builder Notes
+
+## Use This Reference For
+
+- Mapping Jido observability hooks onto OpenTelemetry spans.
+- Keeping exporter configuration separate from the tracer implementation.
+- Reviewing which metadata should become attributes or events.
+
+## Source Highlights
+
+- Core `jido` exposes `Jido.Observe` and `Jido.Observe.Tracer` while intentionally staying free of direct OpenTelemetry dependencies.
+- The observability docs explicitly describe a separate `jido_otel` package as the concrete tracer integration point.
+- Correlation fields such as trace id, span id, parent span id, and causation id are already part of the Jido observability model.
+
+## Implementation Heuristics
+
+- Instrument documented lifecycle hooks first.
+- Treat exception spans and redaction settings as first-class concerns.
+- Keep exporter setup in config, not embedded in tracing logic.
+- Favor stable attribute names over ad hoc metadata dumping.
+
+## Narrowing Rules
+
+- If the task is general dashboarding or alerting, this skill is too low-level.
+- If the task changes core Jido observability APIs, verify the docs before proposing it.
+
+## Sources
+
+- https://jido.run/ecosystem
+- https://hexdocs.pm/jido/observability.html
+- https://hexdocs.pm/jido/Jido.Observe.html
+- https://hexdocs.pm/jido/Jido.Observe.Tracer.html

--- a/priv/skills/arrowcircle-jido-skills/skills/jido-signal/SKILL.md
+++ b/priv/skills/arrowcircle-jido-skills/skills/jido-signal/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: jido-signal
+description: Builder-oriented guidance for the upstream `jido_signal` package. Use when Codex needs to define signal schemas, route or dispatch events, bridge Jido signals to buses or transports, or review `jido_signal` boundaries versus `jido`, `jido_messaging`, and application code.
+---
+
+# Jido Signal
+
+`jido_signal` is the upstream Hex package name.
+
+## Start Here
+
+Use this skill when the task is about signal structure, validation, dispatch, or event boundaries.
+
+Good triggers:
+- "Define the signal shape for this workflow."
+- "Bridge agent events onto PubSub, webhooks, or another bus."
+- "Turn the signal docs into a runnable example."
+- "Review whether this event contract belongs in `jido_signal` or in app code."
+
+Read [references/builder-notes.md](references/builder-notes.md) before implementing when the task touches CloudEvents-like structure, signal versioning, or external delivery boundaries.
+
+## Primary Workflows
+
+### Define signal contracts
+
+- Start with event intent: what happened, who emitted it, and what downstream consumers must rely on.
+- Keep the public signal shape stable even if internal producers change.
+- Prefer explicit type, source, subject, and data conventions over loose maps.
+
+### Build routing and dispatch flows
+
+- Separate signal creation from transport delivery.
+- Keep signal validation close to the producer boundary.
+- Translate into PubSub, queues, or webhooks in adapter code, not in the signal definition itself.
+
+### Turn docs into runnable examples
+
+- Show one producer, one signal payload, and one consumer.
+- Include serialization or validation only when it changes the design.
+- Demonstrate failure handling for malformed or missing fields when that is central to the example.
+
+### Review boundaries
+
+- Keep event contracts and signaling semantics in `jido_signal`.
+- Keep transport-specific adapters in `jido-messaging` or app code.
+- Keep agent planning and execution control in `jido`.
+
+## Build Checklist
+
+- Name the event in domain language.
+- Define the minimum stable payload.
+- Choose versioning or compatibility rules before publishing widely.
+- Test serialization, validation, and consumer expectations.
+
+## Boundaries
+
+- Do not use this skill to design an entire broker stack.
+- Do not overload one signal type with unrelated payload shapes.
+- Do not let consumer-specific fields leak back into the core signal contract.

--- a/priv/skills/arrowcircle-jido-skills/skills/jido-signal/agents/openai.yaml
+++ b/priv/skills/arrowcircle-jido-skills/skills/jido-signal/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Jido Signal"
+  short_description: "Build typed signal workflows"
+  default_prompt: "Use $jido-signal to design signal schemas, routing, buses, and dispatch workflows."

--- a/priv/skills/arrowcircle-jido-skills/skills/jido-signal/references/builder-notes.md
+++ b/priv/skills/arrowcircle-jido-skills/skills/jido-signal/references/builder-notes.md
@@ -1,0 +1,32 @@
+# Jido Signal Builder Notes
+
+## Use This Reference For
+
+- Designing signal contracts before choosing a transport.
+- Reviewing producer and consumer boundaries.
+- Translating docs into practical event flow examples.
+
+## Source Highlights
+
+- The package emphasizes simple, safe, standard signal handling in Elixir.
+- The docs position signals as structured events rather than generic message maps.
+- A builder workflow usually starts with signal shape, then dispatch, then transport adapters.
+
+## Implementation Heuristics
+
+- Treat signals as contracts, not logging blobs.
+- Keep compatibility rules visible when multiple consumers exist.
+- Prefer a small number of meaningful event types over dozens of near-duplicates.
+- Separate dispatch concerns from business logic whenever possible.
+
+## Narrowing Rules
+
+- If the task is about queues, brokers, or external transports, pair with `jido-messaging`.
+- If the task is about agent control flow instead of events, switch to `jido`.
+
+## Sources
+
+- https://jido.run/ecosystem
+- https://hexdocs.pm/jido_signal/readme.html
+- https://hex.pm/packages/jido_signal
+- https://hexdocs.pm/jido/readme.html

--- a/priv/skills/arrowcircle-jido-skills/skills/jido-skill-router/SKILL.md
+++ b/priv/skills/arrowcircle-jido-skills/skills/jido-skill-router/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: jido-skill-router
+description: Meta-skill for routing Jido ecosystem work to the right package skills. Use when Codex needs to choose between $jido, $jido-action, $jido-signal, $req-llm, $llm-db, $ash-jido, $jido-browser, $jido-memory, $jido-behaviortree, $jido-messaging, $jido-otel, or $jido-studio, or when a task spans several of them and needs a handoff order.
+---
+
+# Jido Skill Router
+
+Use this skill as the entry point when the correct Jido package skill is unclear or when the work crosses package boundaries.
+
+Read [references/skill-manifest.yaml](references/skill-manifest.yaml) when the task needs a full routing map, related-skill lookup, or a machine-readable inventory of the current catalog.
+
+## Routing Workflow
+
+1. Identify the anchor concern first.
+2. Load only the anchor skill.
+3. Add one adjacent skill when the task crosses its boundary.
+4. Keep each handoff explicit in the work plan or response.
+5. If the docs are thin, narrow the scope and call out the gap instead of inventing behavior.
+
+## Anchor Skill Selection
+
+- Use `$jido` for agents, directives, runtime loops, and cross-package orchestration.
+- Use `$jido-action` for executable units of work, action schemas, and action reviews.
+- Use `$jido-signal` for signal contracts, event structure, and dispatch semantics.
+- Use `$llm-db` for model catalogs, provider metadata, and capability or price-based model selection.
+- Use `$req-llm` for provider calls, request shaping, streaming, and response normalization.
+- Use `$jido-browser` for browser-backed automation and DOM-dependent workflows.
+- Use `$jido-memory` for recall, summarization, retrieval, and memory policy.
+- Use `$jido-behaviortree` for selectors, sequences, fallback paths, and explicit branching.
+- Use `$ash-jido` for Ash-to-Jido boundaries, generated actions, and domain-context propagation.
+- Use `$jido-studio` for operator tooling, workbench pages, and ecosystem demos.
+- Use `$jido-messaging` for external transport adapters, delivery semantics, and broker boundaries.
+- Use `$jido-otel` for tracing, spans, observability hooks, and OpenTelemetry integration.
+
+## Common Handoffs
+
+- `$llm-db -> $req-llm -> $jido` for model-routed AI workflows.
+- `$jido-action -> $jido -> $jido-signal` for action-driven agent flows.
+- `$ash-jido -> $jido-action -> $jido -> $jido-signal` for Ash-triggered agents.
+- `$jido-browser -> $jido-action -> $jido` for browser agents.
+- `$jido-signal -> $jido-messaging` for external transport delivery.
+- `$jido -> $jido-otel` for runtime observability.
+- `$jido -> $jido-memory` when the workflow needs long-lived recall.
+- `$jido -> $jido-behaviortree` when branching logic becomes a first-class concern.
+
+## Boundaries
+
+- Do not load all Jido skills by default.
+- Do not replace package-specific guidance with generic router text; hand off to the package skill.
+- Do not invent cross-package integrations that the package docs do not support.
+- Do not use this skill when one package skill already owns the task clearly.

--- a/priv/skills/arrowcircle-jido-skills/skills/jido-skill-router/agents/openai.yaml
+++ b/priv/skills/arrowcircle-jido-skills/skills/jido-skill-router/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Jido Skill Router"
+  short_description: "Route tasks across Jido skills"
+  default_prompt: "Use $jido-skill-router to choose and sequence the right Jido ecosystem skills for this task."

--- a/priv/skills/arrowcircle-jido-skills/skills/jido-skill-router/references/skill-manifest.yaml
+++ b/priv/skills/arrowcircle-jido-skills/skills/jido-skill-router/references/skill-manifest.yaml
@@ -1,0 +1,178 @@
+version: 1
+group: jido-ecosystem
+router_skill: jido-skill-router
+shared_references:
+  - https://jido.run/ecosystem
+  - https://hexdocs.pm/jido/readme.html
+  - https://hexdocs.pm/jido_ai/readme.html
+  - https://github.com/agentjido/jido_run/issues/51
+skills:
+  - skill: jido
+    upstream_package: jido
+    role: core runtime and orchestration
+    use_when:
+      - agents
+      - directives
+      - runtime loops
+      - cross-package composition
+    related_skills:
+      - jido-action
+      - jido-signal
+      - jido-memory
+      - jido-behaviortree
+      - req-llm
+      - llm-db
+      - ash-jido
+      - jido-otel
+  - skill: jido-action
+    upstream_package: jido_action
+    role: executable units of work
+    use_when:
+      - action scaffolding
+      - action validation
+      - action refactors
+    related_skills:
+      - jido
+      - jido-signal
+      - ash-jido
+  - skill: jido-signal
+    upstream_package: jido_signal
+    role: signal contracts and dispatch
+    use_when:
+      - event schemas
+      - signal validation
+      - routing semantics
+    related_skills:
+      - jido
+      - jido-messaging
+      - jido-action
+  - skill: llm-db
+    upstream_package: llm_db
+    role: model and provider catalog selection
+    use_when:
+      - model catalogs
+      - provider metadata
+      - capability filtering
+      - price-aware routing
+    related_skills:
+      - req-llm
+      - jido
+  - skill: req-llm
+    upstream_package: req_llm
+    role: provider transport and LLM request execution
+    use_when:
+      - provider adapters
+      - request shaping
+      - streaming
+      - structured output transport
+    related_skills:
+      - llm-db
+      - jido
+  - skill: jido-browser
+    upstream_package: jido_browser
+    role: browser-backed automation
+    use_when:
+      - DOM interaction
+      - rendered-page automation
+      - authenticated browser flows
+    related_skills:
+      - jido-action
+      - jido
+  - skill: jido-memory
+    upstream_package: jido_memory
+    role: memory policy and recall
+    use_when:
+      - episodic memory
+      - long-lived recall
+      - retrieval flows
+      - memory-aware agents
+    related_skills:
+      - jido
+      - req-llm
+  - skill: jido-behaviortree
+    upstream_package: jido_behaviortree
+    role: explicit branching and fallback trees
+    use_when:
+      - selectors
+      - sequences
+      - fallback logic
+      - guard-driven branching
+    related_skills:
+      - jido
+      - jido-action
+  - skill: ash-jido
+    upstream_package: ash_jido
+    role: Ash and Jido boundary integration
+    use_when:
+      - Ash action exposure
+      - generated Jido actions
+      - domain-context propagation
+      - Ash-triggered agents
+    related_skills:
+      - jido
+      - jido-action
+      - jido-signal
+  - skill: jido-studio
+    upstream_package: jido_studio
+    role: operator tooling and ecosystem demos
+    use_when:
+      - workbench pages
+      - operator surfaces
+      - package demos
+      - ecosystem presentation
+    related_skills:
+      - jido
+      - ash-jido
+      - jido-otel
+  - skill: jido-messaging
+    upstream_package: jido_messaging
+    role: external transport adapters
+    use_when:
+      - broker integration
+      - delivery semantics
+      - queue or pubsub adapters
+    related_skills:
+      - jido-signal
+      - jido
+  - skill: jido-otel
+    upstream_package: jido_otel
+    role: OpenTelemetry tracing integration
+    use_when:
+      - spans
+      - trace correlation
+      - tracer backends
+      - observability hooks
+    related_skills:
+      - jido
+      - jido-action
+      - jido-signal
+common_flows:
+  - name: model-routed-ai-workflow
+    sequence:
+      - llm-db
+      - req-llm
+      - jido
+  - name: action-driven-agent
+    sequence:
+      - jido-action
+      - jido
+      - jido-signal
+  - name: ash-triggered-agent
+    sequence:
+      - ash-jido
+      - jido-action
+      - jido
+      - jido-signal
+  - name: browser-agent
+    sequence:
+      - jido-browser
+      - jido-action
+      - jido
+  - name: observable-runtime
+    sequence:
+      - jido
+      - jido-otel
+  - name: external-event-delivery
+    sequence:
+      - jido-signal
+      - jido-messaging

--- a/priv/skills/arrowcircle-jido-skills/skills/jido-studio/SKILL.md
+++ b/priv/skills/arrowcircle-jido-skills/skills/jido-studio/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: jido-studio
+description: Builder-oriented guidance for the upstream `jido_studio` package. Use when Codex needs to plan or review Jido operator tooling, workbench pages, demos, or Studio-facing integrations, especially when turning ecosystem package material into concrete examples without over-claiming undocumented UI capabilities.
+---
+
+# Jido Studio
+
+`jido_studio` is the upstream Hex package name.
+
+## Start Here
+
+Use this skill for workbench, operator, and demo-facing tasks around the Jido ecosystem.
+
+Good triggers:
+- "Add or update a Studio page for this ecosystem package."
+- "Plan an operator-facing workflow for agents."
+- "Turn package source material into a Studio demo."
+- "Review whether this feature belongs in Studio or in a package repo."
+
+The public documentation is thinner here than for the core libraries. Keep proposals narrow and grounded in the ecosystem page, issue #51, and any package-specific examples you can verify.
+
+## Primary Workflows
+
+### Build or update ecosystem-facing pages
+
+- Start from the package boundary and the user workflow the page should support.
+- Prefer concrete demos, examples, or inspection surfaces over generic marketing copy.
+- Reuse existing package terminology so Studio and package docs stay aligned.
+
+### Plan operator tooling
+
+- Make agent state, signals, or traces visible without coupling Studio to private app internals.
+- Keep operational controls explicit and reversible.
+- Document which runtime data the Studio feature depends on.
+
+### Turn source material into demos
+
+- Build examples that prove one builder workflow end to end.
+- Keep the demo small enough to run or explain without hidden infrastructure.
+- Call out assumptions when package docs do not define a Studio integration contract.
+
+## Build Checklist
+
+- Identify the operator or contributor workflow first.
+- Name the package or runtime data the Studio surface depends on.
+- Keep demos aligned with documented package behavior.
+- Mark inferred Studio behavior as inferred.
+
+## Boundaries
+
+- Do not invent undocumented Studio APIs or page contracts.
+- Do not move package-specific implementation details into Studio unless the user explicitly wants that coupling.
+- Do not treat thin ecosystem descriptions as proof of a full product feature.

--- a/priv/skills/arrowcircle-jido-skills/skills/jido-studio/agents/openai.yaml
+++ b/priv/skills/arrowcircle-jido-skills/skills/jido-studio/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Jido Studio"
+  short_description: "Plan Jido Studio integrations"
+  default_prompt: "Use $jido-studio to plan or review Jido Studio workflows, pages, and operator tooling."

--- a/priv/skills/arrowcircle-jido-skills/skills/jido/SKILL.md
+++ b/priv/skills/arrowcircle-jido-skills/skills/jido/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: jido
+description: Builder-oriented guidance for the upstream `jido` package. Use when Codex needs to design or review Jido agents, directives, action pipelines, runtime loops, or example applications that compose `jido_action`, `jido_signal`, memory, and AI-facing packages into working Elixir systems.
+---
+
+# Jido
+
+`jido` is the upstream Hex package name.
+
+## Start Here
+
+Use this skill for the core agent runtime and orchestration layer.
+
+Good triggers:
+- "Design a Jido agent for this workflow."
+- "Refactor this runtime loop into actions, directives, and signals."
+- "Turn the Jido docs into a runnable agent example."
+- "Review whether a feature belongs in core Jido or a package-specific extension."
+
+Read [references/builder-notes.md](references/builder-notes.md) before coding when the task spans multiple Jido concepts or packages.
+
+## Primary Workflows
+
+### Design an agent runtime
+
+- Start with the agent boundary: state, directives, allowed actions, emitted signals, and external dependencies.
+- Keep planning and execution explicit. Do not smuggle hidden orchestration into one action or one callback.
+- Prefer small, composable workflows that can be tested without a full application shell.
+
+### Compose ecosystem packages
+
+- Reach for `jido-action` when the job is an executable unit of work.
+- Reach for `jido-signal` when the job is event shape and dispatch.
+- Reach for `jido-memory`, `req-llm`, `llm-db`, or `ash-jido` only when the feature truly crosses into those domains.
+
+### Turn docs into runnable examples
+
+- Build a thin end-to-end example: agent definition, one or two actions, one signal path, and one observable result.
+- Prefer examples that demonstrate runtime decisions or directives over static data transforms.
+- Keep examples executable in tests or `iex`, not locked to a large demo app.
+
+### Review boundaries
+
+- Keep core runtime coordination in `jido`.
+- Push provider, catalog, browser, memory, and Ash-specific details into their package skills.
+- Narrow proposals that require undocumented runtime hooks.
+
+## Build Checklist
+
+- Define the agent state and lifecycle before writing callbacks.
+- List the actions, directives, and signals that participate.
+- Identify external integrations and keep them behind package boundaries.
+- Add tests for state transitions, directive behavior, and failure recovery.
+
+## Boundaries
+
+- Do not use this skill for package-specific transport or provider code when another package already owns that boundary.
+- Do not invent runtime primitives that the docs do not support.
+- Do not let one agent absorb unrelated business workflows that should remain separate.

--- a/priv/skills/arrowcircle-jido-skills/skills/jido/agents/openai.yaml
+++ b/priv/skills/arrowcircle-jido-skills/skills/jido/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Jido"
+  short_description: "Build Jido agents and runtimes"
+  default_prompt: "Use $jido to design or review Jido agents, directives, and runtime workflows."

--- a/priv/skills/arrowcircle-jido-skills/skills/jido/references/builder-notes.md
+++ b/priv/skills/arrowcircle-jido-skills/skills/jido/references/builder-notes.md
@@ -1,0 +1,31 @@
+# Jido Builder Notes
+
+## Use This Reference For
+
+- Mapping a request onto the right Jido concept: agent, directive, action, signal, or extension package.
+- Designing end-to-end examples that stay small enough to understand.
+- Reviewing whether orchestration belongs in core Jido or in a package-specific extension.
+
+## Source Highlights
+
+- The core docs center the framework around agents, actions, directives, and signals.
+- Jido favors explicit orchestration and composable units over opaque agent magic.
+- The package is the place to compose other ecosystem packages, not to duplicate them.
+
+## Implementation Heuristics
+
+- Start from lifecycle and boundaries, then pick the supporting packages.
+- Prefer one clear runtime loop over many implicit callbacks.
+- Keep examples observable through tests, signals, or telemetry.
+- Reuse existing package abstractions before inventing new core concepts.
+
+## Narrowing Rules
+
+- If the task is mostly a package-specific adapter, switch to that package skill.
+- If the proposed runtime feature is not documented, keep the skill guidance conservative and call out the gap.
+
+## Sources
+
+- https://jido.run/ecosystem
+- https://hexdocs.pm/jido/readme.html
+- https://github.com/agentjido/jido_run/issues/51

--- a/priv/skills/arrowcircle-jido-skills/skills/llm-db/SKILL.md
+++ b/priv/skills/arrowcircle-jido-skills/skills/llm-db/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: llm-db
+description: Builder-oriented guidance for the upstream `llm_db` package. Use when Codex needs to model provider and model catalogs, select models by capability or price, wire catalog lookups into Elixir code, or review `llm_db` boundaries versus `req_llm`, `jido`, and `jido_ai`.
+---
+
+# LLM DB
+
+`llm_db` is the upstream Hex package name.
+
+## Start Here
+
+Use this skill when the task is about model metadata, capability catalogs, or provider/model selection logic.
+
+Good triggers:
+- "Add model selection based on context window or pricing."
+- "Normalize OpenAI, Anthropic, or OpenRouter model ids in Elixir."
+- "Turn the LLM DB docs into a runnable catalog lookup example."
+- "Review whether this code belongs in `llm_db` or in the provider client."
+
+Read [references/builder-notes.md](references/builder-notes.md) before editing when the task touches capability filters, pricing metadata, or cross-provider normalization.
+
+## Primary Workflows
+
+### Build catalog-backed selection
+
+- Model the caller's selection criteria first: provider allowlist, modality, tool support, context window, price ceiling, or local-vs-hosted constraint.
+- Keep catalog lookup pure and deterministic. Return model metadata or a narrowed candidate list before making any network call.
+- Push actual inference requests into `req_llm` or another provider client. `llm_db` should decide, not execute.
+
+### Add or refine provider metadata
+
+- Start from the package's existing schema and naming conventions instead of inventing a parallel shape.
+- Preserve upstream provider ids exactly, then add a local mapping layer only if the app needs aliases.
+- Prefer additive metadata updates over app-specific branching in the core catalog.
+
+### Turn docs into runnable examples
+
+- Build examples around lookup, filtering, ranking, or capability checks.
+- Show how the chosen model metadata feeds a later `req_llm` or Jido workflow.
+- Keep examples small enough to run in `iex` or a focused test.
+
+### Review package boundaries
+
+- Keep catalog concerns in `llm_db`.
+- Keep request transport, retries, and streaming in `req_llm`.
+- Keep agent orchestration, directives, and tool use in `jido` or `jido_ai`.
+
+## Build Checklist
+
+- Confirm which providers and model families the app actually needs.
+- Verify whether the task needs static metadata, live pricing refresh, or both.
+- Keep the API shape obvious: input criteria in, ranked models or metadata out.
+- Add tests for provider aliases, missing models, and fallback behavior.
+
+## Boundaries
+
+- Do not use this skill for prompt design or message shaping.
+- Do not hide provider-specific HTTP logic inside catalog helpers.
+- Do not promise pricing freshness beyond what the package sources actually support.

--- a/priv/skills/arrowcircle-jido-skills/skills/llm-db/agents/openai.yaml
+++ b/priv/skills/arrowcircle-jido-skills/skills/llm-db/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "LLM DB"
+  short_description: "Build and query LLM DB catalogs"
+  default_prompt: "Use $llm-db to build or update model catalog workflows for my Elixir app."

--- a/priv/skills/arrowcircle-jido-skills/skills/llm-db/references/builder-notes.md
+++ b/priv/skills/arrowcircle-jido-skills/skills/llm-db/references/builder-notes.md
@@ -1,0 +1,32 @@
+# LLM DB Builder Notes
+
+## Use This Reference For
+
+- Distilling provider and model metadata into an application-facing selector.
+- Checking whether a task belongs in the catalog layer or in the inference client.
+- Building examples that combine model lookup with later Jido or ReqLLM steps.
+
+## Source Highlights
+
+- The package positions itself as a database of LLMs, provider metadata, capabilities, and pricing.
+- The useful builder workflow is selection and normalization, not chat orchestration.
+- The package is a natural upstream source for routing decisions in `req_llm`, `jido`, or `jido_ai`.
+
+## Implementation Heuristics
+
+- Normalize once at the boundary, then keep internal lookups stable.
+- Prefer explicit filter structs, maps, or typed options over ad hoc condition trees.
+- Treat pricing and capability fields as advisory data unless the package documents stronger guarantees.
+- Keep ranking logic inspectable so agent code can explain why a model was chosen.
+
+## Narrowing Rules
+
+- If the user asks to call an LLM API, switch to `req-llm` or a higher-level Jido skill after selection is complete.
+- If the user asks for prompt strategy, message assembly, or tool calling, use `jido`, `jido_ai`, or package-specific workflow skills.
+
+## Sources
+
+- https://jido.run/ecosystem
+- https://hexdocs.pm/llm_db/readme.html
+- https://hex.pm/packages/llm_db
+- https://github.com/agentjido/llm_db

--- a/priv/skills/arrowcircle-jido-skills/skills/req-llm/SKILL.md
+++ b/priv/skills/arrowcircle-jido-skills/skills/req-llm/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: req-llm
+description: Builder-oriented guidance for the upstream `req_llm` package. Use when Codex needs to configure providers, shape LLM requests, implement streaming or structured outputs, or review `req_llm` boundaries versus `llm_db`, `jido`, and `jido_ai`.
+---
+
+# ReqLLM
+
+`req_llm` is the upstream Hex package name.
+
+## Start Here
+
+Use this skill when the task is about making LLM calls from Elixir through Req-based provider adapters.
+
+Good triggers:
+- "Add OpenAI or Anthropic support to this Elixir app."
+- "Stream model output through ReqLLM."
+- "Turn the package docs into a working provider example."
+- "Review whether this should live in `req_llm` or in a Jido action."
+
+Read [references/builder-notes.md](references/builder-notes.md) before coding when the task involves provider differences, request/response shapes, or how `req_llm` fits under `jido_ai`.
+
+## Primary Workflows
+
+### Configure providers cleanly
+
+- Separate provider configuration from call sites. Keep API keys, base URLs, and model defaults at the edge.
+- Reuse Req idioms for timeouts, middleware, retries, and telemetry instead of inventing a second transport stack.
+- Normalize the app-facing request shape before branching into provider-specific options.
+
+### Build model invocation flows
+
+- Decide whether the caller needs one-shot generation, streaming, tool calling, or structured outputs before writing the adapter code.
+- Keep message shaping explicit. If prompts or tool schemas become complex, coordinate with `jido_ai` or `jido` rather than hiding orchestration in the HTTP client.
+- Feed model selection from `llm_db` when capability or pricing constraints matter.
+
+### Turn docs into runnable examples
+
+- Prefer one provider per example.
+- Show environment configuration, request construction, and response handling in a minimal `iex` or test-friendly flow.
+- Add one example for failure handling or provider-specific options when that difference is the point of the task.
+
+### Review package boundaries
+
+- Keep provider transport and response normalization in `req_llm`.
+- Keep catalog selection in `llm_db`.
+- Keep agents, directives, and multi-step reasoning loops in `jido` or `jido_ai`.
+
+## Build Checklist
+
+- Verify the provider, model family, and auth mechanism first.
+- Confirm whether the caller needs sync, async, or streaming behavior.
+- Keep response parsing small and typed enough for the next layer.
+- Add tests around rate limits, provider errors, and empty or partial responses.
+
+## Boundaries
+
+- Do not use this skill for model pricing catalogs.
+- Do not use this skill for long-lived agent state or tool orchestration.
+- Do not promise cross-provider feature parity when the package docs call out differences.

--- a/priv/skills/arrowcircle-jido-skills/skills/req-llm/agents/openai.yaml
+++ b/priv/skills/arrowcircle-jido-skills/skills/req-llm/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "ReqLLM"
+  short_description: "Build ReqLLM provider workflows"
+  default_prompt: "Use $req-llm to add or refine ReqLLM providers, calls, or streaming workflows."

--- a/priv/skills/arrowcircle-jido-skills/skills/req-llm/references/builder-notes.md
+++ b/priv/skills/arrowcircle-jido-skills/skills/req-llm/references/builder-notes.md
@@ -1,0 +1,32 @@
+# ReqLLM Builder Notes
+
+## Use This Reference For
+
+- Mapping a product requirement onto a provider adapter, request shape, and response flow.
+- Deciding when to stay inside `req_llm` versus escalate to `jido_ai` or `jido`.
+- Building examples that are transport-focused instead of agent-focused.
+
+## Source Highlights
+
+- `req_llm` is an Elixir LLM client built on Req.
+- The package is most useful for provider integration, request building, response parsing, and streaming.
+- `jido_ai` adds AI workflow concepts on top of packages like `req_llm`; it is reference material, not a generated skill target here.
+
+## Implementation Heuristics
+
+- Keep the provider edge thin and predictable.
+- Normalize the request contract once, then map to provider-specific fields.
+- Prefer explicit options for streaming, tools, and structured output modes instead of magical flags.
+- Surface provider errors as data the next layer can handle.
+
+## Narrowing Rules
+
+- If the task becomes a multi-step agent loop, move up to `jido` or `jido_ai`.
+- If the task is model discovery or price-aware routing, pair with `llm_db`.
+
+## Sources
+
+- https://jido.run/ecosystem
+- https://hexdocs.pm/req_llm/readme.html
+- https://hex.pm/packages/req_llm
+- https://hexdocs.pm/jido_ai/readme.html

--- a/priv/skills/arrowcircle-jido-skills/source/prompts.md
+++ b/priv/skills/arrowcircle-jido-skills/source/prompts.md
@@ -1,0 +1,123 @@
+# Jido Ecosystem Skills Generation Prompt
+
+Use this prompt to generate a builder-oriented set of Codex skills for the Jido ecosystem.
+
+```text
+Build a starter catalog of Codex skills for the Jido ecosystem.
+
+Goal
+
+Create one skill per Jido ecosystem package so contributors and adopters can build with each package, not just read about it. Use the framing from agentjido/jido_run issue #51 ("Create builder Skills for common Jido ecosystem workflows") as inspiration for workflow shape and acceptance criteria, but keep the deliverable as one skill per ecosystem package.
+
+Authoritative scope
+
+Treat the current Jido ecosystem page as the authoritative package list. Create exactly one skill for each of these packages and do not create extras unless the ecosystem page itself has changed:
+
+- llm_db
+- req_llm
+- jido_action
+- jido_signal
+- jido
+- jido_browser
+- jido_memory
+- jido_behaviortree
+- ash_jido
+- jido_studio
+- jido_messaging
+- jido_otel
+
+Do not create a separate jido_ai skill unless it appears in the current ecosystem matrix. You may still use jido_ai docs or ecosystem pages as shared reference material if they clarify how a package is built or used.
+
+Source material
+
+Research in this order:
+
+1. Ecosystem scope and package links:
+   - https://jido.run/ecosystem
+2. Shared Jido baseline:
+   - https://hexdocs.pm/jido/readme.html
+3. Package-specific docs and source repos:
+   - Follow the package links from the ecosystem page to each package's HexDocs, Hex package page, GitHub repo, and any package docs linked from there.
+4. Builder-skill inspiration:
+   - https://github.com/agentjido/jido_run/issues/51
+
+If a package has thin or missing docs, inspect the package repo and infer carefully from source structure, examples, tests, and README material. Call out unresolved ambiguity in the final report instead of inventing unsupported behavior.
+
+Deliverable layout
+
+Write all output into the local skills directory. Create one folder per package:
+
+- skills/<package>/SKILL.md
+- skills/<package>/agents/openai.yaml
+
+Optional:
+
+- skills/<package>/references/... only when a package needs condensed local notes, API summaries, workflow checklists, or architecture guidance that would otherwise make SKILL.md too large or too vague.
+
+Do not add scripts, assets, or extra docs unless they are clearly necessary for deterministic, repeated builder workflows. Do not create filler files such as README.md, CHANGELOG.md, NOTES.md, or placeholder assets.
+
+Skill requirements
+
+Each skill must be builder-oriented. Do not produce generic "overview" skills.
+
+Every SKILL.md must:
+
+- Use YAML frontmatter with only:
+  - name
+  - description
+- Use a description that clearly states what the skill does and when it should trigger.
+- Focus on package-native building tasks such as:
+  - scaffolding or extending package concepts
+  - implementing or integrating adapters, plugins, providers, or tooling around that package
+  - turning docs or source material into runnable examples, tutorials, or starter implementations
+  - reviewing boundaries, dependencies, and docs gaps for that package
+- Include concrete task examples that are specific to the package.
+- State boundaries and non-goals so the skill does not over-trigger.
+- Include runtime or ecosystem context when relevant, such as Elixir/OTP conventions, Ash integration, messaging boundaries, telemetry concerns, browser automation limits, or storage/runtime assumptions.
+- Prefer concise, procedural guidance over long explanations.
+- Be written for another Codex instance that will use the skill to do real work.
+
+Each agents/openai.yaml must:
+
+- Match the skill's actual scope.
+- Use a clear display name, short description, and default prompt aligned to builder workflows for that package.
+- Avoid generic metadata that could apply to any library.
+
+Quality bar
+
+- Keep wording Elixir-first and Jido-specific.
+- Reuse shared Jido concepts from the core docs where relevant, but tailor each skill to the package's real responsibilities.
+- Avoid copy-paste bodies across packages.
+- Keep artifacts ASCII-first unless the source material requires otherwise.
+- Do not assume local helper scripts, generators, or scaffolding tools exist unless they are documented in the package you are working from.
+- If a package has no reliable support for a workflow, say so and narrow the skill accordingly.
+
+Execution guidance
+
+- Start by mapping all 12 packages to their linked docs/repos.
+- For each package, identify:
+  - the package purpose
+  - the primary builder workflows
+  - the core abstractions users extend or integrate with
+  - the likely failure modes, boundaries, and docs gaps
+- Then write the skill files for that package before moving to the next.
+- Keep shared concepts consistent across skills, but do not flatten package differences.
+
+Final report
+
+After generating the files, produce a completion report that includes:
+
+- all 12 packages
+- the files created for each package
+- the primary source URLs used for each package
+- any package with missing docs, weak examples, or unresolved ambiguity
+- any package where you intentionally kept the skill narrow because the docs did not justify a broader builder workflow
+
+Success criteria
+
+- Exactly one skill exists for each package in the authoritative ecosystem list.
+- Every package has SKILL.md and agents/openai.yaml.
+- Skills help a user build, extend, review, or integrate with the package.
+- Optional references are present only where they materially improve reuse.
+- The final report makes coverage and gaps explicit.
+```

--- a/test/agent_jido/upstream_skill_catalog_test.exs
+++ b/test/agent_jido/upstream_skill_catalog_test.exs
@@ -1,0 +1,35 @@
+defmodule AgentJido.UpstreamSkillCatalogTest do
+  use ExUnit.Case, async: true
+
+  alias AgentJido.UpstreamSkillCatalog
+
+  test "exposes the vendored upstream skill counts and support file metadata" do
+    assert UpstreamSkillCatalog.count() == 13
+    assert UpstreamSkillCatalog.package_count() == 12
+    assert UpstreamSkillCatalog.router_count() == 1
+    assert UpstreamSkillCatalog.support_file_count() == 24
+    assert UpstreamSkillCatalog.skills_root_source_path() == "priv/skills/arrowcircle-jido-skills/skills"
+    assert UpstreamSkillCatalog.source_prompt_source_path() == "priv/skills/arrowcircle-jido-skills/source/prompts.md"
+  end
+
+  test "maps vendored skill entries to copied source paths and public ecosystem pages when available" do
+    entries = UpstreamSkillCatalog.all_entries()
+    names = Enum.map(entries, & &1.name)
+
+    assert "jido-skill-router" in names
+    assert "jido-action" in names
+    assert "req-llm" in names
+
+    router = Enum.find(entries, &(&1.id == "jido-skill-router"))
+    assert router.category == :router
+    assert router.skill_source_path == "priv/skills/arrowcircle-jido-skills/skills/jido-skill-router/SKILL.md"
+    assert router.reference_files == ["priv/skills/arrowcircle-jido-skills/skills/jido-skill-router/references/skill-manifest.yaml"]
+    assert router.agent_files == ["priv/skills/arrowcircle-jido-skills/skills/jido-skill-router/agents/openai.yaml"]
+
+    req_llm = Enum.find(entries, &(&1.id == "req-llm"))
+    assert req_llm.category == :package
+    assert req_llm.ecosystem_package_id == "req_llm"
+    assert req_llm.ecosystem_path == "/ecosystem/req_llm"
+    assert req_llm.upstream_url == "https://github.com/arrowcircle/jido-skills/tree/main/skills/req-llm"
+  end
+end

--- a/test/agent_jido_web/live/jido_skills_live_test.exs
+++ b/test/agent_jido_web/live/jido_skills_live_test.exs
@@ -1,0 +1,23 @@
+defmodule AgentJidoWeb.JidoSkillsLiveTest do
+  use AgentJidoWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias AgentJido.UpstreamSkillCatalog
+
+  test "renders the vendored upstream skills catalog page", %{conn: conn} do
+    {:ok, _view, html} = live(conn, "/skills")
+
+    assert html =~ "JIDO SKILLS CATALOG"
+    assert html =~ "Vendored package skills for the Jido ecosystem"
+    assert html =~ UpstreamSkillCatalog.skills_root_source_path()
+    assert html =~ UpstreamSkillCatalog.readme_source_path()
+    assert html =~ "jido-skill-router"
+    assert html =~ "jido-action"
+    assert html =~ "req-llm"
+    assert html =~ ~s(href="https://github.com/arrowcircle/jido-skills")
+    assert html =~ ~s(href="/examples/jido-ai-skills-runtime-foundations?tab=demo")
+    assert html =~ ~s(href="/ecosystem/req_llm")
+    assert html =~ ~s(href="/skills")
+  end
+end


### PR DESCRIPTION
Summary
- vendor the upstream arrowcircle/jido-skills catalog under priv/skills/arrowcircle-jido-skills
- add a public /skills page that lists the copied package skills and router skill
- wire /skills into nav, sitemap, and markdown fallback handling

Verification
- CONTENTOPS_CHAT_ENABLED=false ASDF_ELIXIR_VERSION=1.18.4-otp-27 ASDF_ERLANG_VERSION=27.3 mix test
- CONTENTOPS_CHAT_ENABLED=false ASDF_ELIXIR_VERSION=1.18.4-otp-27 ASDF_ERLANG_VERSION=27.3 mix credo --strict
- CONTENTOPS_CHAT_ENABLED=false ASDF_ELIXIR_VERSION=1.18.4-otp-27 ASDF_ERLANG_VERSION=27.3 mix dialyzer

Follow-up to the comment on #51 requesting that we pull in https://github.com/arrowcircle/jido-skills.