### PR TITLE
refactor(workbench): reduce clone hotspots

### DIFF
--- a/lib/agent_jido_web/content_assistant_support.ex
+++ b/lib/agent_jido_web/content_assistant_support.ex
@@ -1,0 +1,165 @@
+defmodule AgentJidoWeb.ContentAssistantSupport do
+  @moduledoc false
+
+  alias AgentJido.ContentAssistant.Response
+
+  @default_progressive_swap_min_ms 1_200
+
+  def normalize_query(query) when is_binary(query), do: String.trim(query)
+  def normalize_query(_query), do: ""
+
+  def normalize_feedback_value(value) when is_binary(value) do
+    case String.trim(value) do
+      "helpful" -> "helpful"
+      "not_helpful" -> "not_helpful"
+      _ -> nil
+    end
+  end
+
+  def normalize_feedback_value(_value), do: nil
+
+  def normalize_feedback_note(value) when is_binary(value) do
+    value
+    |> String.trim()
+    |> String.slice(0, 500)
+    |> case do
+      "" -> nil
+      note -> note
+    end
+  end
+
+  def normalize_feedback_note(_value), do: nil
+
+  def source_label(:docs), do: "Docs"
+  def source_label(:blog), do: "Blog"
+  def source_label(:ecosystem), do: "Ecosystem"
+  def source_label(_), do: "Content"
+
+  def analytics_metadata(%Response{} = response, metadata) when is_map(metadata) do
+    Map.merge(metadata, %{
+      answer_mode: response.answer_mode,
+      retrieval_status: response.retrieval_status,
+      llm_attempted: response.llm_attempted?,
+      llm_enhanced: response.llm_enhanced?,
+      enhancement_blocked_reason: response.enhancement_blocked_reason
+    })
+  end
+
+  def analytics_metadata(_response, metadata) when is_map(metadata), do: metadata
+
+  def query_latency_ms(started_at) when is_integer(started_at) do
+    System.monotonic_time()
+    |> Kernel.-(started_at)
+    |> System.convert_time_unit(:native, :millisecond)
+  end
+
+  def query_latency_ms(_started_at), do: 0
+
+  def progressive_swap_min_ms do
+    case content_assistant_config() |> config_value(:progressive_swap_min_ms, @default_progressive_swap_min_ms) do
+      value when is_integer(value) and value >= 0 -> value
+      _ -> @default_progressive_swap_min_ms
+    end
+  end
+
+  def maybe_wait_for_progressive_dwell(started_at_ms) when is_integer(started_at_ms) do
+    remaining_ms = progressive_swap_min_ms() - (monotonic_ms() - started_at_ms)
+
+    if remaining_ms > 0 do
+      Process.sleep(remaining_ms)
+    end
+  end
+
+  def maybe_wait_for_progressive_dwell(_started_at_ms), do: :ok
+
+  def monotonic_ms do
+    System.monotonic_time()
+    |> System.convert_time_unit(:native, :millisecond)
+  end
+
+  def reset_turnstile_widget(socket) do
+    if socket.assigns[:turnstile_required] do
+      Phoenix.LiveView.push_event(socket, "content_assistant_turnstile_reset", %{id: socket.assigns.turnstile_widget_id})
+    else
+      socket
+    end
+  end
+
+  def turnstile_widget_id(id), do: "#{id}-turnstile"
+  def turnstile_input_id(id), do: "#{id}-turnstile-token"
+  def turnstile_submit_id(id), do: "#{id}-submit"
+  def turnstile_status_id(id), do: "#{id}-turnstile-status"
+  def turnstile_retry_id(id), do: "#{id}-turnstile-retry"
+
+  def require_turnstile? do
+    turnstile_required =
+      content_assistant_config()
+      |> config_value(:require_turnstile, false)
+      |> truthy?()
+
+    search_response_mode() == :enhanced and turnstile_required
+  end
+
+  def turnstile_site_key do
+    content_assistant_config()
+    |> config_value(:turnstile_site_key, nil)
+  end
+
+  def content_assistant_config do
+    Application.get_env(:agent_jido, AgentJido.ContentAssistant, [])
+  end
+
+  def config_value(config, key, default) when is_list(config), do: Keyword.get(config, key, default)
+  def config_value(config, key, default) when is_map(config), do: Map.get(config, key, default)
+  def config_value(_config, _key, default), do: default
+
+  def truthy?(value), do: value in [true, "true", 1, "1", "on"]
+
+  def maybe_apply_search_response_mode(opts, stage) when is_list(opts) do
+    case {search_response_mode(), stage} do
+      {:enhanced, _stage} ->
+        opts
+
+      {:deterministic, _stage} ->
+        opts
+        |> Keyword.put(:llm, nil)
+        |> Keyword.put(:require_turnstile, false)
+
+      {:progressive, :enhancement} ->
+        opts
+        |> Keyword.put_new(:llm, Application.get_env(:arcana, :llm))
+        |> Keyword.put(:require_turnstile, false)
+
+      {:progressive, _stage} ->
+        opts
+        |> Keyword.put(:llm, nil)
+        |> Keyword.put(:require_turnstile, false)
+    end
+  end
+
+  def maybe_apply_search_response_mode(opts, _stage), do: opts
+
+  def search_response_mode do
+    case content_assistant_config() |> config_value(:search_response_mode, :progressive) do
+      mode when mode in [:progressive, "progressive"] -> :progressive
+      mode when mode in [:enhanced, "enhanced"] -> :enhanced
+      _ -> :deterministic
+    end
+  end
+
+  def search_retrieval_mode do
+    case content_assistant_config() |> config_value(:search_retrieval_mode, :hybrid) do
+      mode when mode in [:hybrid, "hybrid"] -> :hybrid
+      _ -> :fulltext
+    end
+  end
+
+  def llm_enabled?(opts) when is_list(opts) do
+    case Keyword.fetch(opts, :llm) do
+      {:ok, llm} -> not is_nil(llm)
+      :error -> not is_nil(Application.get_env(:arcana, :llm))
+    end
+  end
+
+  def llm_enabled?(_opts), do: false
+end

--- a/lib/agent_jido_web/examples/plugin_basics_agent_live.ex
+++ b/lib/agent_jido_web/examples/plugin_basics_agent_live.ex
@@ -5,6 +5,7 @@ defmodule AgentJidoWeb.Examples.PluginBasicsAgentLive do
   use AgentJidoWeb, :live_view
 
   alias AgentJido.Demos.PluginBasicsAgent
+  alias AgentJidoWeb.Examples.RuntimeDemoHelpers
   alias Jido.AgentServer
   alias Jido.Signal
 
@@ -22,30 +23,14 @@ defmodule AgentJidoWeb.Examples.PluginBasicsAgentLive do
       |> assign(:log_entries, [])
       |> assign(:last_error, nil)
 
-    socket =
-      if connected?(socket) do
-        case start_demo_server() do
-          {:ok, pid, agent} ->
-            Process.send_after(self(), :poll_state, @poll_interval_ms)
-            socket |> assign(:server_pid, pid) |> assign(:agent, agent)
-
-          {:error, reason} ->
-            assign(socket, :last_error, "Failed to start runtime: #{inspect(reason)}")
-        end
-      else
-        socket
-      end
+    socket = RuntimeDemoHelpers.start_runtime(socket, &start_demo_server/0, @poll_interval_ms)
 
     {:ok, socket}
   end
 
   @impl true
   def terminate(_reason, socket) do
-    if pid = socket.assigns[:server_pid] do
-      if Process.alive?(pid), do: GenServer.stop(pid, :normal)
-    end
-
-    :ok
+    RuntimeDemoHelpers.stop_runtime(socket)
   end
 
   @impl true
@@ -107,7 +92,7 @@ defmodule AgentJidoWeb.Examples.PluginBasicsAgentLive do
   def handle_event("add_note", %{"text" => text}, socket) do
     trimmed = String.trim(text)
 
-    with {:ok, pid} <- fetch_server_pid(socket),
+    with {:ok, pid} <- RuntimeDemoHelpers.fetch_server_pid(socket),
          true <- trimmed != "",
          {:ok, agent} <- AgentServer.call(pid, Signal.new!("notes.add", %{text: trimmed}, source: "/demo")) do
       entry = %{action: "notes.add", detail: trimmed, at: DateTime.utc_now()}
@@ -125,7 +110,7 @@ defmodule AgentJidoWeb.Examples.PluginBasicsAgentLive do
   end
 
   def handle_event("clear_notes", _params, socket) do
-    with {:ok, pid} <- fetch_server_pid(socket),
+    with {:ok, pid} <- RuntimeDemoHelpers.fetch_server_pid(socket),
          {:ok, agent} <- AgentServer.call(pid, Signal.new!("notes.clear", %{}, source: "/demo")) do
       entry = %{action: "notes.clear", detail: "all entries removed", at: DateTime.utc_now()}
 
@@ -141,17 +126,7 @@ defmodule AgentJidoWeb.Examples.PluginBasicsAgentLive do
 
   @impl true
   def handle_info(:poll_state, socket) do
-    socket =
-      case fetch_server_pid(socket) do
-        {:ok, pid} ->
-          case AgentServer.state(pid) do
-            {:ok, %{agent: agent}} -> assign(socket, :agent, agent)
-            _ -> socket
-          end
-
-        _ ->
-          socket
-      end
+    socket = RuntimeDemoHelpers.refresh_agent(socket)
 
     Process.send_after(self(), :poll_state, @poll_interval_ms)
     {:noreply, socket}
@@ -163,13 +138,6 @@ defmodule AgentJidoWeb.Examples.PluginBasicsAgentLive do
     with {:ok, pid} <- AgentServer.start_link(jido: AgentJido.Jido, agent: PluginBasicsAgent, id: id),
          {:ok, %{agent: agent}} <- AgentServer.state(pid) do
       {:ok, pid, agent}
-    end
-  end
-
-  defp fetch_server_pid(socket) do
-    case socket.assigns.server_pid do
-      pid when is_pid(pid) -> if(Process.alive?(pid), do: {:ok, pid}, else: {:error, :runtime_not_started})
-      _ -> {:error, :runtime_not_started}
     end
   end
 end

--- a/lib/agent_jido_web/examples/runtime_demo_helpers.ex
+++ b/lib/agent_jido_web/examples/runtime_demo_helpers.ex
@@ -1,0 +1,55 @@
+defmodule AgentJidoWeb.Examples.RuntimeDemoHelpers do
+  @moduledoc false
+
+  alias Jido.AgentServer
+
+  def start_runtime(socket, start_fun, poll_interval_ms, opts \\ []) when is_function(start_fun, 0) do
+    if Phoenix.LiveView.connected?(socket) do
+      case start_fun.() do
+        {:ok, pid, agent} ->
+          Process.send_after(self(), :poll_state, poll_interval_ms)
+
+          socket
+          |> Phoenix.Component.assign(:server_pid, pid)
+          |> Phoenix.Component.assign(:agent, agent)
+
+        {:error, reason} ->
+          Phoenix.Component.assign(
+            socket,
+            :last_error,
+            "#{Keyword.get(opts, :start_error_prefix, "Failed to start runtime")}: #{inspect(reason)}"
+          )
+      end
+    else
+      socket
+    end
+  end
+
+  def stop_runtime(socket) do
+    if pid = socket.assigns[:server_pid] do
+      if Process.alive?(pid), do: GenServer.stop(pid, :normal)
+    end
+
+    :ok
+  end
+
+  def refresh_agent(socket) do
+    case fetch_server_pid(socket) do
+      {:ok, pid} ->
+        case AgentServer.state(pid) do
+          {:ok, %{agent: agent}} -> Phoenix.Component.assign(socket, :agent, agent)
+          _ -> socket
+        end
+
+      _ ->
+        socket
+    end
+  end
+
+  def fetch_server_pid(socket) do
+    case socket.assigns.server_pid do
+      pid when is_pid(pid) -> if(Process.alive?(pid), do: {:ok, pid}, else: {:error, :runtime_not_started})
+      _ -> {:error, :runtime_not_started}
+    end
+  end
+end

--- a/lib/agent_jido_web/examples/schedule_directive_agent_live.ex
+++ b/lib/agent_jido_web/examples/schedule_directive_agent_live.ex
@@ -5,6 +5,7 @@ defmodule AgentJidoWeb.Examples.ScheduleDirectiveAgentLive do
   use AgentJidoWeb, :live_view
 
   alias AgentJido.Demos.ScheduleDirectiveAgent
+  alias AgentJidoWeb.Examples.RuntimeDemoHelpers
   alias Jido.AgentServer
   alias Jido.Signal
 
@@ -24,30 +25,14 @@ defmodule AgentJidoWeb.Examples.ScheduleDirectiveAgentLive do
       |> assign(:log_entries, [])
       |> assign(:last_error, nil)
 
-    socket =
-      if connected?(socket) do
-        case start_demo_server() do
-          {:ok, pid, agent} ->
-            Process.send_after(self(), :poll_state, @poll_interval_ms)
-            socket |> assign(:server_pid, pid) |> assign(:agent, agent)
-
-          {:error, reason} ->
-            assign(socket, :last_error, "Failed to start runtime: #{inspect(reason)}")
-        end
-      else
-        socket
-      end
+    socket = RuntimeDemoHelpers.start_runtime(socket, &start_demo_server/0, @poll_interval_ms)
 
     {:ok, socket}
   end
 
   @impl true
   def terminate(_reason, socket) do
-    if pid = socket.assigns[:server_pid] do
-      if Process.alive?(pid), do: GenServer.stop(pid, :normal)
-    end
-
-    :ok
+    RuntimeDemoHelpers.stop_runtime(socket)
   end
 
   @impl true
@@ -164,7 +149,7 @@ defmodule AgentJidoWeb.Examples.ScheduleDirectiveAgentLive do
 
   @impl true
   def handle_event("start_timer", %{"delay_ms" => delay_raw}, socket) do
-    with {:ok, pid} <- fetch_server_pid(socket),
+    with {:ok, pid} <- RuntimeDemoHelpers.fetch_server_pid(socket),
          {:ok, delay_ms} <- parse_positive_integer(delay_raw) do
       timer_id = "T-#{System.unique_integer([:positive])}"
 
@@ -188,7 +173,7 @@ defmodule AgentJidoWeb.Examples.ScheduleDirectiveAgentLive do
   end
 
   def handle_event("start_retry", %{"max_attempts" => max_raw, "delay_ms" => delay_raw}, socket) do
-    with {:ok, pid} <- fetch_server_pid(socket),
+    with {:ok, pid} <- RuntimeDemoHelpers.fetch_server_pid(socket),
          {:ok, max_attempts} <- parse_positive_integer(max_raw),
          {:ok, delay_ms} <- parse_positive_integer(delay_raw) do
       signal =
@@ -226,24 +211,14 @@ defmodule AgentJidoWeb.Examples.ScheduleDirectiveAgentLive do
 
   @impl true
   def handle_info(:poll_state, socket) do
-    socket =
-      case fetch_server_pid(socket) do
-        {:ok, pid} ->
-          case AgentServer.state(pid) do
-            {:ok, %{agent: agent}} -> assign(socket, :agent, agent)
-            _ -> socket
-          end
-
-        _ ->
-          socket
-      end
+    socket = RuntimeDemoHelpers.refresh_agent(socket)
 
     Process.send_after(self(), :poll_state, @poll_interval_ms)
     {:noreply, socket}
   end
 
   defp send_manual_cron(socket, signal_type, log_label) do
-    case fetch_server_pid(socket) do
+    case RuntimeDemoHelpers.fetch_server_pid(socket) do
       {:ok, pid} ->
         case AgentServer.call(pid, Signal.new!(signal_type, %{}, source: "/demo")) do
           {:ok, agent} ->
@@ -268,13 +243,6 @@ defmodule AgentJidoWeb.Examples.ScheduleDirectiveAgentLive do
     with {:ok, pid} <- AgentServer.start_link(jido: AgentJido.Jido, agent: ScheduleDirectiveAgent, id: id),
          {:ok, %{agent: agent}} <- AgentServer.state(pid) do
       {:ok, pid, agent}
-    end
-  end
-
-  defp fetch_server_pid(socket) do
-    case socket.assigns.server_pid do
-      pid when is_pid(pid) -> if(Process.alive?(pid), do: {:ok, pid}, else: {:error, :runtime_not_started})
-      _ -> {:error, :runtime_not_started}
     end
   end
 

--- a/lib/agent_jido_web/examples/simulated_showcase_live.ex
+++ b/lib/agent_jido_web/examples/simulated_showcase_live.ex
@@ -9,6 +9,89 @@ defmodule AgentJidoWeb.Examples.SimulatedShowcaseLive do
   use AgentJidoWeb, :live_view
 
   @step_delay_ms 550
+  @default_scenario %{
+    title: "Simulated Example",
+    steps: [
+      %{label: "Load fixtures", detail: "Prepared deterministic demo inputs"},
+      %{label: "Execute flow", detail: "Ran scenario with no external calls"},
+      %{label: "Publish output", detail: "Returned stable simulated result"}
+    ],
+    result: "Demo completed in deterministic simulation mode."
+  }
+  @scenarios %{
+    "deep-research" => %{
+      title: "Deep Research",
+      steps: [
+        %{label: "Collect sources", detail: "Loaded 5 deterministic source snippets"},
+        %{label: "Synthesize findings", detail: "Clustered claims into consensus and risk buckets"},
+        %{label: "Draft memo", detail: "Generated summary and open questions"}
+      ],
+      result: """
+      Summary:
+      - Adoption is accelerating in ops and support workflows.
+      - Main risk remains evaluation quality under ambiguous inputs.
+      - Recommendation: pilot with bounded, high-observability tasks first.
+      """
+    },
+    "coding-assistant" => %{
+      title: "Coding Assistant",
+      steps: [
+        %{label: "Read files", detail: "Indexed 4 fixture files in lib/ and test/"},
+        %{label: "Detect issue", detail: "Found one nil-handling edge case in parser"},
+        %{label: "Propose patch", detail: "Built patch suggestion with unit test update"}
+      ],
+      result: """
+      Patch plan:
+      1. Guard nil input before trim/1.
+      2. Add parser unit test for nil payload.
+      3. Run mix test for parser suite.
+      """
+    },
+    "incident-triage" => %{
+      title: "Incident Triage",
+      steps: [
+        %{label: "Ingest alerts", detail: "Loaded 12 fixture alerts from logs + paging"},
+        %{label: "Cluster incidents", detail: "Grouped alerts into 2 active incidents"},
+        %{label: "Recommend action", detail: "Escalated API latency issue to SRE owner"}
+      ],
+      result: """
+      Incident: api-latency-degradation
+      Severity: SEV-2
+      Owner: sre-oncall
+      Suggested next step: rollback deploy #742
+      """
+    },
+    "text-to-sql-analytics" => %{
+      title: "Text-to-SQL Analytics",
+      steps: [
+        %{label: "Interpret question", detail: "Mapped request to monthly revenue trend"},
+        %{label: "Compile SQL", detail: "Generated parameterized query from fixture schema"},
+        %{label: "Render chart data", detail: "Returned 12 monthly points for visualization"}
+      ],
+      result: """
+      SQL:
+      SELECT month, SUM(revenue) AS total_revenue
+      FROM analytics.monthly_revenue
+      WHERE year = 2025
+      GROUP BY month
+      ORDER BY month;
+      """
+    },
+    "workflow-coordinator" => %{
+      title: "Workflow Coordinator",
+      steps: [
+        %{label: "Plan graph", detail: "Built 4-node workflow with retry boundaries"},
+        %{label: "Dispatch workers", detail: "Started classifier, enricher, and notifier stages"},
+        %{label: "Recover fault", detail: "Injected node failure and replayed from checkpoint"}
+      ],
+      result: """
+      Workflow status:
+      - completed_nodes: 4/4
+      - retries: 1
+      - checkpoint_recovery: true
+      """
+    }
+  }
 
   @impl true
   def mount(_params, session, socket) do
@@ -155,102 +238,5 @@ defmodule AgentJidoWeb.Examples.SimulatedShowcaseLive do
 
   defp progress_pct(_step_index, _steps), do: 0
 
-  defp scenario_for("deep-research") do
-    %{
-      title: "Deep Research",
-      steps: [
-        %{label: "Collect sources", detail: "Loaded 5 deterministic source snippets"},
-        %{label: "Synthesize findings", detail: "Clustered claims into consensus and risk buckets"},
-        %{label: "Draft memo", detail: "Generated summary and open questions"}
-      ],
-      result: """
-      Summary:
-      - Adoption is accelerating in ops and support workflows.
-      - Main risk remains evaluation quality under ambiguous inputs.
-      - Recommendation: pilot with bounded, high-observability tasks first.
-      """
-    }
-  end
-
-  defp scenario_for("coding-assistant") do
-    %{
-      title: "Coding Assistant",
-      steps: [
-        %{label: "Read files", detail: "Indexed 4 fixture files in lib/ and test/"},
-        %{label: "Detect issue", detail: "Found one nil-handling edge case in parser"},
-        %{label: "Propose patch", detail: "Built patch suggestion with unit test update"}
-      ],
-      result: """
-      Patch plan:
-      1. Guard nil input before trim/1.
-      2. Add parser unit test for nil payload.
-      3. Run mix test for parser suite.
-      """
-    }
-  end
-
-  defp scenario_for("incident-triage") do
-    %{
-      title: "Incident Triage",
-      steps: [
-        %{label: "Ingest alerts", detail: "Loaded 12 fixture alerts from logs + paging"},
-        %{label: "Cluster incidents", detail: "Grouped alerts into 2 active incidents"},
-        %{label: "Recommend action", detail: "Escalated API latency issue to SRE owner"}
-      ],
-      result: """
-      Incident: api-latency-degradation
-      Severity: SEV-2
-      Owner: sre-oncall
-      Suggested next step: rollback deploy #742
-      """
-    }
-  end
-
-  defp scenario_for("text-to-sql-analytics") do
-    %{
-      title: "Text-to-SQL Analytics",
-      steps: [
-        %{label: "Interpret question", detail: "Mapped request to monthly revenue trend"},
-        %{label: "Compile SQL", detail: "Generated parameterized query from fixture schema"},
-        %{label: "Render chart data", detail: "Returned 12 monthly points for visualization"}
-      ],
-      result: """
-      SQL:
-      SELECT month, SUM(revenue) AS total_revenue
-      FROM analytics.monthly_revenue
-      WHERE year = 2025
-      GROUP BY month
-      ORDER BY month;
-      """
-    }
-  end
-
-  defp scenario_for("workflow-coordinator") do
-    %{
-      title: "Workflow Coordinator",
-      steps: [
-        %{label: "Plan graph", detail: "Built 4-node workflow with retry boundaries"},
-        %{label: "Dispatch workers", detail: "Started classifier, enricher, and notifier stages"},
-        %{label: "Recover fault", detail: "Injected node failure and replayed from checkpoint"}
-      ],
-      result: """
-      Workflow status:
-      - completed_nodes: 4/4
-      - retries: 1
-      - checkpoint_recovery: true
-      """
-    }
-  end
-
-  defp scenario_for(_slug) do
-    %{
-      title: "Simulated Example",
-      steps: [
-        %{label: "Load fixtures", detail: "Prepared deterministic demo inputs"},
-        %{label: "Execute flow", detail: "Ran scenario with no external calls"},
-        %{label: "Publish output", detail: "Returned stable simulated result"}
-      ],
-      result: "Demo completed in deterministic simulation mode."
-    }
-  end
+  defp scenario_for(slug), do: Map.get(@scenarios, slug, @default_scenario)
 end

--- a/lib/agent_jido_web/live/components/content_assistant_modal_component.ex
+++ b/lib/agent_jido_web/live/components/content_assistant_modal_component.ex
@@ -11,9 +11,32 @@ defmodule AgentJidoWeb.ContentAssistantModalComponent do
   alias AgentJido.QueryLogs
   alias Phoenix.LiveView.JS
 
+  import AgentJidoWeb.ContentAssistantSupport,
+    only: [
+      analytics_metadata: 2,
+      llm_enabled?: 1,
+      maybe_apply_search_response_mode: 2,
+      maybe_wait_for_progressive_dwell: 1,
+      monotonic_ms: 0,
+      normalize_feedback_note: 1,
+      normalize_feedback_value: 1,
+      normalize_query: 1,
+      query_latency_ms: 1,
+      require_turnstile?: 0,
+      reset_turnstile_widget: 1,
+      search_response_mode: 0,
+      search_retrieval_mode: 0,
+      source_label: 1,
+      turnstile_input_id: 1,
+      turnstile_retry_id: 1,
+      turnstile_site_key: 0,
+      turnstile_status_id: 1,
+      turnstile_submit_id: 1,
+      turnstile_widget_id: 1
+    ]
+
   @default_citation_limit 6
   @default_thread_limit 3
-  @default_progressive_swap_min_ms 1_200
 
   @type assistant_status :: :idle | :loading | :answer | :empty | :error
 
@@ -623,15 +646,6 @@ defmodule AgentJidoWeb.ContentAssistantModalComponent do
 
   defp should_start_progressive_enhancement?(_response, _enhancement_opts), do: false
 
-  defp llm_enabled?(opts) when is_list(opts) do
-    case Keyword.fetch(opts, :llm) do
-      {:ok, llm} -> not is_nil(llm)
-      :error -> not is_nil(Application.get_env(:arcana, :llm))
-    end
-  end
-
-  defp llm_enabled?(_opts), do: false
-
   defp assistant_opts(socket, turnstile_token, stage) do
     retrieval_opts = [mode: search_retrieval_mode(), graph: true]
 
@@ -754,11 +768,6 @@ defmodule AgentJidoWeb.ContentAssistantModalComponent do
 
   defp fallback_banner(_response), do: nil
 
-  defp source_label(:docs), do: "Docs"
-  defp source_label(:blog), do: "Blog"
-  defp source_label(:ecosystem), do: "Ecosystem"
-  defp source_label(_), do: "Content"
-
   defp mode_label(:llm), do: "LLM"
   defp mode_label(:deterministic), do: "Deterministic"
   defp mode_label(:deterministic_fallback), do: "Deterministic fallback"
@@ -768,31 +777,6 @@ defmodule AgentJidoWeb.ContentAssistantModalComponent do
 
   defp mode_label(mode) when is_atom(mode), do: mode |> Atom.to_string() |> String.replace("_", " ")
   defp mode_label(_mode), do: "Unknown"
-
-  defp normalize_query(query) when is_binary(query), do: String.trim(query)
-  defp normalize_query(_query), do: ""
-
-  defp normalize_feedback_value(value) when is_binary(value) do
-    case String.trim(value) do
-      "helpful" -> "helpful"
-      "not_helpful" -> "not_helpful"
-      _ -> nil
-    end
-  end
-
-  defp normalize_feedback_value(_value), do: nil
-
-  defp normalize_feedback_note(value) when is_binary(value) do
-    value
-    |> String.trim()
-    |> String.slice(0, 500)
-    |> case do
-      "" -> nil
-      note -> note
-    end
-  end
-
-  defp normalize_feedback_note(_value), do: nil
 
   defp normalize_rank(value) when is_integer(value) and value > 0, do: value
 
@@ -894,134 +878,15 @@ defmodule AgentJidoWeb.ContentAssistantModalComponent do
     })
   end
 
-  defp query_latency_ms(started_at) when is_integer(started_at) do
-    System.monotonic_time()
-    |> Kernel.-(started_at)
-    |> System.convert_time_unit(:native, :millisecond)
-  end
-
-  defp query_latency_ms(_started_at), do: 0
-
-  defp progressive_swap_min_ms do
-    case content_assistant_config() |> config_value(:progressive_swap_min_ms, @default_progressive_swap_min_ms) do
-      value when is_integer(value) and value >= 0 -> value
-      _ -> @default_progressive_swap_min_ms
-    end
-  end
-
-  defp maybe_wait_for_progressive_dwell(started_at_ms) when is_integer(started_at_ms) do
-    remaining_ms = progressive_swap_min_ms() - (monotonic_ms() - started_at_ms)
-
-    if remaining_ms > 0 do
-      Process.sleep(remaining_ms)
-    end
-  end
-
-  defp maybe_wait_for_progressive_dwell(_started_at_ms), do: :ok
-
-  defp monotonic_ms do
-    System.monotonic_time()
-    |> System.convert_time_unit(:native, :millisecond)
-  end
-
-  defp reset_turnstile_widget(socket) do
-    if socket.assigns[:turnstile_required] do
-      push_event(socket, "content_assistant_turnstile_reset", %{id: socket.assigns.turnstile_widget_id})
-    else
-      socket
-    end
-  end
-
-  defp turnstile_widget_id(id), do: "#{id}-turnstile"
-  defp turnstile_input_id(id), do: "#{id}-turnstile-token"
-  defp turnstile_submit_id(id), do: "#{id}-submit"
-  defp turnstile_status_id(id), do: "#{id}-turnstile-status"
-  defp turnstile_retry_id(id), do: "#{id}-turnstile-retry"
-
   defp component_id(socket, assigns) do
     Map.get(assigns, :id) || Map.get(socket.assigns, :id) || "primary-nav-content-assistant-modal"
   end
-
-  defp require_turnstile? do
-    turnstile_required =
-      content_assistant_config()
-      |> config_value(:require_turnstile, false)
-      |> truthy?()
-
-    search_response_mode() == :enhanced and turnstile_required
-  end
-
-  defp turnstile_site_key do
-    content_assistant_config()
-    |> config_value(:turnstile_site_key, nil)
-  end
-
-  defp analytics_metadata(%Response{} = response, metadata) when is_map(metadata) do
-    Map.merge(metadata, %{
-      answer_mode: response.answer_mode,
-      retrieval_status: response.retrieval_status,
-      llm_attempted: response.llm_attempted?,
-      llm_enhanced: response.llm_enhanced?,
-      enhancement_blocked_reason: response.enhancement_blocked_reason
-    })
-  end
-
-  defp analytics_metadata(_response, metadata) when is_map(metadata), do: metadata
 
   defp content_assistant_module do
     Application.get_env(:agent_jido, :content_assistant_module, ContentAssistant)
   end
 
-  defp content_assistant_config do
-    Application.get_env(:agent_jido, AgentJido.ContentAssistant, [])
-  end
-
-  defp config_value(config, key, default) when is_list(config), do: Keyword.get(config, key, default)
-  defp config_value(config, key, default) when is_map(config), do: Map.get(config, key, default)
-  defp config_value(_config, _key, default), do: default
-
-  defp truthy?(value), do: value in [true, "true", 1, "1", "on"]
-
-  defp maybe_apply_search_response_mode(opts, stage) when is_list(opts) do
-    case {search_response_mode(), stage} do
-      {:enhanced, _stage} ->
-        opts
-
-      {:deterministic, _stage} ->
-        opts
-        |> Keyword.put(:llm, nil)
-        |> Keyword.put(:require_turnstile, false)
-
-      {:progressive, :enhancement} ->
-        opts
-        |> Keyword.put_new(:llm, Application.get_env(:arcana, :llm))
-        |> Keyword.put(:require_turnstile, false)
-
-      {:progressive, _stage} ->
-        opts
-        |> Keyword.put(:llm, nil)
-        |> Keyword.put(:require_turnstile, false)
-    end
-  end
-
-  defp maybe_apply_search_response_mode(opts, _stage), do: opts
-
-  defp search_response_mode do
-    case content_assistant_config() |> config_value(:search_response_mode, :progressive) do
-      mode when mode in [:progressive, "progressive"] -> :progressive
-      mode when mode in [:enhanced, "enhanced"] -> :enhanced
-      _ -> :deterministic
-    end
-  end
-
   defp progressive_mode?, do: search_response_mode() == :progressive
-
-  defp search_retrieval_mode do
-    case content_assistant_config() |> config_value(:search_retrieval_mode, :hybrid) do
-      mode when mode in [:hybrid, "hybrid"] -> :hybrid
-      _ -> :fulltext
-    end
-  end
 
   defp analytics_module do
     Application.get_env(:agent_jido, :analytics_module, Analytics)

--- a/lib/agent_jido_web/live/content_assistant_live.ex
+++ b/lib/agent_jido_web/live/content_assistant_live.ex
@@ -12,13 +12,33 @@ defmodule AgentJidoWeb.ContentAssistantLive do
   alias AgentJido.QueryLogs
 
   import AgentJidoWeb.Jido.MarketingLayouts
+
+  import AgentJidoWeb.ContentAssistantSupport,
+    only: [
+      analytics_metadata: 2,
+      config_value: 3,
+      content_assistant_config: 0,
+      llm_enabled?: 1,
+      maybe_apply_search_response_mode: 2,
+      maybe_wait_for_progressive_dwell: 1,
+      monotonic_ms: 0,
+      normalize_feedback_note: 1,
+      normalize_feedback_value: 1,
+      normalize_query: 1,
+      require_turnstile?: 0,
+      reset_turnstile_widget: 1,
+      search_response_mode: 0,
+      search_retrieval_mode: 0,
+      source_label: 1,
+      turnstile_site_key: 0
+    ]
+
   require Logger
 
   @default_thread_limit 8
   @default_query_max_length 500
   @default_assistant_timeout_ms 12_000
   @default_citation_limit 6
-  @default_progressive_swap_min_ms 1_200
   @assistant_task_supervisor AgentJido.ContentAssistant.TaskSupervisor
 
   @telemetry_issued_event [:agent_jido, :content_assistant, :query, :issued]
@@ -965,15 +985,6 @@ defmodule AgentJidoWeb.ContentAssistantLive do
     )
   end
 
-  defp llm_enabled?(opts) when is_list(opts) do
-    case Keyword.fetch(opts, :llm) do
-      {:ok, llm} -> not is_nil(llm)
-      :error -> not is_nil(Application.get_env(:arcana, :llm))
-    end
-  end
-
-  defp llm_enabled?(_opts), do: false
-
   defp replace_latest_thread_entry([_latest | rest], %Response{} = response) do
     [
       %{
@@ -1068,31 +1079,6 @@ defmodule AgentJidoWeb.ContentAssistantLive do
   end
 
   defp validate_query(query, _max_length), do: {:ok, normalize_query(query)}
-
-  defp normalize_query(query) when is_binary(query), do: String.trim(query)
-  defp normalize_query(_query), do: ""
-
-  defp normalize_feedback_value(value) when is_binary(value) do
-    case String.trim(value) do
-      "helpful" -> "helpful"
-      "not_helpful" -> "not_helpful"
-      _ -> nil
-    end
-  end
-
-  defp normalize_feedback_value(_value), do: nil
-
-  defp normalize_feedback_note(value) when is_binary(value) do
-    value
-    |> String.trim()
-    |> String.slice(0, 500)
-    |> case do
-      "" -> nil
-      note -> note
-    end
-  end
-
-  defp normalize_feedback_note(_value), do: nil
 
   defp track_query_id(query, socket) when is_binary(query) do
     query_log_id =
@@ -1258,11 +1244,6 @@ defmodule AgentJidoWeb.ContentAssistantLive do
   defp related_queries(%Response{related_queries: related_queries}) when is_list(related_queries), do: related_queries
   defp related_queries(_response), do: []
 
-  defp source_label(:docs), do: "Docs"
-  defp source_label(:blog), do: "Blog"
-  defp source_label(:ecosystem), do: "Ecosystem"
-  defp source_label(_), do: "Content"
-
   defp mode_label(:llm), do: "LLM"
   defp mode_label(:deterministic), do: "Grounded"
   defp mode_label(:deterministic_fallback), do: "Grounded fallback"
@@ -1288,18 +1269,6 @@ defmodule AgentJidoWeb.ContentAssistantLive do
       query_log_id: nil
     }
   end
-
-  defp analytics_metadata(%Response{} = response, metadata) when is_map(metadata) do
-    Map.merge(metadata, %{
-      answer_mode: response.answer_mode,
-      retrieval_status: response.retrieval_status,
-      llm_attempted: response.llm_attempted?,
-      llm_enhanced: response.llm_enhanced?,
-      enhancement_blocked_reason: response.enhancement_blocked_reason
-    })
-  end
-
-  defp analytics_metadata(_response, metadata) when is_map(metadata), do: metadata
 
   defp assistant_opts(socket, turnstile_token, stage \\ :default) do
     retrieval_opts = [mode: search_retrieval_mode(), graph: true]
@@ -1358,100 +1327,7 @@ defmodule AgentJidoWeb.ContentAssistantLive do
     end
   end
 
-  defp progressive_swap_min_ms do
-    case content_assistant_config() |> config_value(:progressive_swap_min_ms, @default_progressive_swap_min_ms) do
-      value when is_integer(value) and value >= 0 -> value
-      _ -> @default_progressive_swap_min_ms
-    end
-  end
-
-  defp maybe_wait_for_progressive_dwell(started_at_ms) when is_integer(started_at_ms) do
-    remaining_ms = progressive_swap_min_ms() - (monotonic_ms() - started_at_ms)
-
-    if remaining_ms > 0 do
-      Process.sleep(remaining_ms)
-    end
-  end
-
-  defp maybe_wait_for_progressive_dwell(_started_at_ms), do: :ok
-
-  defp monotonic_ms do
-    System.monotonic_time()
-    |> System.convert_time_unit(:native, :millisecond)
-  end
-
-  defp reset_turnstile_widget(socket) do
-    if socket.assigns[:turnstile_required] do
-      push_event(socket, "content_assistant_turnstile_reset", %{id: socket.assigns.turnstile_widget_id})
-    else
-      socket
-    end
-  end
-
-  defp require_turnstile? do
-    turnstile_required =
-      content_assistant_config()
-      |> config_value(:require_turnstile, false)
-      |> truthy?()
-
-    search_response_mode() == :enhanced and turnstile_required
-  end
-
-  defp turnstile_site_key do
-    content_assistant_config()
-    |> config_value(:turnstile_site_key, nil)
-  end
-
-  defp content_assistant_config do
-    Application.get_env(:agent_jido, AgentJido.ContentAssistant, [])
-  end
-
-  defp config_value(config, key, default) when is_list(config), do: Keyword.get(config, key, default)
-  defp config_value(config, key, default) when is_map(config), do: Map.get(config, key, default)
-  defp config_value(_config, _key, default), do: default
-
-  defp truthy?(value), do: value in [true, "true", 1, "1", "on"]
-
-  defp maybe_apply_search_response_mode(opts, stage) when is_list(opts) do
-    case {search_response_mode(), stage} do
-      {:enhanced, _stage} ->
-        opts
-
-      {:deterministic, _stage} ->
-        opts
-        |> Keyword.put(:llm, nil)
-        |> Keyword.put(:require_turnstile, false)
-
-      {:progressive, :enhancement} ->
-        opts
-        |> Keyword.put_new(:llm, Application.get_env(:arcana, :llm))
-        |> Keyword.put(:require_turnstile, false)
-
-      {:progressive, _stage} ->
-        opts
-        |> Keyword.put(:llm, nil)
-        |> Keyword.put(:require_turnstile, false)
-    end
-  end
-
-  defp maybe_apply_search_response_mode(opts, _stage), do: opts
-
-  defp search_response_mode do
-    case content_assistant_config() |> config_value(:search_response_mode, :progressive) do
-      mode when mode in [:progressive, "progressive"] -> :progressive
-      mode when mode in [:enhanced, "enhanced"] -> :enhanced
-      _ -> :deterministic
-    end
-  end
-
   defp progressive_mode?, do: search_response_mode() == :progressive
-
-  defp search_retrieval_mode do
-    case content_assistant_config() |> config_value(:search_retrieval_mode, :hybrid) do
-      mode when mode in [:hybrid, "hybrid"] -> :hybrid
-      _ -> :fulltext
-    end
-  end
 
   defp analytics_module do
     Application.get_env(:agent_jido, :analytics_module, Analytics)


### PR DESCRIPTION
Closes #50

## Summary
- extract shared content assistant helper logic into a single support module
- extract shared runtime server lifecycle helpers for duplicated demo LiveViews
- replace repeated simulated showcase scenario clauses with a static scenario catalog

## Verification
- mix compile --warnings-as-errors
- mix test test/agent_jido/examples_test.exs test/agent_jido_web/live/jido_examples_live_test.exs test/agent_jido_web/live/search_live_test.exs test/agent_jido_web/live/components/content_assistant_modal_component_test.exs
- mix credo --strict
- mix test
- mix dialyzer