### PR TITLE
test(showcase): close community showcase gaps

### DIFF
--- a/priv/community_showcase/agent-jido-workbench.md
+++ b/priv/community_showcase/agent-jido-workbench.md
@@ -1,0 +1,14 @@
+%{
+  title: "Agent Jido Workbench",
+  description: "Reference Phoenix workbench for docs, demos, and ecosystem tooling across Jido.",
+  project_url: "https://jido.run",
+  repo_url: "https://github.com/agentjido/jido_run",
+  tags: ["internal", "reference"],
+  featured: true,
+  status: :draft,
+  sort_order: 10
+}
+---
+
+Internal showcase entry used to verify that draft community cards stay out of the public listing
+until they are explicitly promoted to `:live`.

--- a/test/agent_jido/community/showcase_test.exs
+++ b/test/agent_jido/community/showcase_test.exs
@@ -10,7 +10,6 @@ defmodule AgentJido.Community.ShowcaseTest do
     assert Enum.any?(projects, &(&1.slug == "loomkin"))
     assert Enum.any?(projects, &(&1.slug == "screentour"))
     refute Enum.any?(projects, &(&1.slug == "agent-jido-workbench"))
-    refute Enum.any?(projects, &(&1.slug == "jido-run"))
     assert Enum.all?(projects, &(&1.status == :live))
   end
 
@@ -24,6 +23,22 @@ defmodule AgentJido.Community.ShowcaseTest do
     assert is_list(project.tags)
     refute project.featured
     assert String.contains?(project.path, "/priv/community_showcase/")
+  end
+
+  test "draft showcase entries stay hidden unless drafts are requested" do
+    assert Showcase.get_project("agent-jido-workbench") == nil
+
+    project = Showcase.get_project!("agent-jido-workbench", include_drafts: true)
+
+    assert project.title == "Agent Jido Workbench"
+    assert project.status == :draft
+    assert project.featured
+    assert String.starts_with?(project.project_url, "https://")
+
+    assert Showcase.project_count(include_drafts: true) == Showcase.project_count() + 1
+
+    assert Enum.any?(Showcase.all_projects(include_drafts: true), &(&1.slug == "agent-jido-workbench"))
+    assert Enum.any?(Showcase.featured_projects(include_drafts: true), &(&1.slug == "agent-jido-workbench"))
   end
 
   test "missing showcase project raises a not found error" do

--- a/test/agent_jido_web/live/page_live_test.exs
+++ b/test/agent_jido_web/live/page_live_test.exs
@@ -522,9 +522,10 @@ defmodule AgentJidoWeb.PageLiveTest do
       assert html =~ "Community Showcase"
       assert html =~ "Loomkin"
       assert html =~ "ScreenTour"
+      assert html =~ "Submit Project"
       assert html =~ ~s(id="showcase-project-loomkin")
       refute html =~ "Agent Jido Workbench"
-      refute html =~ ~s(id="showcase-project-jido-run")
+      refute html =~ ~s(id="showcase-project-agent-jido-workbench")
       assert html =~ "SUBMIT YOUR PROJECT"
     end
 


### PR DESCRIPTION
Closes #32

## Summary
- add a draft showcase entry so the structured loader exercises hidden community cards
- extend showcase tests to verify draft inclusion and exclusion behavior
- tighten the community showcase route assertions around public card rendering and submission CTA

## Verification
- mix compile --warnings-as-errors
- mix test test/agent_jido/community/showcase_test.exs test/agent_jido_web/live/page_live_test.exs test/agent_jido_web/controllers/llm_response_plug_test.exs test/agent_jido_web/controllers/sitemap_controller_test.exs
- mix credo --strict
- mix test
- mix dialyzer