### PR TITLE
feat(mcp): add docs query server

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,28 @@ mix quality
 
 `mix quality` now runs the strict Credo baseline, warnings-as-errors compile, and Dialyzer. The managed `pre_push` hook also runs `mix credo --strict`, `mix test`, and `mix dialyzer`.
 
+## MCP Docs Server
+
+The workbench now ships a read-only MCP docs server for the published documentation corpus.
+
+- `stdio` entrypoint: `mix mcp.docs`
+- public HTTP endpoint: `POST /mcp/docs`
+- v1 tools: `search_docs`, `get_doc`, `list_sections`
+- v1 scope: docs only
+
+Notes:
+
+- The MCP server reads from the same docs Arcana collection populated by the local content ingestion flow.
+- Search uses the existing hybrid retrieval pipeline and falls back to lexical docs search when the Arcana backend fails.
+- `get_doc` returns markdown plus canonical metadata for docs routes.
+- Compile the project before launching `mix mcp.docs` from an MCP client so stdout stays reserved for JSON-RPC.
+
+If you need to refresh the underlying search index locally, run:
+
+```bash
+mix content.ingest.local
+```
+
 ## Content Layout
 
 - `priv/content_plan/**` contains content briefs and planning docs.

--- a/config/config.exs
+++ b/config/config.exs
@@ -66,6 +66,15 @@ config :agent_jido, AgentJido.ContentAssistant,
   search_retrieval_mode: :hybrid,
   progressive_swap_min_ms: 1_200
 
+config :agent_jido, AgentJido.MCP,
+  protocol_version: "2025-11-25",
+  server_name: "agent_jido_docs",
+  http_max_body_bytes: 32_768,
+  http_rate_limit_max_requests: 60,
+  http_rate_limit_window_seconds: 60,
+  search_limit: 10,
+  query_max_length: 500
+
 config :agent_jido, AgentJidoWeb.ContentOpsGithubLive,
   owner: "agentjido",
   repo: "agentjido_xyz",

--- a/lib/agent_jido/mcp.ex
+++ b/lib/agent_jido/mcp.ex
@@ -1,0 +1,104 @@
+defmodule AgentJido.MCP do
+  @moduledoc """
+  Shared configuration and helper functions for the MCP server surfaces.
+  """
+
+  @default_protocol_version "2025-11-25"
+  @default_http_max_body_bytes 32_768
+  @default_http_rate_limit_max_requests 60
+  @default_http_rate_limit_window_seconds 60
+  @default_search_limit 10
+  @max_search_limit 20
+  @default_query_max_length 500
+
+  @type config_opt ::
+          {:protocol_version, String.t()}
+          | {:http_max_body_bytes, pos_integer()}
+          | {:http_rate_limit_max_requests, pos_integer()}
+          | {:http_rate_limit_window_seconds, pos_integer()}
+          | {:search_limit, pos_integer()}
+          | {:query_max_length, pos_integer()}
+          | {:server_name, String.t()}
+
+  @spec config() :: keyword()
+  def config do
+    Application.get_env(:agent_jido, __MODULE__, [])
+  end
+
+  @spec protocol_version() :: String.t()
+  def protocol_version do
+    config()
+    |> Keyword.get(:protocol_version, @default_protocol_version)
+    |> normalize_string(@default_protocol_version)
+  end
+
+  @spec server_name() :: String.t()
+  def server_name do
+    config()
+    |> Keyword.get(:server_name, "agent_jido_docs")
+    |> normalize_string("agent_jido_docs")
+  end
+
+  @spec server_version() :: String.t()
+  def server_version do
+    :agent_jido
+    |> Application.spec(:vsn)
+    |> case do
+      nil -> "0.0.0"
+      version -> List.to_string(version)
+    end
+  end
+
+  @spec http_max_body_bytes() :: pos_integer()
+  def http_max_body_bytes do
+    config()
+    |> Keyword.get(:http_max_body_bytes, @default_http_max_body_bytes)
+    |> normalize_positive_integer(@default_http_max_body_bytes)
+  end
+
+  @spec http_rate_limit_max_requests() :: pos_integer()
+  def http_rate_limit_max_requests do
+    config()
+    |> Keyword.get(:http_rate_limit_max_requests, @default_http_rate_limit_max_requests)
+    |> normalize_positive_integer(@default_http_rate_limit_max_requests)
+  end
+
+  @spec http_rate_limit_window_seconds() :: pos_integer()
+  def http_rate_limit_window_seconds do
+    config()
+    |> Keyword.get(:http_rate_limit_window_seconds, @default_http_rate_limit_window_seconds)
+    |> normalize_positive_integer(@default_http_rate_limit_window_seconds)
+  end
+
+  @spec default_search_limit() :: pos_integer()
+  def default_search_limit do
+    config()
+    |> Keyword.get(:search_limit, @default_search_limit)
+    |> normalize_positive_integer(@default_search_limit)
+  end
+
+  @spec max_search_limit() :: pos_integer()
+  def max_search_limit, do: @max_search_limit
+
+  @spec query_max_length() :: pos_integer()
+  def query_max_length do
+    config()
+    |> Keyword.get(:query_max_length, @default_query_max_length)
+    |> normalize_positive_integer(@default_query_max_length)
+  end
+
+  @spec endpoint_url() :: String.t()
+  def endpoint_url do
+    AgentJidoWeb.Endpoint.url()
+    |> String.trim_trailing("/")
+  end
+
+  @spec canonical_url(String.t()) :: String.t()
+  def canonical_url(path) when is_binary(path), do: endpoint_url() <> path
+
+  defp normalize_positive_integer(value, _default) when is_integer(value) and value > 0, do: value
+  defp normalize_positive_integer(_value, default), do: default
+
+  defp normalize_string(value, _default) when is_binary(value) and value != "", do: value
+  defp normalize_string(_value, default), do: default
+end

--- a/lib/agent_jido/mcp/docs_tools.ex
+++ b/lib/agent_jido/mcp/docs_tools.ex
@@ -1,0 +1,510 @@
+defmodule AgentJido.MCP.DocsTools do
+  @moduledoc """
+  MCP tool implementations for read-only documentation retrieval.
+  """
+
+  alias AgentJido.ContentAssistant.Result
+  alias AgentJido.ContentAssistant.Retrieval
+  alias AgentJido.ContentAssistant.URL
+  alias AgentJido.MCP
+  alias AgentJido.Pages
+  alias AgentJidoWeb.MarkdownContent
+
+  @docs_collection ["site_docs"]
+
+  @type tool_result :: %{
+          required(String.t()) => term()
+        }
+
+  @spec tools() :: [map()]
+  def tools do
+    [
+      %{
+        "name" => "search_docs",
+        "description" => "Search Agent Jido documentation pages with citation-friendly snippets.",
+        "inputSchema" => search_docs_input_schema(),
+        "outputSchema" => search_docs_output_schema()
+      },
+      %{
+        "name" => "get_doc",
+        "description" => "Fetch the markdown payload and metadata for a documentation page by path.",
+        "inputSchema" => get_doc_input_schema(),
+        "outputSchema" => get_doc_output_schema()
+      },
+      %{
+        "name" => "list_sections",
+        "description" => "List the published documentation sections and their visible child pages.",
+        "inputSchema" => list_sections_input_schema(),
+        "outputSchema" => list_sections_output_schema()
+      }
+    ]
+  end
+
+  @spec call_tool(String.t(), map(), keyword()) :: {:ok, tool_result()} | {:error, map()}
+  def call_tool("search_docs", arguments, opts), do: search_docs(arguments, opts)
+  def call_tool("get_doc", arguments, opts), do: get_doc(arguments, opts)
+  def call_tool("list_sections", arguments, opts), do: list_sections(arguments, opts)
+
+  def call_tool(name, _arguments, _opts) do
+    {:error, %{"code" => "unknown_tool", "message" => "Unknown tool #{inspect(name)}"}}
+  end
+
+  @spec search_docs(map(), keyword()) :: {:ok, tool_result()} | {:error, map()}
+  def search_docs(arguments, opts) when is_map(arguments) and is_list(opts) do
+    with {:ok, query} <- require_non_empty_string(arguments, "query", MCP.query_max_length()),
+         {:ok, limit} <- optional_limit(arguments, "limit", MCP.default_search_limit(), MCP.max_search_limit()) do
+      retrieval_module = Keyword.get(opts, :retrieval_module, Retrieval)
+      retrieval_opts = Keyword.get(opts, :retrieval_opts, [])
+
+      retrieval_opts =
+        retrieval_opts
+        |> Keyword.put(:collections, @docs_collection)
+        |> Keyword.put_new(:mode, :hybrid)
+        |> Keyword.put_new(:limit, limit)
+        |> Keyword.put_new(:fallback_fun, &docs_local_fallback/2)
+
+      {results, retrieval_status} =
+        case retrieval_module.query_with_status(query, retrieval_opts) do
+          {:ok, rows, status} -> {normalize_search_results(rows, limit), normalize_status(status)}
+          {:ok, rows} -> {normalize_search_results(rows, limit), "success"}
+          _other -> {[], "fallback"}
+        end
+
+      structured =
+        %{
+          "query" => query,
+          "retrieval_status" => retrieval_status,
+          "results" => results
+        }
+
+      {:ok,
+       tool_result(
+         "Found #{length(results)} documentation result#{if length(results) == 1, do: "", else: "s"} for #{inspect(query)}.",
+         structured
+       )}
+    end
+  end
+
+  def search_docs(_arguments, _opts) do
+    {:error, %{"code" => "invalid_arguments", "message" => "search_docs expects an object argument"}}
+  end
+
+  @spec get_doc(map(), keyword()) :: {:ok, tool_result()} | {:error, map()}
+  def get_doc(arguments, opts) when is_map(arguments) and is_list(opts) do
+    with {:ok, requested_path} <- require_non_empty_string(arguments, "path"),
+         {:ok, normalized_path} <- normalize_doc_path(requested_path),
+         {:ok, page, resolution} <- resolve_docs_page(normalized_path, opts),
+         {:ok, markdown} <- resolve_markdown(Pages.route_for(page), opts) do
+      canonical_path = Pages.route_for(page)
+
+      structured =
+        %{
+          "title" => page.title,
+          "path" => canonical_path,
+          "canonical_url" => MCP.canonical_url(canonical_path),
+          "section" => Pages.docs_section_for_path(canonical_path),
+          "markdown" => markdown,
+          "github_url" => page.github_url,
+          "livebook_url" => page.livebook_url,
+          "legacy_resolution" => legacy_resolution_payload(normalized_path, canonical_path, resolution)
+        }
+        |> Enum.reject(fn {_key, value} -> is_nil(value) end)
+        |> Map.new()
+
+      {:ok, tool_result(markdown, structured)}
+    end
+  end
+
+  def get_doc(_arguments, _opts) do
+    {:error, %{"code" => "invalid_arguments", "message" => "get_doc expects an object argument"}}
+  end
+
+  @spec list_sections(map(), keyword()) :: {:ok, tool_result()} | {:error, map()}
+  def list_sections(arguments, opts) when is_map(arguments) and is_list(opts) do
+    if map_size(arguments) > 0 do
+      {:error, %{"code" => "invalid_arguments", "message" => "list_sections does not accept arguments"}}
+    else
+      pages_module = Keyword.get(opts, :pages_module, Pages)
+
+      sections =
+        pages_module.docs_sections()
+        |> Enum.map(fn root ->
+          section = pages_module.docs_section_for_path(root.path)
+          section_pages = pages_module.docs_section_pages(section)
+          child_pages = Enum.reject(section_pages, &(&1.path == root.path))
+
+          %{
+            "title" => root.title,
+            "path" => root.path,
+            "canonical_url" => MCP.canonical_url(root.path),
+            "section" => section,
+            "page_count" => length(section_pages),
+            "pages" =>
+              Enum.map(child_pages, fn page ->
+                %{
+                  "title" => page.title,
+                  "path" => page.path,
+                  "canonical_url" => MCP.canonical_url(page.path),
+                  "description" => page.description
+                }
+                |> Enum.reject(fn {_key, value} -> is_nil(value) end)
+                |> Map.new()
+              end)
+          }
+        end)
+
+      structured = %{"sections" => sections}
+
+      {:ok,
+       tool_result(
+         "Listed #{length(sections)} documentation section#{if length(sections) == 1, do: "", else: "s"}.",
+         structured
+       )}
+    end
+  end
+
+  def list_sections(_arguments, _opts) do
+    {:error, %{"code" => "invalid_arguments", "message" => "list_sections expects an object argument"}}
+  end
+
+  defp tool_result(text, structured_content) do
+    %{
+      "content" => [%{"type" => "text", "text" => text}],
+      "structuredContent" => structured_content,
+      "isError" => false
+    }
+  end
+
+  defp normalize_search_results(rows, limit) when is_list(rows) do
+    rows
+    |> Enum.map(&normalize_search_result/1)
+    |> Enum.reject(&is_nil/1)
+    |> Enum.take(limit)
+  end
+
+  defp normalize_search_results(_rows, _limit), do: []
+
+  defp normalize_search_result(%Result{} = result) do
+    case normalize_doc_path(result.url) do
+      {:ok, path} ->
+        %{
+          "title" => result.title,
+          "path" => path,
+          "canonical_url" => MCP.canonical_url(path),
+          "section" => Pages.docs_section_for_path(path),
+          "snippet" => result.snippet,
+          "score" => result.score
+        }
+        |> Enum.reject(fn {_key, value} -> is_nil(value) end)
+        |> Map.new()
+
+      _ ->
+        nil
+    end
+  end
+
+  defp normalize_search_result(%{title: title, snippet: snippet, url: url} = result) do
+    normalize_search_result(%Result{
+      title: title,
+      snippet: snippet,
+      url: url,
+      source_type: :docs,
+      score: Map.get(result, :score) || Map.get(result, "score")
+    })
+  end
+
+  defp normalize_search_result(_result), do: nil
+
+  defp docs_local_fallback(query, opts) do
+    limit =
+      case Keyword.get(opts, :limit, MCP.default_search_limit()) do
+        value when is_integer(value) and value > 0 -> value
+        _ -> MCP.default_search_limit()
+      end
+
+    terms = tokenize(query)
+    query_downcase = String.downcase(String.trim(query))
+
+    if terms == [] do
+      []
+    else
+      Pages.pages_by_category(:docs)
+      |> Enum.map(&fallback_result(&1, terms, query_downcase))
+      |> Enum.reject(&is_nil/1)
+      |> Enum.sort_by(&(&1.score || 0.0), :desc)
+      |> Enum.take(limit)
+    end
+  end
+
+  defp fallback_result(page, terms, query_downcase) do
+    searchable_text =
+      [page.description, strip_html(page.body), Enum.join(page.tags || [], " ")]
+      |> Enum.filter(&is_binary/1)
+      |> Enum.join(" ")
+
+    score = lexical_score(page.title, searchable_text, terms, query_downcase)
+
+    if score > 0 do
+      %Result{
+        title: page.title,
+        snippet: truncate_text(searchable_text, 320),
+        url: page.path,
+        source_type: :docs,
+        score: score
+      }
+    end
+  end
+
+  defp normalize_status(:fallback), do: "fallback"
+  defp normalize_status(_status), do: "success"
+
+  defp resolve_docs_page(path, opts) do
+    pages_module = Keyword.get(opts, :pages_module, Pages)
+
+    case pages_module.resolve_page_for_path(path) do
+      {:ok, %{category: :docs} = page, resolution} ->
+        {:ok, page, resolution}
+
+      {:ok, _page, _resolution} ->
+        {:error, %{"code" => "not_found", "message" => "No documentation page exists for #{inspect(path)}"}}
+
+      :error ->
+        {:error, %{"code" => "not_found", "message" => "No documentation page exists for #{inspect(path)}"}}
+    end
+  end
+
+  defp resolve_markdown(path, opts) do
+    markdown_resolver = Keyword.get(opts, :markdown_resolver, &MarkdownContent.resolve/2)
+
+    case markdown_resolver.(path, MCP.canonical_url(path)) do
+      {:ok, markdown} when is_binary(markdown) -> {:ok, markdown}
+      _other -> {:error, %{"code" => "not_found", "message" => "Could not resolve markdown for #{inspect(path)}"}}
+    end
+  end
+
+  defp legacy_resolution_payload(_requested_path, _canonical_path, :canonical), do: nil
+
+  defp legacy_resolution_payload(requested_path, canonical_path, resolution) do
+    %{
+      "requested_path" => requested_path,
+      "resolved_path" => canonical_path,
+      "resolution" => to_string(resolution)
+    }
+  end
+
+  defp require_non_empty_string(arguments, key, max_length \\ nil) when is_map(arguments) and is_binary(key) do
+    value =
+      arguments
+      |> Map.get(key)
+      |> case do
+        binary when is_binary(binary) -> String.trim(binary)
+        _other -> ""
+      end
+
+    cond do
+      value == "" ->
+        {:error, %{"code" => "invalid_arguments", "message" => "#{key} must be a non-empty string"}}
+
+      is_integer(max_length) and String.length(value) > max_length ->
+        {:error,
+         %{
+           "code" => "invalid_arguments",
+           "message" => "#{key} must be #{max_length} characters or fewer"
+         }}
+
+      true ->
+        {:ok, value}
+    end
+  end
+
+  defp optional_limit(arguments, key, default, max_limit) when is_map(arguments) do
+    case Map.get(arguments, key, default) do
+      value when is_integer(value) and value > 0 and value <= max_limit -> {:ok, value}
+      value when is_integer(value) -> {:error, %{"code" => "invalid_arguments", "message" => "#{key} must be between 1 and #{max_limit}"}}
+      nil -> {:ok, default}
+      _other -> {:error, %{"code" => "invalid_arguments", "message" => "#{key} must be an integer"}}
+    end
+  end
+
+  defp normalize_doc_path(value) when is_binary(value) do
+    value
+    |> String.trim()
+    |> URL.normalize_href()
+    |> case do
+      nil -> {:error, %{"code" => "invalid_arguments", "message" => "path must be a valid path or same-site URL"}}
+      normalized -> normalized |> strip_markdown_suffix() |> ensure_docs_path()
+    end
+  end
+
+  defp normalize_doc_path(_value) do
+    {:error, %{"code" => "invalid_arguments", "message" => "path must be a string"}}
+  end
+
+  defp strip_markdown_suffix(path) do
+    if String.ends_with?(path, ".md"), do: String.trim_trailing(path, ".md"), else: path
+  end
+
+  defp ensure_docs_path("/docs" <> _rest = path), do: {:ok, path}
+
+  defp ensure_docs_path(path) do
+    {:error, %{"code" => "not_found", "message" => "No documentation page exists for #{inspect(path)}"}}
+  end
+
+  defp tokenize(query) do
+    query
+    |> String.downcase()
+    |> String.split(~r/[^[:alnum:]_]+/u, trim: true)
+    |> Enum.uniq()
+  end
+
+  defp lexical_score(title, searchable_text, terms, query_downcase)
+       when is_binary(title) and is_binary(searchable_text) and is_binary(query_downcase) do
+    title_down = String.downcase(title)
+    text_down = String.downcase(searchable_text)
+
+    phrase_title_bonus = if query_downcase != "" and String.contains?(title_down, query_downcase), do: 6.0, else: 0.0
+    phrase_text_bonus = if query_downcase != "" and String.contains?(text_down, query_downcase), do: 3.0, else: 0.0
+
+    term_bonus =
+      Enum.reduce(terms, 0.0, fn term, acc ->
+        title_hits = count_occurrences(title_down, term) * 2
+        text_hits = count_occurrences(text_down, term)
+        acc + title_hits + text_hits
+      end)
+
+    phrase_title_bonus + phrase_text_bonus + term_bonus
+  end
+
+  defp count_occurrences(_text, term) when term in [nil, ""], do: 0
+
+  defp count_occurrences(text, term) when is_binary(text) do
+    text
+    |> String.split(term)
+    |> length()
+    |> Kernel.-(1)
+    |> max(0)
+  end
+
+  defp strip_html(text) when is_binary(text) do
+    text
+    |> String.replace(~r/<[^>]*>/u, " ")
+    |> String.replace(~r/\s+/u, " ")
+    |> String.trim()
+  end
+
+  defp strip_html(_text), do: ""
+
+  defp truncate_text(text, max_len) when is_binary(text) and is_integer(max_len) do
+    if String.length(text) <= max_len, do: text, else: String.slice(text, 0, max_len) <> "..."
+  end
+
+  defp search_docs_input_schema do
+    %{
+      "type" => "object",
+      "additionalProperties" => false,
+      "required" => ["query"],
+      "properties" => %{
+        "query" => %{"type" => "string", "minLength" => 1, "maxLength" => MCP.query_max_length()},
+        "limit" => %{"type" => "integer", "minimum" => 1, "maximum" => MCP.max_search_limit()}
+      }
+    }
+  end
+
+  defp search_docs_output_schema do
+    %{
+      "type" => "object",
+      "required" => ["query", "retrieval_status", "results"],
+      "properties" => %{
+        "query" => %{"type" => "string"},
+        "retrieval_status" => %{"type" => "string", "enum" => ["success", "fallback"]},
+        "results" => %{
+          "type" => "array",
+          "items" => %{
+            "type" => "object",
+            "required" => ["title", "path", "canonical_url", "section", "snippet"],
+            "properties" => %{
+              "title" => %{"type" => "string"},
+              "path" => %{"type" => "string"},
+              "canonical_url" => %{"type" => "string"},
+              "section" => %{"type" => "string"},
+              "snippet" => %{"type" => "string"},
+              "score" => %{"type" => "number"}
+            }
+          }
+        }
+      }
+    }
+  end
+
+  defp get_doc_input_schema do
+    %{
+      "type" => "object",
+      "additionalProperties" => false,
+      "required" => ["path"],
+      "properties" => %{
+        "path" => %{"type" => "string", "minLength" => 1}
+      }
+    }
+  end
+
+  defp get_doc_output_schema do
+    %{
+      "type" => "object",
+      "required" => ["title", "path", "canonical_url", "section", "markdown", "github_url"],
+      "properties" => %{
+        "title" => %{"type" => "string"},
+        "path" => %{"type" => "string"},
+        "canonical_url" => %{"type" => "string"},
+        "section" => %{"type" => "string"},
+        "markdown" => %{"type" => "string"},
+        "github_url" => %{"type" => "string"},
+        "livebook_url" => %{"type" => "string"},
+        "legacy_resolution" => %{"type" => "object"}
+      }
+    }
+  end
+
+  defp list_sections_input_schema do
+    %{
+      "type" => "object",
+      "additionalProperties" => false,
+      "properties" => %{}
+    }
+  end
+
+  defp list_sections_output_schema do
+    %{
+      "type" => "object",
+      "required" => ["sections"],
+      "properties" => %{
+        "sections" => %{
+          "type" => "array",
+          "items" => %{
+            "type" => "object",
+            "required" => ["title", "path", "canonical_url", "section", "page_count", "pages"],
+            "properties" => %{
+              "title" => %{"type" => "string"},
+              "path" => %{"type" => "string"},
+              "canonical_url" => %{"type" => "string"},
+              "section" => %{"type" => "string"},
+              "page_count" => %{"type" => "integer"},
+              "pages" => %{
+                "type" => "array",
+                "items" => %{
+                  "type" => "object",
+                  "required" => ["title", "path", "canonical_url"],
+                  "properties" => %{
+                    "title" => %{"type" => "string"},
+                    "path" => %{"type" => "string"},
+                    "canonical_url" => %{"type" => "string"},
+                    "description" => %{"type" => "string"}
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  end
+end

--- a/lib/agent_jido/mcp/server.ex
+++ b/lib/agent_jido/mcp/server.ex
@@ -1,0 +1,234 @@
+defmodule AgentJido.MCP.Server do
+  @moduledoc """
+  Transport-neutral MCP server core for the docs tool surface.
+  """
+
+  alias AgentJido.MCP
+  alias AgentJido.MCP.DocsTools
+
+  @server_not_initialized_code -32_002
+  @invalid_request_code -32_600
+  @method_not_found_code -32_601
+  @invalid_params_code -32_602
+  @internal_error_code -32_603
+
+  defmodule State do
+    @moduledoc false
+    defstruct initialized?: false, protocol_version: nil, client_info: %{}
+
+    @type t :: %__MODULE__{
+            initialized?: boolean(),
+            protocol_version: String.t() | nil,
+            client_info: map()
+          }
+  end
+
+  @type response_tuple ::
+          {:reply, map(), State.t()}
+          | {:noreply, State.t()}
+
+  @spec new(keyword()) :: State.t()
+  def new(opts \\ []) do
+    %State{protocol_version: Keyword.get(opts, :protocol_version, MCP.protocol_version())}
+  end
+
+  @spec handle_message(map(), State.t(), keyword()) :: response_tuple()
+  def handle_message(message, state, opts \\ [])
+
+  def handle_message(message, %State{} = state, opts) when is_map(message) and is_list(opts) do
+    case normalize_request(message) do
+      {:ok, request} ->
+        dispatch(request, state, opts)
+
+      {:error, {code, error_message, id}} ->
+        {:reply, error_response(id, code, error_message), state}
+    end
+  end
+
+  def handle_message(_message, %State{} = state, _opts) do
+    {:reply, error_response(nil, @invalid_request_code, "Invalid JSON-RPC request"), state}
+  end
+
+  @spec handle_http_message(map(), keyword()) :: {:reply, map()} | :noreply
+  def handle_http_message(message, opts \\ [])
+
+  def handle_http_message(message, opts) when is_map(message) and is_list(opts) do
+    method = Map.get(message, "method")
+
+    state =
+      case method do
+        "initialize" -> new(opts)
+        _other -> %State{initialized?: true, protocol_version: Keyword.get(opts, :protocol_version, MCP.protocol_version())}
+      end
+
+    case handle_message(message, state, opts) do
+      {:reply, response, _state} -> {:reply, response}
+      {:noreply, _state} -> :noreply
+    end
+  end
+
+  def handle_http_message(_message, _opts), do: {:reply, error_response(nil, @invalid_request_code, "Invalid JSON-RPC request")}
+
+  defp dispatch(%{method: "ping", id: nil}, state, _opts), do: {:noreply, state}
+
+  defp dispatch(%{method: "ping", id: id}, state, _opts) do
+    {:reply, success_response(id, %{}), state}
+  end
+
+  defp dispatch(%{method: "initialize", id: nil}, state, _opts), do: {:noreply, %{state | initialized?: true}}
+
+  defp dispatch(%{method: "initialize", id: id, params: params}, state, opts) do
+    protocol_version = Keyword.get(opts, :protocol_version, MCP.protocol_version())
+
+    next_state = %State{
+      state
+      | initialized?: true,
+        protocol_version: protocol_version,
+        client_info: normalize_map(Map.get(params, "clientInfo", %{}))
+    }
+
+    result = %{
+      "protocolVersion" => protocol_version,
+      "capabilities" => %{
+        "tools" => %{"listChanged" => false}
+      },
+      "serverInfo" => %{
+        "name" => MCP.server_name(),
+        "version" => MCP.server_version()
+      },
+      "instructions" => "Read-only documentation MCP server for Agent Jido. Available tools: search_docs, get_doc, list_sections."
+    }
+
+    {:reply, success_response(id, result), next_state}
+  end
+
+  defp dispatch(%{method: "notifications/initialized"}, state, _opts) do
+    {:noreply, %{state | initialized?: true}}
+  end
+
+  defp dispatch(%{method: "tools/list", id: id}, %State{initialized?: false} = state, _opts) do
+    {:reply, error_response(id, @server_not_initialized_code, "Server not initialized"), state}
+  end
+
+  defp dispatch(%{method: "tools/list", id: nil}, state, _opts), do: {:noreply, state}
+
+  defp dispatch(%{method: "tools/list", id: id}, state, opts) do
+    tools_module = Keyword.get(opts, :tools_module, DocsTools)
+    {:reply, success_response(id, %{"tools" => tools_module.tools()}), state}
+  end
+
+  defp dispatch(%{method: "tools/call", id: id}, %State{initialized?: false} = state, _opts) do
+    {:reply, error_response(id, @server_not_initialized_code, "Server not initialized"), state}
+  end
+
+  defp dispatch(%{method: "tools/call", id: nil}, state, _opts), do: {:noreply, state}
+
+  defp dispatch(%{method: "tools/call", id: id, params: params}, state, opts) do
+    tools_module = Keyword.get(opts, :tools_module, DocsTools)
+    tool_opts = Keyword.get(opts, :tool_opts, [])
+
+    with {:ok, tool_name} <- fetch_non_empty_string(params, "name"),
+         {:ok, arguments} <- fetch_arguments(params) do
+      case tools_module.call_tool(tool_name, arguments, tool_opts) do
+        {:ok, result} ->
+          {:reply, success_response(id, result), state}
+
+        {:error, %{"code" => code, "message" => message} = error} ->
+          tool_error =
+            %{
+              "content" => [%{"type" => "text", "text" => message}],
+              "structuredContent" => %{"ok" => false, "error" => error},
+              "isError" => true
+            }
+            |> maybe_put_error_code(code)
+
+          {:reply, success_response(id, tool_error), state}
+
+        _other ->
+          {:reply, error_response(id, @internal_error_code, "Tool dispatch failed"), state}
+      end
+    else
+      {:error, message} ->
+        {:reply, error_response(id, @invalid_params_code, message), state}
+    end
+  end
+
+  defp dispatch(%{method: nil}, state, _opts), do: {:noreply, state}
+
+  defp dispatch(%{method: _method, id: id}, state, _opts) do
+    {:reply, error_response(id, @method_not_found_code, "Method not found"), state}
+  end
+
+  defp normalize_request(%{"jsonrpc" => "2.0", "method" => method} = request) when is_binary(method) do
+    {:ok,
+     %{
+       id: Map.get(request, "id"),
+       method: method,
+       params: normalize_map(Map.get(request, "params", %{}))
+     }}
+  end
+
+  defp normalize_request(%{"jsonrpc" => "2.0"} = request) do
+    if Map.has_key?(request, "result") or Map.has_key?(request, "error") do
+      {:ok, %{id: Map.get(request, "id"), method: nil, params: %{}}}
+    else
+      {:error, {@invalid_request_code, "Invalid JSON-RPC request", nil}}
+    end
+  end
+
+  defp normalize_request(%{"method" => _method} = request) do
+    {:error, {@invalid_request_code, "jsonrpc must be \"2.0\"", Map.get(request, "id")}}
+  end
+
+  defp normalize_request(_request) do
+    {:error, {@invalid_request_code, "Invalid JSON-RPC request", nil}}
+  end
+
+  defp fetch_non_empty_string(params, key) when is_map(params) do
+    case Map.get(params, key) do
+      value when is_binary(value) ->
+        trimmed = String.trim(value)
+
+        if trimmed != "" do
+          {:ok, trimmed}
+        else
+          {:error, "#{key} must be a non-empty string"}
+        end
+
+      _other ->
+        {:error, "#{key} must be a non-empty string"}
+    end
+  end
+
+  defp fetch_arguments(params) when is_map(params) do
+    case Map.get(params, "arguments", %{}) do
+      nil -> {:ok, %{}}
+      arguments when is_map(arguments) -> {:ok, normalize_map(arguments)}
+      _other -> {:error, "arguments must be an object"}
+    end
+  end
+
+  defp normalize_map(map) when is_map(map), do: map
+  defp normalize_map(_map), do: %{}
+
+  defp success_response(id, result) do
+    %{"jsonrpc" => "2.0", "id" => id, "result" => result}
+  end
+
+  defp error_response(id, code, message) do
+    %{
+      "jsonrpc" => "2.0",
+      "id" => id,
+      "error" => %{
+        "code" => code,
+        "message" => message
+      }
+    }
+  end
+
+  defp maybe_put_error_code(tool_error, code) when is_binary(code) do
+    put_in(tool_error, ["structuredContent", "error", "code"], code)
+  end
+
+  defp maybe_put_error_code(tool_error, _code), do: tool_error
+end

--- a/lib/agent_jido/mcp/stdio.ex
+++ b/lib/agent_jido/mcp/stdio.ex
@@ -1,0 +1,67 @@
+defmodule AgentJido.MCP.Stdio do
+  @moduledoc """
+  Newline-delimited stdio transport for the docs MCP server.
+  """
+
+  alias AgentJido.MCP.Server
+
+  @spec run(keyword()) :: no_return()
+  def run(opts \\ []) when is_list(opts) do
+    loop(Server.new(opts), opts)
+  end
+
+  defp loop(state, opts) do
+    case IO.binread(:stdio, :line) do
+      :eof ->
+        exit(:normal)
+
+      {:error, reason} ->
+        IO.binwrite(:stderr, "[mcp-docs] stdin read failed: #{inspect(reason)}\n")
+        exit(:normal)
+
+      line when is_binary(line) ->
+        next_state =
+          line
+          |> String.trim()
+          |> handle_line(state, opts)
+
+        loop(next_state, opts)
+    end
+  end
+
+  defp handle_line("", state, _opts), do: state
+
+  defp handle_line(line, state, opts) do
+    case Jason.decode(line) do
+      {:ok, message} when is_map(message) ->
+        case Server.handle_message(message, state, opts) do
+          {:reply, response, next_state} ->
+            write_response(response)
+            next_state
+
+          {:noreply, next_state} ->
+            next_state
+        end
+
+      {:error, _reason} ->
+        response = %{
+          "jsonrpc" => "2.0",
+          "id" => nil,
+          "error" => %{
+            "code" => -32_700,
+            "message" => "Parse error"
+          }
+        }
+
+        write_response(response)
+        state
+    end
+  end
+
+  defp write_response(response) when is_map(response) do
+    response
+    |> Jason.encode!()
+    |> Kernel.<>("\n")
+    |> then(&IO.binwrite(:stdio, &1))
+  end
+end

--- a/lib/agent_jido_web/controllers/llms_txt_controller.ex
+++ b/lib/agent_jido_web/controllers/llms_txt_controller.ex
@@ -42,6 +42,11 @@ defmodule AgentJidoWeb.LLMSTxtController do
     - Sitemap: #{endpoint_url}/sitemap.xml
     - Feed: #{endpoint_url}/feed
 
+    MCP docs server
+    - HTTP endpoint: #{endpoint_url}/mcp/docs
+    - Tools: search_docs, get_doc, list_sections
+    - Scope: published docs only
+
     Rendered fallback pattern
     - If source markdown is unavailable, request the canonical route with:
       - Accept: text/markdown

--- a/lib/agent_jido_web/controllers/mcp_docs_controller.ex
+++ b/lib/agent_jido_web/controllers/mcp_docs_controller.ex
@@ -1,0 +1,158 @@
+defmodule AgentJidoWeb.MCPDocsController do
+  @moduledoc """
+  Public HTTP transport for the read-only docs MCP server.
+  """
+
+  use AgentJidoWeb, :controller
+
+  alias AgentJido.Analytics.RateLimiter
+  alias AgentJido.MCP
+  alias AgentJido.MCP.Server
+
+  @invalid_request_code -32_600
+  @rate_limited_code -32_029
+  @request_too_large_code -32_413
+
+  @spec handle(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def handle(%Plug.Conn{method: "POST"} = conn, params) when is_map(params) do
+    request_id = Map.get(params, "id")
+
+    with :ok <- validate_body_size(conn, params),
+         :ok <- enforce_rate_limit(conn) do
+      conn =
+        conn
+        |> put_resp_content_type("application/json")
+        |> put_resp_header("mcp-protocol-version", MCP.protocol_version())
+
+      case Server.handle_http_message(params, tool_opts: tool_opts()) do
+        {:reply, response} ->
+          conn
+          |> put_status(:ok)
+          |> json(response)
+
+        :noreply ->
+          send_resp(conn, :accepted, "")
+      end
+    else
+      {:error, :too_large} ->
+        conn
+        |> put_status(:payload_too_large)
+        |> put_resp_content_type("application/json")
+        |> json(error_response(request_id, @request_too_large_code, "Request body exceeds the MCP HTTP limit"))
+
+      {:error, :rate_limited} ->
+        conn
+        |> put_status(:too_many_requests)
+        |> put_resp_content_type("application/json")
+        |> json(error_response(request_id, @rate_limited_code, "Rate limit exceeded"))
+    end
+  end
+
+  def handle(conn, _params) do
+    conn
+    |> put_resp_content_type("application/json")
+    |> put_status(:method_not_allowed)
+    |> json(error_response(nil, @invalid_request_code, "Only POST is supported for this endpoint"))
+  end
+
+  defp validate_body_size(conn, params) do
+    max_body_bytes = MCP.http_max_body_bytes()
+
+    size =
+      conn
+      |> get_req_header("content-length")
+      |> List.first()
+      |> case do
+        nil ->
+          params
+          |> Jason.encode!()
+          |> byte_size()
+
+        value ->
+          case Integer.parse(value) do
+            {parsed, ""} -> parsed
+            _other -> max_body_bytes + 1
+          end
+      end
+
+    if size <= max_body_bytes, do: :ok, else: {:error, :too_large}
+  end
+
+  defp enforce_rate_limit(conn) do
+    if RateLimiter.allow?(
+         client_identifier(conn),
+         "mcp_docs_http",
+         max_events: MCP.http_rate_limit_max_requests(),
+         window_seconds: MCP.http_rate_limit_window_seconds()
+       ) do
+      :ok
+    else
+      {:error, :rate_limited}
+    end
+  end
+
+  defp client_identifier(conn) do
+    forwarded_for =
+      conn
+      |> get_req_header("x-forwarded-for")
+      |> List.first()
+      |> parse_forwarded_for()
+
+    real_ip =
+      conn
+      |> get_req_header("x-real-ip")
+      |> List.first()
+      |> normalize_ip_string()
+
+    cond do
+      is_binary(forwarded_for) -> forwarded_for
+      is_binary(real_ip) -> real_ip
+      true -> tuple_ip_to_string(conn.remote_ip)
+    end
+  end
+
+  defp parse_forwarded_for(nil), do: nil
+
+  defp parse_forwarded_for(value) do
+    value
+    |> String.split(",", trim: true)
+    |> Enum.map(&normalize_ip_string/1)
+    |> Enum.find(&is_binary/1)
+  end
+
+  defp normalize_ip_string(value) when is_binary(value) do
+    value
+    |> String.trim()
+    |> case do
+      "" ->
+        nil
+
+      candidate ->
+        case :inet.parse_address(String.to_charlist(candidate)) do
+          {:ok, _ip} -> candidate
+          {:error, _reason} -> nil
+        end
+    end
+  end
+
+  defp normalize_ip_string(_value), do: nil
+
+  defp tuple_ip_to_string({_, _, _, _} = ip), do: ip |> Tuple.to_list() |> Enum.join(".")
+  defp tuple_ip_to_string({_, _, _, _, _, _, _, _} = ip), do: ip |> :inet.ntoa() |> to_string()
+
+  defp error_response(id, code, message) do
+    %{
+      "jsonrpc" => "2.0",
+      "id" => id,
+      "error" => %{
+        "code" => code,
+        "message" => message
+      }
+    }
+  end
+
+  defp tool_opts do
+    MCP.config()
+    |> Keyword.get(:tool_opts, [])
+  end
+end

--- a/lib/agent_jido_web/router.ex
+++ b/lib/agent_jido_web/router.ex
@@ -86,6 +86,12 @@ defmodule AgentJidoWeb.Router do
     get("/llms.txt", LLMSTxtController, :index)
   end
 
+  scope "/mcp", AgentJidoWeb do
+    pipe_through(:api)
+
+    match :*, "/docs", MCPDocsController, :handle
+  end
+
   if Application.compile_env(:agent_jido, :dev_routes) do
     scope "/dev" do
       pipe_through([:browser])

--- a/lib/mix/tasks/mcp.docs.ex
+++ b/lib/mix/tasks/mcp.docs.ex
@@ -1,0 +1,21 @@
+defmodule Mix.Tasks.Mcp.Docs do
+  use Mix.Task
+
+  alias AgentJido.MCP.Stdio
+
+  @shortdoc "Starts the Agent Jido docs MCP server over stdio"
+
+  @moduledoc """
+  Starts the read-only Agent Jido docs MCP server over stdio.
+
+  This task is intended for MCP clients that launch a local subprocess.
+  Ensure the project is compiled before use so stdout stays reserved for
+  newline-delimited JSON-RPC messages.
+  """
+
+  @impl true
+  def run(_args) do
+    Mix.Task.run("app.start")
+    Stdio.run()
+  end
+end

--- a/test/agent_jido/mcp/docs_tools_test.exs
+++ b/test/agent_jido/mcp/docs_tools_test.exs
@@ -1,0 +1,76 @@
+defmodule AgentJido.MCP.DocsToolsTest do
+  use ExUnit.Case, async: true
+
+  alias AgentJido.ContentAssistant.Result
+  alias AgentJido.MCP.DocsTools
+
+  defmodule RetrievalStub do
+    def query_with_status(_query, _opts) do
+      {:ok,
+       [
+         %Result{
+           title: "Plugins and composable agents",
+           snippet: "Compose runtime plugins safely.",
+           url: "/docs/learn/plugins-and-composable-agents",
+           source_type: :docs,
+           score: 0.9
+         },
+         %Result{
+           title: "Jido Skill",
+           snippet: "Package listing",
+           url: "/ecosystem/jido_skill",
+           source_type: :ecosystem,
+           score: 0.7
+         }
+       ], :success}
+    end
+  end
+
+  test "search_docs returns only docs routes with section metadata" do
+    assert {:ok, result} =
+             DocsTools.search_docs(
+               %{"query" => "plugins"},
+               retrieval_module: RetrievalStub
+             )
+
+    assert result["structuredContent"]["retrieval_status"] == "success"
+
+    assert [
+             %{
+               "path" => "/docs/learn/plugins-and-composable-agents",
+               "section" => "learn",
+               "canonical_url" => canonical_url
+             }
+           ] = result["structuredContent"]["results"]
+
+    assert canonical_url =~ "/docs/learn/plugins-and-composable-agents"
+  end
+
+  test "search_docs rejects blank queries" do
+    assert {:error, %{"code" => "invalid_arguments"}} =
+             DocsTools.search_docs(%{"query" => "   "}, retrieval_module: RetrievalStub)
+  end
+
+  test "get_doc resolves legacy docs routes to canonical markdown" do
+    assert {:ok, result} = DocsTools.get_doc(%{"path" => "/docs/chat-response"}, [])
+
+    structured = result["structuredContent"]
+
+    assert structured["path"] == "/docs/guides/cookbook/chat-response"
+    assert structured["section"] == "guides"
+    assert structured["legacy_resolution"]["requested_path"] == "/docs/chat-response"
+    assert structured["markdown"] =~ "#"
+  end
+
+  test "list_sections returns section roots and visible child pages" do
+    assert {:ok, result} = DocsTools.list_sections(%{}, [])
+
+    sections = result["structuredContent"]["sections"]
+    learn_section = Enum.find(sections, &(&1["section"] == "learn"))
+
+    assert is_map(learn_section)
+    assert learn_section["path"] == "/docs/learn"
+    assert learn_section["page_count"] > 1
+    assert Enum.any?(learn_section["pages"], &(&1["path"] == "/docs/learn/ai-chat-agent"))
+  end
+end

--- a/test/agent_jido/mcp/server_test.exs
+++ b/test/agent_jido/mcp/server_test.exs
@@ -1,0 +1,142 @@
+defmodule AgentJido.MCP.ServerTest do
+  use ExUnit.Case, async: true
+
+  alias AgentJido.MCP.Server
+
+  defmodule StubTools do
+    def tools do
+      [
+        %{
+          "name" => "search_docs",
+          "description" => "stub search",
+          "inputSchema" => %{"type" => "object"}
+        }
+      ]
+    end
+
+    def call_tool("search_docs", %{"query" => query}, _opts) do
+      {:ok,
+       %{
+         "content" => [%{"type" => "text", "text" => "Found 1 result for #{query}"}],
+         "structuredContent" => %{
+           "query" => query,
+           "retrieval_status" => "success",
+           "results" => [
+             %{
+               "title" => "Stub Result",
+               "path" => "/docs/reference/architecture",
+               "canonical_url" => "https://jido.run/docs/reference/architecture",
+               "section" => "reference",
+               "snippet" => "Stub snippet"
+             }
+           ]
+         },
+         "isError" => false
+       }}
+    end
+
+    def call_tool(_name, _arguments, _opts) do
+      {:error, %{"code" => "unknown_tool", "message" => "Unknown tool"}}
+    end
+  end
+
+  test "initialize advertises tools-only MCP capabilities" do
+    request = %{
+      "jsonrpc" => "2.0",
+      "id" => 1,
+      "method" => "initialize",
+      "params" => %{
+        "protocolVersion" => "2025-11-25",
+        "clientInfo" => %{"name" => "test-client", "version" => "1.0.0"},
+        "capabilities" => %{}
+      }
+    }
+
+    {:reply, response, state} = Server.handle_message(request, Server.new(), tools_module: StubTools)
+
+    assert response["result"]["protocolVersion"] == "2025-11-25"
+    assert response["result"]["capabilities"]["tools"]["listChanged"] == false
+    assert response["result"]["serverInfo"]["name"] == "agent_jido_docs"
+    assert state.initialized?
+  end
+
+  test "tools/list requires initialization on stateful transports" do
+    request = %{"jsonrpc" => "2.0", "id" => 2, "method" => "tools/list", "params" => %{}}
+
+    {:reply, response, _state} = Server.handle_message(request, Server.new(), tools_module: StubTools)
+
+    assert response["error"]["code"] == -32_002
+  end
+
+  test "tools/list returns the shared tool catalog after initialize" do
+    init = %{"jsonrpc" => "2.0", "id" => 1, "method" => "initialize", "params" => %{"protocolVersion" => "2025-11-25"}}
+    {:reply, _response, state} = Server.handle_message(init, Server.new(), tools_module: StubTools)
+
+    request = %{"jsonrpc" => "2.0", "id" => 2, "method" => "tools/list", "params" => %{}}
+    {:reply, response, _state} = Server.handle_message(request, state, tools_module: StubTools)
+
+    assert [%{"name" => "search_docs"}] = response["result"]["tools"]
+  end
+
+  test "tools/call validates arguments before dispatch" do
+    init = %{"jsonrpc" => "2.0", "id" => 1, "method" => "initialize", "params" => %{"protocolVersion" => "2025-11-25"}}
+    {:reply, _response, state} = Server.handle_message(init, Server.new(), tools_module: StubTools)
+
+    request = %{
+      "jsonrpc" => "2.0",
+      "id" => 3,
+      "method" => "tools/call",
+      "params" => %{"name" => "search_docs", "arguments" => "not-an-object"}
+    }
+
+    {:reply, response, _state} = Server.handle_message(request, state, tools_module: StubTools)
+
+    assert response["error"]["code"] == -32_602
+    assert response["error"]["message"] =~ "arguments must be an object"
+  end
+
+  test "tools/call returns structured tool results" do
+    init = %{"jsonrpc" => "2.0", "id" => 1, "method" => "initialize", "params" => %{"protocolVersion" => "2025-11-25"}}
+    {:reply, _response, state} = Server.handle_message(init, Server.new(), tools_module: StubTools)
+
+    request = %{
+      "jsonrpc" => "2.0",
+      "id" => 4,
+      "method" => "tools/call",
+      "params" => %{"name" => "search_docs", "arguments" => %{"query" => "architecture"}}
+    }
+
+    {:reply, response, _state} = Server.handle_message(request, state, tools_module: StubTools)
+
+    assert response["result"]["isError"] == false
+    assert response["result"]["structuredContent"]["query"] == "architecture"
+    assert hd(response["result"]["structuredContent"]["results"])["path"] == "/docs/reference/architecture"
+  end
+
+  test "unknown tools return MCP tool errors" do
+    init = %{"jsonrpc" => "2.0", "id" => 1, "method" => "initialize", "params" => %{"protocolVersion" => "2025-11-25"}}
+    {:reply, _response, state} = Server.handle_message(init, Server.new(), tools_module: StubTools)
+
+    request = %{
+      "jsonrpc" => "2.0",
+      "id" => 5,
+      "method" => "tools/call",
+      "params" => %{"name" => "missing_tool", "arguments" => %{}}
+    }
+
+    {:reply, response, _state} = Server.handle_message(request, state, tools_module: StubTools)
+
+    assert response["result"]["isError"] == true
+    assert response["result"]["structuredContent"]["error"]["code"] == "unknown_tool"
+  end
+
+  test "notifications/initialized is acknowledged without a response" do
+    init = %{"jsonrpc" => "2.0", "id" => 1, "method" => "initialize", "params" => %{"protocolVersion" => "2025-11-25"}}
+    {:reply, _response, state} = Server.handle_message(init, Server.new(), tools_module: StubTools)
+
+    request = %{"jsonrpc" => "2.0", "method" => "notifications/initialized"}
+
+    assert {:noreply, %Server.State{initialized?: true}} =
+             Server.handle_message(request, state, tools_module: StubTools)
+  end
+end

--- a/test/agent_jido/mcp/stdio_test.exs
+++ b/test/agent_jido/mcp/stdio_test.exs
@@ -1,0 +1,75 @@
+defmodule AgentJido.MCP.StdioTest do
+  use ExUnit.Case, async: false
+
+  @moduletag timeout: 15_000
+
+  test "stdio transport serves newline-delimited MCP JSON-RPC" do
+    mix = System.find_executable("mix") || flunk("mix executable not found")
+    cwd = File.cwd!()
+
+    port =
+      Port.open(
+        {:spawn_executable, mix},
+        [
+          :binary,
+          :exit_status,
+          {:cd, String.to_charlist(cwd)},
+          {:env,
+           [
+             {~c"MIX_ENV", ~c"test"},
+             {~c"CONTENTOPS_CHAT_ENABLED", ~c"false"},
+             {~c"ARCANA_GRAPH_ENABLED", ~c"false"}
+           ]},
+          {:args, ["mcp.docs"]}
+        ]
+      )
+
+    on_exit(fn ->
+      try do
+        Port.close(port)
+      rescue
+        _ -> :ok
+      end
+    end)
+
+    send_json(port, %{
+      "jsonrpc" => "2.0",
+      "id" => 1,
+      "method" => "initialize",
+      "params" => %{"protocolVersion" => "2025-11-25", "clientInfo" => %{"name" => "stdio-test"}}
+    })
+
+    init_response = receive_json(port)
+    assert init_response["result"]["serverInfo"]["name"] == "agent_jido_docs"
+
+    send_json(port, %{"jsonrpc" => "2.0", "method" => "notifications/initialized"})
+
+    send_json(port, %{
+      "jsonrpc" => "2.0",
+      "id" => 2,
+      "method" => "tools/list",
+      "params" => %{}
+    })
+
+    tools_response = receive_json(port)
+    assert Enum.map(tools_response["result"]["tools"], & &1["name"]) == ["search_docs", "get_doc", "list_sections"]
+  end
+
+  defp send_json(port, payload) do
+    Port.command(port, Jason.encode!(payload) <> "\n")
+  end
+
+  defp receive_json(port) do
+    receive do
+      {^port, {:data, data}} ->
+        data
+        |> String.trim()
+        |> Jason.decode!()
+
+      {^port, {:exit_status, status}} ->
+        flunk("stdio server exited before replying with status #{status}")
+    after
+      5_000 -> flunk("timed out waiting for stdio response")
+    end
+  end
+end

--- a/test/agent_jido_web/controllers/llms_txt_test.exs
+++ b/test/agent_jido_web/controllers/llms_txt_test.exs
@@ -12,6 +12,8 @@ defmodule AgentJidoWeb.LLMSTxtTest do
     assert body =~ "#{endpoint_url}/docs/reference/why-not-just-a-genserver.md"
     assert body =~ "Accept: text/markdown"
     assert body =~ "#{endpoint_url}/sitemap.xml"
+    assert body =~ "#{endpoint_url}/mcp/docs"
+    assert body =~ "search_docs, get_doc, list_sections"
     assert body =~ "If source markdown is unavailable"
   end
 end

--- a/test/agent_jido_web/controllers/mcp_docs_controller_test.exs
+++ b/test/agent_jido_web/controllers/mcp_docs_controller_test.exs
@@ -1,0 +1,171 @@
+defmodule AgentJidoWeb.MCPDocsControllerTest do
+  use AgentJidoWeb.ConnCase, async: false
+
+  alias AgentJido.Analytics.RateLimiter
+
+  defmodule RetrievalStub do
+    alias AgentJido.ContentAssistant.Result
+
+    def query_with_status(_query, _opts) do
+      {:ok,
+       [
+         %Result{
+           title: "Architecture",
+           snippet: "Jido architecture overview.",
+           url: "/docs/reference/architecture",
+           source_type: :docs,
+           score: 0.95
+         }
+       ], :success}
+    end
+  end
+
+  setup do
+    original = Application.get_env(:agent_jido, AgentJido.MCP, [])
+    :ok = RateLimiter.reset!()
+
+    on_exit(fn ->
+      Application.put_env(:agent_jido, AgentJido.MCP, original)
+      RateLimiter.reset!()
+    end)
+
+    Application.put_env(
+      :agent_jido,
+      AgentJido.MCP,
+      Keyword.merge(original,
+        tool_opts: [retrieval_module: RetrievalStub],
+        http_rate_limit_max_requests: 60,
+        http_rate_limit_window_seconds: 60
+      )
+    )
+
+    :ok
+  end
+
+  test "POST /mcp/docs initialize returns tools capability metadata", %{conn: conn} do
+    conn =
+      post(conn, "/mcp/docs", %{
+        "jsonrpc" => "2.0",
+        "id" => 1,
+        "method" => "initialize",
+        "params" => %{
+          "protocolVersion" => "2025-11-25",
+          "clientInfo" => %{"name" => "test-client", "version" => "1.0.0"}
+        }
+      })
+
+    response = json_response(conn, 200)
+
+    assert get_resp_header(conn, "mcp-protocol-version") == ["2025-11-25"]
+    assert response["result"]["capabilities"]["tools"]["listChanged"] == false
+    assert response["result"]["serverInfo"]["name"] == "agent_jido_docs"
+  end
+
+  test "POST /mcp/docs tools/list works over stateless HTTP", %{conn: conn} do
+    conn =
+      post(conn, "/mcp/docs", %{
+        "jsonrpc" => "2.0",
+        "id" => 2,
+        "method" => "tools/list",
+        "params" => %{}
+      })
+
+    response = json_response(conn, 200)
+
+    assert Enum.map(response["result"]["tools"], & &1["name"]) == ["search_docs", "get_doc", "list_sections"]
+  end
+
+  test "POST /mcp/docs search_docs returns structured docs results", %{conn: conn} do
+    conn =
+      post(conn, "/mcp/docs", %{
+        "jsonrpc" => "2.0",
+        "id" => 3,
+        "method" => "tools/call",
+        "params" => %{
+          "name" => "search_docs",
+          "arguments" => %{"query" => "architecture"}
+        }
+      })
+
+    response = json_response(conn, 200)
+
+    assert response["result"]["isError"] == false
+    assert response["result"]["structuredContent"]["query"] == "architecture"
+    assert hd(response["result"]["structuredContent"]["results"])["path"] == "/docs/reference/architecture"
+  end
+
+  test "POST /mcp/docs get_doc returns canonical markdown for docs paths", %{conn: conn} do
+    conn =
+      post(conn, "/mcp/docs", %{
+        "jsonrpc" => "2.0",
+        "id" => 4,
+        "method" => "tools/call",
+        "params" => %{
+          "name" => "get_doc",
+          "arguments" => %{"path" => "/docs/chat-response"}
+        }
+      })
+
+    response = json_response(conn, 200)
+
+    assert response["result"]["structuredContent"]["path"] == "/docs/guides/cookbook/chat-response"
+    assert response["result"]["structuredContent"]["legacy_resolution"]["resolution"] == "legacy"
+  end
+
+  test "POST /mcp/docs rejects malformed tools/call params", %{conn: conn} do
+    conn =
+      post(conn, "/mcp/docs", %{
+        "jsonrpc" => "2.0",
+        "id" => 5,
+        "method" => "tools/call",
+        "params" => %{
+          "name" => "search_docs",
+          "arguments" => "bad"
+        }
+      })
+
+    response = json_response(conn, 200)
+
+    assert response["error"]["code"] == -32_602
+  end
+
+  test "GET /mcp/docs is rejected", %{conn: conn} do
+    conn = get(conn, "/mcp/docs")
+    response = json_response(conn, 405)
+
+    assert response["error"]["message"] =~ "Only POST"
+  end
+
+  test "POST /mcp/docs enforces rate limits per client", %{conn: conn} do
+    Application.put_env(
+      :agent_jido,
+      AgentJido.MCP,
+      Keyword.merge(Application.get_env(:agent_jido, AgentJido.MCP, []),
+        http_rate_limit_max_requests: 1,
+        http_rate_limit_window_seconds: 60
+      )
+    )
+
+    request = %{
+      "jsonrpc" => "2.0",
+      "id" => 6,
+      "method" => "tools/list",
+      "params" => %{}
+    }
+
+    conn1 =
+      conn
+      |> put_req_header("x-forwarded-for", "203.0.113.10")
+      |> post("/mcp/docs", request)
+
+    assert json_response(conn1, 200)["result"]["tools"] != []
+
+    conn2 =
+      build_conn()
+      |> put_req_header("x-forwarded-for", "203.0.113.10")
+      |> post("/mcp/docs", request)
+
+    response = json_response(conn2, 429)
+    assert response["error"]["code"] == -32_029
+  end
+end


### PR DESCRIPTION
## Summary
- add a tools-only MCP docs server core with `search_docs`, `get_doc`, and `list_sections`
- expose the same read-only docs server over `mix mcp.docs` and `POST /mcp/docs`
- cover the MCP core, stdio transport, HTTP transport, and docs tool behavior with tests

## Testing
- mix compile --warnings-as-errors
- mix credo --strict
- mix test
- mix dialyzer

Closes #49