### PR TITLE
chore(dev): disable chat by default locally

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+erlang 27.3
+elixir 1.18.4-otp-27

--- a/config/config.exs
+++ b/config/config.exs
@@ -92,7 +92,7 @@ contentops_chat_bindings = [
 ]
 
 config :agent_jido, AgentJido.ContentOps.Chat,
-  enabled: config_env() == :dev,
+  enabled: false,
   bindings: contentops_chat_bindings,
   allowed_telegram_user_ids: ["645038810"],
   allowed_discord_user_ids: ["281856954903691264", "1235534042062131258"],


### PR DESCRIPTION
## Summary
- disable ContentOps chat by default so local website startup does not require Telegram or Discord bot tokens
- add `.tool-versions` for the repo's working Erlang and Elixir versions so local hooks and `mix` commands resolve cleanly via ASDF

## Testing
- mix compile --warnings-as-errors
- mix credo --strict
- mix test
- mix dialyzer

Note: the MCP helper script was already merged separately in #106.