### PR TITLE
Fix AI agent with tools livebook drift and add coverage

### DIFF
--- a/priv/blog/2025/03-28-weather-agent.livemd
+++ b/priv/blog/2025/03-28-weather-agent.livemd
@@ -90,7 +90,7 @@ defmodule WeatherAgent do
       agent: __MODULE__,           # Link this module to the server
       # log_level: :info,         # Optional: Increase agent logging
       ai: [                       # AI-specific configuration
-        model: {:openai, model: "gpt-4o-mini"}, # Specify the LLM
+        model: {:openai, model: "gpt-5-mini"}, # Specify the LLM
         prompt: """
         You are an enthusiastic weather reporter.
         <%= @message %>

--- a/priv/pages/docs/learn/ai-agent-with-tools.livemd
+++ b/priv/pages/docs/learn/ai-agent-with-tools.livemd
@@ -13,7 +13,7 @@
     "Inspect tool activity after a successful answer"
   ],
   livebook: %{
-    runnable: false,
+    runnable: true,
     required_env_vars: ["OPENAI_API_KEY"],
     requires_network: true,
     setup_instructions: "Set OPENAI_API_KEY or LB_OPENAI_API_KEY before running the request cells."
@@ -22,13 +22,14 @@
 ---
 ## Setup
 
-This notebook is self-contained. Install the dependencies, configure the provider key, start one agent in the default Jido runtime, then let that agent call tools as needed. If you want the smaller model-only introduction first, review [Your first LLM agent](/docs/getting-started/first-llm-agent).
+This notebook is self-contained. It installs the released Jido packages, defines the weather Actions locally, configures the provider key, starts one agent in the default runtime, then lets that agent call tools as needed. If you want the smaller model-only introduction first, review [Your first LLM agent](/docs/getting-started/first-llm-agent).
 
 ```elixir
 Mix.install([
   {{mix_dep:jido}},
   {{mix_dep:jido_ai}},
-  {{mix_dep:req_llm}}
+  {{mix_dep:req_llm}},
+  {:req, "~> 0.5"}
 ])
 
 Logger.configure(level: :warning)
@@ -84,33 +85,213 @@ The agent geocodes "Denver" to coordinates, resolves those coordinates into the 
 
 In Jido, every tool is a `Jido.Action`. The same module works as a programmatic action you call from code and as an LLM-callable tool. The LLM sees each Action's `name`, `description`, and `schema`, then decides when to invoke it.
 
-Jido ships weather tools that wrap the free NWS (National Weather Service) API. No API key is needed for the weather data itself.
-
-`Jido.Tools.Weather.Geocode` converts a city name to coordinates:
+This notebook defines the weather Actions locally so the example stays accurate for the published Hex packages and runnable in Livebook. The weather data itself comes from free public APIs, so you do not need a separate weather API key.
 
 ```elixir
-Jido.Tools.Weather.Geocode.run(
+defmodule MyApp.WeatherHTTP do
+  @headers [
+    {"user-agent", "jido.run ai-agent-with-tools tutorial (https://jido.run)"},
+    {"accept", "application/geo+json, application/json"}
+  ]
+
+  def get_json(url, opts \\ []) do
+    with {:ok, response} <-
+           Req.get(
+             url: url,
+             params: Keyword.get(opts, :params, []),
+             headers: @headers
+           ) do
+      {:ok, response.body}
+    end
+  end
+end
+
+defmodule MyApp.WeatherGeocode do
+  use Jido.Action,
+    name: "weather_geocode",
+    description: "Convert a city or location string into latitude and longitude coordinates.",
+    schema: [
+      location: [type: :string, required: true, doc: "City, state, or other human-readable location"]
+    ]
+
+  @impl true
+  def run(%{location: location}, _context) do
+    with {:ok, results} <-
+           MyApp.WeatherHTTP.get_json(
+             "https://nominatim.openstreetmap.org/search",
+             params: [q: location, format: "jsonv2", limit: 1]
+           ),
+         [match | _] <- results,
+         {latitude, _} <- Float.parse(match["lat"]),
+         {longitude, _} <- Float.parse(match["lon"]) do
+      {:ok,
+       %{
+         location: location,
+         display_name: match["display_name"],
+         latitude: latitude,
+         longitude: longitude,
+         coordinates: "#{latitude},#{longitude}"
+       }}
+    else
+      [] -> {:error, :location_not_found}
+      :error -> {:error, :invalid_coordinates}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+end
+
+defmodule MyApp.WeatherLocationToGrid do
+  use Jido.Action,
+    name: "weather_location_to_grid",
+    description: "Resolve a latitude/longitude pair into the National Weather Service forecast URLs.",
+    schema: [
+      coordinates: [
+        type: :string,
+        required: true,
+        doc: "Latitude and longitude as \"lat,lng\""
+      ]
+    ]
+
+  @impl true
+  def run(%{coordinates: coordinates}, _context) do
+    with [latitude, longitude] <- String.split(coordinates, ",", parts: 2),
+         latitude = String.trim(latitude),
+         longitude = String.trim(longitude),
+         {:ok, body} <- MyApp.WeatherHTTP.get_json("https://api.weather.gov/points/#{latitude},#{longitude}"),
+         properties when is_map(properties) <- body["properties"] do
+      {:ok,
+       %{
+         coordinates: coordinates,
+         office: properties["gridId"],
+         grid_x: properties["gridX"],
+         grid_y: properties["gridY"],
+         urls: %{
+           forecast: properties["forecast"],
+           hourly_forecast: properties["forecastHourly"],
+           observation_stations: properties["observationStations"]
+         }
+       }}
+    else
+      {:error, reason} -> {:error, reason}
+      _ -> {:error, :invalid_coordinates}
+    end
+  end
+end
+
+defmodule MyApp.WeatherForecast do
+  use Jido.Action,
+    name: "weather_forecast",
+    description: "Fetch the upcoming weather forecast from an NWS forecast URL.",
+    schema: [
+      forecast_url: [type: :string, required: true, doc: "Forecast URL returned by weather_location_to_grid"]
+    ]
+
+  @impl true
+  def run(%{forecast_url: forecast_url}, _context) do
+    with {:ok, body} <- MyApp.WeatherHTTP.get_json(forecast_url),
+         periods when is_list(periods) <- get_in(body, ["properties", "periods"]) do
+      preview =
+        periods
+        |> Enum.take(4)
+        |> Enum.map(fn period ->
+          %{
+            name: period["name"],
+            temperature: period["temperature"],
+            temperature_unit: period["temperatureUnit"],
+            short_forecast: period["shortForecast"],
+            detailed_forecast: period["detailedForecast"]
+          }
+        end)
+
+      summary =
+        Enum.map_join(preview, "\n", fn period ->
+          "#{period.name}: #{period.temperature}#{period.temperature_unit}, #{period.short_forecast}"
+        end)
+
+      {:ok, %{summary: summary, periods: preview}}
+    else
+      {:error, reason} -> {:error, reason}
+      _ -> {:error, :forecast_unavailable}
+    end
+  end
+end
+
+defmodule MyApp.WeatherCurrentConditions do
+  use Jido.Action,
+    name: "weather_current_conditions",
+    description: "Fetch the latest reported conditions from an NWS observation stations URL.",
+    schema: [
+      observation_stations_url: [
+        type: :string,
+        required: true,
+        doc: "Observation stations URL returned by weather_location_to_grid"
+      ]
+    ]
+
+  @impl true
+  def run(%{observation_stations_url: observation_stations_url}, _context) do
+    with {:ok, body} <- MyApp.WeatherHTTP.get_json(observation_stations_url),
+         [station_url | _] <- station_urls(body),
+         {:ok, observation} <- MyApp.WeatherHTTP.get_json("#{station_url}/observations/latest"),
+         properties when is_map(properties) <- observation["properties"] do
+      {:ok,
+       %{
+         station_id: properties["stationId"],
+         station_name: properties["stationName"],
+         timestamp: properties["timestamp"],
+         summary: properties["textDescription"],
+         temperature_c: round_value(get_in(properties, ["temperature", "value"])),
+         relative_humidity: round_value(get_in(properties, ["relativeHumidity", "value"])),
+         wind_speed_kmh: round_value(get_in(properties, ["windSpeed", "value"]))
+       }}
+    else
+      [] -> {:error, :observation_station_not_found}
+      {:error, reason} -> {:error, reason}
+      _ -> {:error, :conditions_unavailable}
+    end
+  end
+
+  defp station_urls(%{"observationStations" => stations}) when is_list(stations),
+    do: Enum.filter(stations, &is_binary/1)
+
+  defp station_urls(%{"features" => features}) when is_list(features) do
+    features
+    |> Enum.map(fn feature -> feature["id"] || get_in(feature, ["properties", "@id"]) end)
+    |> Enum.filter(&is_binary/1)
+  end
+
+  defp station_urls(_body), do: []
+
+  defp round_value(value) when is_number(value), do: Float.round(value * 1.0, 1)
+  defp round_value(_value), do: nil
+end
+```
+
+`MyApp.WeatherGeocode` converts a city name to coordinates:
+
+```elixir
+MyApp.WeatherGeocode.run(
   %{location: "Denver, CO"},
   %{}
 )
 ```
 
-This returns `{:ok, %{lat: "39.7...", lng: "-104.9..."}}`. The geocode tool uses OpenStreetMap Nominatim, which is free and unauthenticated.
+This returns `{:ok, %{coordinates: "39.7...,-104.9...", ...}}`. The geocode tool uses OpenStreetMap Nominatim, which is free and unauthenticated.
 
-`Jido.Tools.Weather.LocationToGrid` resolves a `"lat,lng"` coordinate pair into the NWS URLs you need for downstream weather lookups:
+`MyApp.WeatherLocationToGrid` resolves a `"lat,lng"` coordinate pair into the NWS URLs you need for downstream weather lookups:
 
 ```elixir
 {:ok, grid_info} =
-  Jido.Tools.Weather.LocationToGrid.run(
-    %{location: "39.7392,-104.9903"},
+  MyApp.WeatherLocationToGrid.run(
+    %{coordinates: "39.7392,-104.9903"},
     %{}
   )
 ```
 
-Then `Jido.Tools.Weather.Forecast` uses the forecast URL returned by `LocationToGrid`:
+Then `MyApp.WeatherForecast` uses the forecast URL returned by `MyApp.WeatherLocationToGrid`:
 
 ```elixir
-Jido.Tools.Weather.Forecast.run(
+MyApp.WeatherForecast.run(
   %{forecast_url: grid_info.urls.forecast},
   %{}
 )
@@ -119,13 +300,13 @@ Jido.Tools.Weather.Forecast.run(
 For current conditions, use the observation-stations URL from that same lookup:
 
 ```elixir
-Jido.Tools.Weather.CurrentConditions.run(
+MyApp.WeatherCurrentConditions.run(
   %{observation_stations_url: grid_info.urls.observation_stations},
   %{}
 )
 ```
 
-You can also write custom Tool Actions. Here is a temperature converter that the agent can call when needed:
+You can also write custom Tool Actions. Here is a temperature converter that the agent can call when needed. Because LLM tool calls arrive as JSON, enum-like tool inputs should use string values rather than atoms:
 
 ```elixir
 defmodule MyApp.TemperatureConverter do
@@ -135,29 +316,29 @@ defmodule MyApp.TemperatureConverter do
     schema: [
       value: [type: :float, required: true, doc: "Temperature value"],
       from: [
-        type: {:in, [:fahrenheit, :celsius]},
+        type: {:in, ["fahrenheit", "celsius"]},
         required: true,
         doc: "Source unit"
       ],
       to: [
-        type: {:in, [:fahrenheit, :celsius]},
+        type: {:in, ["fahrenheit", "celsius"]},
         required: true,
         doc: "Target unit"
       ]
     ]
 
   @impl true
-  def run(%{value: v, from: :fahrenheit, to: :celsius}, _ctx) do
-    {:ok, %{result: Float.round((v - 32) * 5 / 9, 1), unit: "°C"}}
+  def run(%{value: value, from: "fahrenheit", to: "celsius"}, _context) do
+    {:ok, %{result: Float.round((value - 32) * 5 / 9, 1), unit: "°C"}}
   end
 
-  def run(%{value: v, from: :celsius, to: :fahrenheit}, _ctx) do
-    {:ok, %{result: Float.round(v * 9 / 5 + 32, 1), unit: "°F"}}
+  def run(%{value: value, from: "celsius", to: "fahrenheit"}, _context) do
+    {:ok, %{result: Float.round(value * 9 / 5 + 32, 1), unit: "°F"}}
   end
 
-  def run(%{value: v, from: same, to: same}, _ctx) do
-    unit = if same == :celsius, do: "°C", else: "°F"
-    {:ok, %{result: v, unit: unit}}
+  def run(%{value: value, from: same, to: same}, _context) do
+    unit = if same == "celsius", do: "°C", else: "°F"
+    {:ok, %{result: value, unit: unit}}
   end
 end
 ```
@@ -174,28 +355,51 @@ defmodule MyApp.WeatherAgent do
     name: "weather_agent",
     description: "Weather assistant with tool access",
     tools: [
-      Jido.Tools.Weather.Geocode,
-      Jido.Tools.Weather.LocationToGrid,
-      Jido.Tools.Weather.Forecast,
-      Jido.Tools.Weather.CurrentConditions,
+      MyApp.WeatherGeocode,
+      MyApp.WeatherLocationToGrid,
+      MyApp.WeatherForecast,
+      MyApp.WeatherCurrentConditions,
       MyApp.TemperatureConverter
     ],
-    model: :fast,
+    model: "openai:gpt-5-mini",
     max_iterations: 6,
     system_prompt: """
     You are a helpful weather assistant.
     Use weather_geocode to convert city names to coordinates first.
     Then use weather_location_to_grid to get the NWS forecast and observation URLs.
-    Use the forecast URL for forecasts and the observation stations URL for current conditions.
+    Use weather_forecast for forecast questions and weather_current_conditions for current conditions.
+    Use convert_temperature only when the user explicitly asks to convert units.
     Provide practical, conversational advice.
     """
+
+  @default_timeout 60_000
+
+  @spec get_forecast(pid(), String.t(), keyword()) ::
+          {:ok, String.t()} | {:error, term()}
+  def get_forecast(pid, location, opts \\ []) do
+    query =
+      "Get the weather forecast for #{location}. " <>
+        "Include temperature, precipitation, and recommendations."
+
+    ask_sync(pid, query, Keyword.put_new(opts, :timeout, @default_timeout))
+  end
+
+  @spec get_conditions(pid(), String.t(), keyword()) ::
+          {:ok, String.t()} | {:error, term()}
+  def get_conditions(pid, location, opts \\ []) do
+    ask_sync(
+      pid,
+      "What are the current conditions in #{location}?",
+      Keyword.put_new(opts, :timeout, @default_timeout)
+    )
+  end
 end
 ```
 
 Key configuration options:
 
 - **tools** lists the `Jido.Action` modules available to the LLM. The runtime converts each Action's schema to JSON Schema for the provider's tool-calling protocol.
-- **model** selects the LLM. `:fast` keeps the notebook portable across provider backends.
+- **model** selects the LLM. This notebook uses an explicit OpenAI model so it matches the `OPENAI_API_KEY` setup above.
 - **max_iterations** caps the number of ReAct reasoning loops. Set this high enough for multi-step tool chains but low enough to prevent runaway costs.
 - **system_prompt** tells the LLM how to use the tools. Include constraints like coordinate format requirements here.
 
@@ -271,7 +475,8 @@ tool_activity =
     {:ok, status} ->
       %{
         result: status.snapshot.result,
-        tool_calls: status.snapshot.details[:tool_calls] || [],
+        conversation: status.snapshot.details[:conversation] || [],
+        trace_summary: status.snapshot.details[:trace_summary],
         model: status.snapshot.details[:model]
       }
 
@@ -282,57 +487,11 @@ tool_activity =
 IO.inspect(tool_activity, label: "Tool activity")
 ```
 
-The `tool_calls` list should show actions like `weather_geocode` and `weather_location_to_grid` when the model needs them.
+After a completed run, inspect `status.snapshot.details[:conversation]` for the tool call and tool result history, and `status.snapshot.details[:trace_summary]` for a compact summary. `status.snapshot.details[:tool_calls]` only reflects in-flight tool calls while a request is still running.
 
 ## Helper methods
 
-Wrap `ask_sync/3` in domain-specific functions to give callers a clean API instead of raw string prompts:
-
-```elixir
-defmodule MyApp.WeatherAgent do
-  use Jido.AI.Agent,
-    name: "weather_agent",
-    description: "Weather assistant with tool access",
-    tools: [
-      Jido.Tools.Weather.Geocode,
-      Jido.Tools.Weather.LocationToGrid,
-      Jido.Tools.Weather.Forecast,
-      Jido.Tools.Weather.CurrentConditions,
-      MyApp.TemperatureConverter
-    ],
-    model: :fast,
-    max_iterations: 6,
-    system_prompt: """
-    You are a helpful weather assistant.
-    Use weather_geocode to convert city names to coordinates first.
-    Then use weather_location_to_grid to get the NWS forecast and observation URLs.
-    Use the forecast URL for forecasts and the observation stations URL for current conditions.
-    Provide practical, conversational advice.
-    """
-
-  @spec get_forecast(pid(), String.t(), keyword()) ::
-          {:ok, String.t()} | {:error, term()}
-  def get_forecast(pid, location, opts \\ []) do
-    query =
-      "Get the weather forecast for #{location}. " <>
-        "Include temperature, precipitation, and recommendations."
-
-    ask_sync(pid, query, Keyword.put_new(opts, :timeout, 60_000))
-  end
-
-  @spec get_conditions(pid(), String.t(), keyword()) ::
-          {:ok, String.t()} | {:error, term()}
-  def get_conditions(pid, location, opts \\ []) do
-    ask_sync(
-      pid,
-      "What are the current conditions in #{location}?",
-      Keyword.put_new(opts, :timeout, 60_000)
-    )
-  end
-end
-```
-
-These functions delegate to `ask_sync/3` internally and return the same `{:ok, answer}` or `{:error, reason}` tuples. Callers never construct prompt strings directly:
+Because `MyApp.WeatherAgent` already wraps `ask_sync/3` in domain-specific helpers, callers do not need to construct prompt strings directly:
 
 ```elixir
 {:ok, _} = Jido.start()
@@ -341,6 +500,8 @@ runtime = Jido.default_instance()
 {:ok, forecast} = MyApp.WeatherAgent.get_forecast(pid, "Portland, OR")
 IO.puts(forecast)
 ```
+
+The same pattern works for `MyApp.WeatherAgent.get_conditions/3`, and both helpers return the same `{:ok, answer}` or `{:error, reason}` tuples as `ask_sync/3`.
 
 ## Configuration options
 

--- a/priv/pages/docs/learn/ai-chat-agent.livemd
+++ b/priv/pages/docs/learn/ai-chat-agent.livemd
@@ -65,7 +65,7 @@ defmodule MyApp.ChatAgent do
     name: "chat_agent",
     description: "Multi-turn chat agent",
     tools: [],
-    model: "openai:gpt-4o-mini",
+    model: "openai:gpt-5-mini",
     system_prompt: """
     You are a concise, friendly chat assistant.
     Ask a short clarifying question when the user is ambiguous.

--- a/priv/pages/docs/learn/memory-and-retrieval-augmented-agents.livemd
+++ b/priv/pages/docs/learn/memory-and-retrieval-augmented-agents.livemd
@@ -197,7 +197,7 @@ defmodule MyApp.KnowledgeAgent do
     name: "knowledge_agent",
     description: "RAG agent with memory and thread",
     tools: [],
-    model: "openai:gpt-4o-mini",
+    model: "openai:gpt-5-mini",
     max_iterations: 1,
     system_prompt: """
     You are a technical assistant. Use the provided context
@@ -215,7 +215,7 @@ defmodule MyApp.KnowledgeAgent do
     name: "knowledge_agent",
     description: "RAG agent with memory and thread",
     tools: [],
-    model: "openai:gpt-4o-mini",
+    model: "openai:gpt-5-mini",
     max_iterations: 1,
     system_prompt: """
     You are a technical assistant. Use the provided context

--- a/priv/pages/docs/learn/multi-agent-orchestration.livemd
+++ b/priv/pages/docs/learn/multi-agent-orchestration.livemd
@@ -429,7 +429,7 @@ Use the Planning action directly:
   Jido.Exec.run(Jido.AI.Actions.Planning.Decompose, %{
     goal: "Prepare a release readiness brief for the new command palette",
     max_depth: 2,
-    model: "openai:gpt-4o-mini"
+    model: "openai:gpt-5-mini"
   })
 ```
 

--- a/priv/pages/docs/learn/reasoning-strategies-compared.livemd
+++ b/priv/pages/docs/learn/reasoning-strategies-compared.livemd
@@ -107,7 +107,7 @@ defmodule MyApp.ReleaseDecisionCoTAgent do
   use Jido.AI.CoTAgent,
     name: "release_decision_cot_agent",
     description: "Explains a release decision step by step",
-    model: "openai:gpt-4o-mini",
+    model: "openai:gpt-5-mini",
     system_prompt: """
     You are a release advisor.
     Reason step by step.
@@ -119,7 +119,7 @@ defmodule MyApp.ReleaseDecisionToTAgent do
   use Jido.AI.ToTAgent,
     name: "release_decision_tot_agent",
     description: "Explores multiple release options before choosing",
-    model: "openai:gpt-4o-mini",
+    model: "openai:gpt-5-mini",
     branching_factor: 3,
     max_depth: 3,
     top_k: 3,
@@ -171,7 +171,7 @@ defmodule MyApp.ReleaseDecisionAdaptiveAgent do
   use Jido.AI.AdaptiveAgent,
     name: "release_decision_adaptive_agent",
     description: "Selects the best reasoning strategy for a product decision",
-    model: "openai:gpt-4o-mini",
+    model: "openai:gpt-5-mini",
     default_strategy: :cot,
     available_strategies: [:cot, :tot, :trm]
 end

--- a/priv/pages/docs/learn/task-planning-and-execution.livemd
+++ b/priv/pages/docs/learn/task-planning-and-execution.livemd
@@ -347,7 +347,7 @@ For example, you can generate the initial task list with a planning action:
   Jido.Exec.run(Jido.AI.Actions.Planning.Decompose, %{
     goal: "Write a README for an Elixir HTTP client library called Fetch",
     max_depth: 2,
-    model: "openai:gpt-4o-mini"
+    model: "openai:gpt-5-mini"
   })
 ```
 

--- a/test/agent_jido/livebook_docs_coverage_test.exs
+++ b/test/agent_jido/livebook_docs_coverage_test.exs
@@ -12,6 +12,7 @@ defmodule AgentJido.LivebookDocsCoverageTest do
     "priv/pages/docs/guides/error-handling-and-recovery.livemd",
     "priv/pages/docs/guides/persistence-and-checkpoints.livemd",
     "priv/pages/docs/guides/testing-agents-and-actions.livemd",
+    "priv/pages/docs/learn/ai-agent-with-tools.livemd",
     "priv/pages/docs/learn/ai-chat-agent.livemd",
     "priv/pages/docs/learn/first-workflow.livemd",
     "priv/pages/docs/learn/hybrid-chat-agent.livemd",
@@ -26,7 +27,6 @@ defmodule AgentJido.LivebookDocsCoverageTest do
   ]
 
   @reference_only_livebooks [
-    "priv/pages/docs/learn/ai-agent-with-tools.livemd",
     "priv/pages/docs/reference/why-not-just-a-genserver.livemd"
   ]
 

--- a/test/agent_jido/pages_test.exs
+++ b/test/agent_jido/pages_test.exs
@@ -221,7 +221,7 @@ defmodule AgentJido.PagesTest do
       assert source =~ "details.streaming_text"
       assert source =~ "Jido.AI.set_system_prompt"
       assert source =~ "Jido.AI.Plugins.Chat"
-      assert source =~ ~s(model: "openai:gpt-4o-mini")
+      assert source =~ ~s(model: "openai:gpt-5-mini")
       refute source =~ "model: :fast"
       refute source =~ "{:ai_react_start, params}"
       refute source =~ "on_before_cmd"
@@ -263,18 +263,26 @@ defmodule AgentJido.PagesTest do
       end)
     end
 
-    test "AI agent with tools guide uses the LocationToGrid weather flow" do
+    test "AI agent with tools guide uses notebook-local weather actions and completed-run inspection" do
       source =
         File.read!(Path.expand("priv/pages/docs/learn/ai-agent-with-tools.livemd", File.cwd!()))
 
       assert source =~ "livebook: %{"
+      assert source =~ "runnable: true"
+      assert source =~ ~s({:req, "~> 0.5"})
       assert source =~ "{:ok, _} = Jido.start()"
       assert source =~ "Jido.start_agent(runtime, MyApp.WeatherAgent"
-      assert source =~ "details[:tool_calls]"
-      assert source =~ "Jido.Tools.Weather.LocationToGrid.run"
+      assert source =~ "defmodule MyApp.WeatherGeocode do"
+      assert source =~ "defmodule MyApp.WeatherLocationToGrid do"
+      assert source =~ "defmodule MyApp.WeatherForecast do"
+      assert source =~ "defmodule MyApp.WeatherCurrentConditions do"
+      assert source =~ "MyApp.WeatherLocationToGrid.run"
       assert source =~ "%{forecast_url: grid_info.urls.forecast}"
       assert source =~ "%{observation_stations_url: grid_info.urls.observation_stations}"
       assert source =~ "weather_location_to_grid"
+      assert source =~ ~s(type: {:in, ["fahrenheit", "celsius"]})
+      assert source =~ "details[:conversation]"
+      assert source =~ "details[:trace_summary]"
 
       refute source =~ """
              Jido.Tools.Weather.Forecast.run(
@@ -282,6 +290,9 @@ defmodule AgentJido.PagesTest do
                %{}
              )
              """
+
+      refute source =~ "Jido.Tools.Weather."
+      refute source =~ "tool_calls: status.snapshot.details[:tool_calls] || []"
     end
 
     test "local-only guide notebooks declare quiet setup and explicit local-only metadata" do

--- a/test/livebooks/docs/ai_agent_with_tools_livebook_test.exs
+++ b/test/livebooks/docs/ai_agent_with_tools_livebook_test.exs
@@ -1,0 +1,11 @@
+defmodule AgentJido.Livebooks.Docs.AIAgentWithToolsLivebookTest do
+  use AgentJido.LivebookCase,
+    livebook: "priv/pages/docs/learn/ai-agent-with-tools.livemd",
+    timeout: 180_000,
+    external: true,
+    required_any_env: ["OPENAI_API_KEY", "LB_OPENAI_API_KEY"]
+
+  test "runs cleanly" do
+    assert :ok = run_livebook()
+  end
+end


### PR DESCRIPTION
## Summary
- update the `AI agent with tools` Livebook to define the weather actions locally instead of referencing unavailable packaged modules
- fix the completed-run inspection guidance to use `:conversation` and `:trace_summary`
- add runnable coverage for the Livebook and refresh the touched docs/examples away from stale `gpt-4o-mini` references

Closes #117