### PR TITLE
docs: fix various links

### DIFF
--- a/priv/pages/docs/concepts.md
+++ b/priv/pages/docs/concepts.md
@@ -27,7 +27,7 @@ Beyond the core, Jido has three cognitive pillars: Thread records what happened 
 7. **[Strategy](/docs/concepts/strategy)** - Pluggable execution models that control how agents process actions.
 8. **[Plugins](/docs/concepts/plugins)** - Composable behavior bundles that extend agents with actions, routes, and state.
 9. **[Execution](/docs/concepts/execution)** - The pipeline that runs actions: validation, chaining, retry, compensation, and async.
-10. **[Thread](/docs/concepts/thread)** - The append-only interaction log that records what happened during agent operation.
+10. **[Threads](/docs/concepts/threads)** - The append-only interaction log that records what happened during agent operation.
 11. **[Memory](/docs/concepts/memory)** - The mutable cognitive substrate where agents store current beliefs and goals.
 12. **[Persistence](/docs/concepts/persistence)** - How agents survive restarts through hibernate, thaw, and storage adapters.
 

--- a/priv/pages/docs/getting-started/elixir-developers.md
+++ b/priv/pages/docs/getting-started/elixir-developers.md
@@ -90,4 +90,4 @@ Jido's architecture is built on a small set of composable primitives. The [Conce
 
 - [Start with installation](/docs/getting-started/installation) - begin the onboarding ladder
 - [Concepts](/docs/concepts) - the full architectural reference for every Jido primitive
-- [Why not just a GenServer?](/docs/learn/why-not-just-a-genserver) - the full case for separating data from process
+- [Why not just a GenServer?](/docs/reference/why-not-just-a-genserver) - the full case for separating data from process

--- a/priv/pages/docs/learn.md
+++ b/priv/pages/docs/learn.md
@@ -36,4 +36,4 @@ Add LLM reasoning, tools, and multi-agent coordination.
 
 - [Concepts](/docs/concepts) - understand the architecture behind what you built
 - [Guides](/docs/guides) - task-focused recipes for specific problems
-- [Ecosystem](/docs/ecosystem) - explore the packages that extend Jido
+- [Ecosystem](/ecosystem) - explore the packages that extend Jido

--- a/priv/pages/docs/reference/behavior-first-architecture.md
+++ b/priv/pages/docs/reference/behavior-first-architecture.md
@@ -119,7 +119,7 @@ The rest of the core extends the same split.
 | [Strategy](/docs/concepts/strategy) | Defines execution policy without changing the Agent contract |
 | [Plugin](/docs/concepts/plugins) | Packages reusable capability bundles for composition |
 | [Execution](/docs/concepts/execution) | Runs validation, chaining, retry, and compensation consistently |
-| [Thread](/docs/concepts/thread) | Records what happened in an append-only log |
+| [Thread](/docs/concepts/threads) | Records what happened in an append-only log |
 | [Memory](/docs/concepts/memory) | Holds mutable working knowledge and intent |
 | [Persistence](/docs/concepts/persistence) | Defines how agents survive restart and restore state |
 

--- a/priv/pages/docs/reference/glossary.md
+++ b/priv/pages/docs/reference/glossary.md
@@ -60,7 +60,7 @@ A named partition within [Memory](#memory). Each space holds either a key-value 
 
 ### Thread
 
-An immutable, append-only log of `Entry` structs stored at `agent.state[:__thread__]`. Records what happened during agent operation. Provider-agnostic: LLM conversation context is projected from Thread entries, never stored directly. See [Thread concept](/docs/concepts/thread).
+An immutable, append-only log of `Entry` structs stored at `agent.state[:__thread__]`. Records what happened during agent operation. Provider-agnostic: LLM conversation context is projected from Thread entries, never stored directly. See [Thread concept](/docs/concepts/threads).
 
 ### Thread Entry
 


### PR DESCRIPTION
## Description

Just some simple link fixes:
- `/docs/concepts/threads`
- `/ecosystem`
- `/docs/reference/why-not-just-a-genserver`

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [x] Documentation update

## Testing

- [ ] Tests pass (`mix test`)
- [ ] Quality checks pass (`mix quality`)

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have updated the documentation accordingly
- [ ] I have added tests that prove my fix/feature works
- [ ] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)

